### PR TITLE
Sync collection, rollout, and eval save pipeline

### DIFF
--- a/configs/00_base/defaults.py
+++ b/configs/00_base/defaults.py
@@ -100,6 +100,25 @@ collection = dict(
     tasks=[],
 )
 
+rollout = dict(
+    storage=dict(
+        enabled=False,
+        log_dir="",
+        fps=30,
+        save_queue_max=15,
+        async_save=False,
+    ),
+    intervention=dict(
+        enabled=False,
+        control_mode="absolute",
+    ),
+)
+
+operator_control = dict(
+    enabled=False,
+    button_topic="/eva/operator_button",
+)
+
 eval_cfg = {}  # Empty dict marks a non-eval config; eval configs fill this block.
 # Eval block template (see configs/03_evaluation/*); fill eval_cfg to turn a deploy preset
 # into an eval run:
@@ -111,6 +130,8 @@ eval_cfg = {}  # Empty dict marks a non-eval config; eval configs fill this bloc
 #       reset_after_each_trial=False,
 #       skip_warmup_after_first=True,
 #       checkpoints=[dict(name="<ckpt>", config="<deploy_preset.py>", port=9000)],
+#       shuffle_ckpts=False,
+#       shuffle_seed=42,
 #       enable_ssh_forward=False,
 #       ssh=dict(host="", user="", port=8000, remote_sync_dir=""),
 #       tasks=[dict(prompt_en="pick the apple", milestones=(("grasp", "grasp apple"),))],

--- a/configs/01_deploy/r1lite/_base.py
+++ b/configs/01_deploy/r1lite/_base.py
@@ -34,3 +34,77 @@ transport = dict(
         ),
     ),
 )
+
+collection = dict(
+    storage=dict(
+        log_dir='work_dirs/collection/r1lite',
+        fps=15,
+        save_queue_max=15,
+    ),
+    schema=dict(
+        robot_type='r1_lite',
+        min_episode_frames=10,
+        arms=dict(
+            left_arm='left',
+            right_arm='right',
+        ),
+        cameras=dict(
+            cam_high='observation.images.cam_high',
+            cam_left_wrist='observation.images.cam_left_wrist',
+            cam_right_wrist='observation.images.cam_right_wrist',
+        ),
+        columns=dict(
+            qpos='observations.state.qpos',
+            eef='observations.state.eef',
+            action_qpos='action.qpos',
+            action_eef='action.eef',
+        ),
+    ),
+    transport=dict(
+        ros2=dict(
+            max_frame_skew_sec=0.3,
+            groups=dict(
+                left_arm=dict(
+                    qpos_topic='/hdas/feedback_arm_left',
+                    qpos_gripper_topic='/hdas/feedback_gripper_left',
+                    eef_topic='/relaxed_ik/motion_control/pose_ee_arm_left',
+                    hil_qpos_topic='/eva/hil/input_joint_state_arm_left',
+                    action_qpos_topic='/motion_target/target_joint_state_arm_left',
+                    action_qpos_gripper_source='operator',
+                    action_qpos_gripper_topic=None,
+                    action_qpos_gripper_binary=True,
+                    action_eef_topic='/relaxed_ik/motion_control/pose_ee_arm_left',
+                ),
+                right_arm=dict(
+                    qpos_topic='/hdas/feedback_arm_right',
+                    qpos_gripper_topic='/hdas/feedback_gripper_right',
+                    eef_topic='/relaxed_ik/motion_control/pose_ee_arm_right',
+                    hil_qpos_topic='/eva/hil/input_joint_state_arm_right',
+                    action_qpos_topic='/motion_target/target_joint_state_arm_right',
+                    action_qpos_gripper_source='operator',
+                    action_qpos_gripper_topic=None,
+                    action_qpos_gripper_binary=True,
+                    action_eef_topic='/relaxed_ik/motion_control/pose_ee_arm_right',
+                ),
+            ),
+        ),
+    ),
+)
+
+rollout = dict(
+    storage=dict(
+        enabled=True,
+        log_dir='work_dirs/rollout/r1lite',
+        fps=15,
+        save_queue_max=15,
+        async_save=False,
+        image_height=360,
+        image_width=640,
+    ),
+    intervention=dict(enabled=True, control_mode='relative'),
+)
+
+operator_control = dict(
+    enabled=True,
+    button_topic='/eva/operator_button',
+)

--- a/configs/02_collection/r1lite.py
+++ b/configs/02_collection/r1lite.py
@@ -1,13 +1,10 @@
 """R1 Lite: teleop data collection over ROS2."""
 
-_base_ = ['../00_base/defaults.py']
+_base_ = ['../01_deploy/r1lite/_base.py']
 
 robot = dict(
     type='r1_lite',
     eef_reference_frame='torso_link3',
-    gripper_threshold=0.98,
-    gripper_open=0.0,
-    gripper_close=1.0,
 )
 
 transport = dict(
@@ -25,6 +22,8 @@ collection = dict(
         log_dir='work_dirs/collection/r1lite',
         fps=15,
         save_queue_max=15,
+        image_height=360,
+        image_width=640,
     ),
     schema=dict(
         robot_type='r1_lite',
@@ -51,20 +50,35 @@ collection = dict(
             groups=dict(
                 left_arm=dict(
                     qpos_topic='/hdas/feedback_arm_left',
+                    qpos_gripper_topic='/hdas/feedback_gripper_left',
                     eef_topic='/relaxed_ik/motion_control/pose_ee_arm_left',
+                    hil_qpos_topic='/eva/hil/input_joint_state_arm_left',
                     action_qpos_topic='/motion_target/target_joint_state_arm_left',
+                    action_qpos_gripper_source='operator',
+                    action_qpos_gripper_topic=None,
+                    action_qpos_gripper_binary=True,
                     action_eef_topic='/relaxed_ik/motion_control/pose_ee_arm_left',
                 ),
                 right_arm=dict(
                     qpos_topic='/hdas/feedback_arm_right',
+                    qpos_gripper_topic='/hdas/feedback_gripper_right',
                     eef_topic='/relaxed_ik/motion_control/pose_ee_arm_right',
+                    hil_qpos_topic='/eva/hil/input_joint_state_arm_right',
                     action_qpos_topic='/motion_target/target_joint_state_arm_right',
+                    action_qpos_gripper_source='operator',
+                    action_qpos_gripper_topic=None,
+                    action_qpos_gripper_binary=True,
                     action_eef_topic='/relaxed_ik/motion_control/pose_ee_arm_right',
                 ),
             ),
         ),
     ),
     tasks=['pick up the apple'],
+)
+
+operator_control = dict(
+    enabled=True,
+    button_topic='/eva/operator_button',
 )
 
 inference_cfg = dict(

--- a/src/core/app/collection_capture.py
+++ b/src/core/app/collection_capture.py
@@ -1,0 +1,115 @@
+"""Background capture loop for teleop collection episodes."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class CollectionCaptureRunner:
+    """Move collection raw snapshot capture off the control/state-machine loop."""
+
+    def __init__(
+        self,
+        runtime: Any,
+        fps: float,
+        max_raw_snapshots_per_tick: int,
+    ) -> None:
+        if fps <= 0:
+            raise ValueError(f"collection capture fps must be positive, got {fps}")
+        if max_raw_snapshots_per_tick <= 0:
+            raise ValueError(
+                "collection capture max_raw_snapshots_per_tick must be positive"
+            )
+        self._runtime = runtime
+        self._interval_s = 1.0 / float(fps)
+        self._max_raw_snapshots_per_tick = max_raw_snapshots_per_tick
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(
+            target=self._run,
+            name="eva-collection-capture",
+            daemon=True,
+        )
+        self._error: BaseException | None = None
+
+    def start(self) -> None:
+        """Start the background capture thread."""
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the capture thread and surface any background failure."""
+        self._stop_event.set()
+        if self._thread.is_alive():
+            self._thread.join()
+        self._drain_available_raw(self._max_raw_snapshots_per_tick)
+        if self._error is not None:
+            raise RuntimeError("collection capture runner failed") from self._error
+
+    @property
+    def is_running(self) -> bool:
+        """True while the capture thread is alive."""
+        return self._thread.is_alive()
+
+    def _run(self) -> None:
+        try:
+            while not self._stop_event.is_set():
+                self._capture_tick()
+                self._stop_event.wait(self._interval_s)
+        except BaseException as exc:
+            self._error = exc
+            logger.exception("Collection capture runner failed")
+
+    def _capture_tick(self) -> bool:
+        episode_logger = self._runtime.episode_logger
+        if episode_logger is None or not episode_logger.is_collection_enabled:
+            return False
+        recorded = False
+        for _ in range(self._max_raw_snapshots_per_tick):
+            if self._stop_event.is_set():
+                break
+            snapshot = self._runtime.transport.acquire_collection_raw()
+            if snapshot is None:
+                break
+            episode_logger.ingest_collection_snapshot(snapshot)
+            recorded = True
+        return recorded
+
+    def _drain_available_raw(self, max_snapshots: int) -> bool:
+        episode_logger = self._runtime.episode_logger
+        if episode_logger is None or not episode_logger.is_collection_enabled:
+            return False
+        recorded = False
+        for _ in range(max_snapshots):
+            snapshot = self._runtime.transport.acquire_collection_raw()
+            if snapshot is None:
+                return recorded
+            episode_logger.ingest_collection_snapshot(snapshot)
+            recorded = True
+        return recorded
+
+
+def start_collection_capture(
+    runtime: Any,
+    fps: float,
+    max_raw_snapshots_per_tick: int,
+) -> None:
+    """Attach and start one collection capture runner on the runtime."""
+    if getattr(runtime, "collection_capture_runner", None) is not None:
+        raise RuntimeError("collection capture runner is already active")
+    runner = CollectionCaptureRunner(runtime, fps, max_raw_snapshots_per_tick)
+    runtime.collection_capture_runner = runner
+    runner.start()
+
+
+def stop_collection_capture(runtime: Any) -> None:
+    """Stop and detach the active collection capture runner if present."""
+    runner = getattr(runtime, "collection_capture_runner", None)
+    if runner is None:
+        return
+    try:
+        runner.stop()
+    finally:
+        runtime.collection_capture_runner = None

--- a/src/core/app/console/server.py
+++ b/src/core/app/console/server.py
@@ -15,6 +15,7 @@ import gzip
 import json
 import logging
 import os
+import random
 import re
 import threading
 import time
@@ -31,7 +32,7 @@ from core.app.handlers import (
     _resolve_runtime_path,
     eval_episode_dir,
     eval_model_name,
-    manual_publish_rate,
+    rollout_save_status,
 )
 from core.app.state import (
     RuntimeState,
@@ -96,6 +97,16 @@ def _infer_replay_video_key(dataset_dir: Path, cam: str) -> str:
     return match or image.get("default") or ""
 
 
+def _ensure_ckpt_order(config: ConfigDict, runtime: RuntimeState) -> None:
+    eval_cfg = config.eval
+    if eval_cfg is None or not eval_cfg.checkpoints or runtime.ckpt_order:
+        return
+    runtime.ckpt_order = list(range(len(eval_cfg.checkpoints)))
+    if eval_cfg.shuffle_ckpts:
+        rng = random.Random(eval_cfg.shuffle_seed)
+        rng.shuffle(runtime.ckpt_order)
+
+
 @dataclasses.dataclass
 class ConsoleContext:
     """Shared state for the console request handler."""
@@ -140,6 +151,7 @@ def _serialize_eval(ctx: ConsoleContext) -> dict:
     eval_cfg = ctx.config.eval
     if eval_cfg is None:
         return {}
+    order = ctx.runtime.ckpt_order or list(range(len(eval_cfg.checkpoints)))
     # The INIT panel is always available under eval: when no init_pose is configured
     # the start pose falls back to the robot's initial_qpos (home).
     init_pose_enabled = True
@@ -163,9 +175,9 @@ def _serialize_eval(ctx: ConsoleContext) -> dict:
             {
                 "slot": slot,
                 "label": ctx.ckpt_label(slot),
-                "name": ckpt.name,
+                "name": eval_cfg.checkpoints[order[slot]].name,
             }
-            for slot, ckpt in enumerate(eval_cfg.checkpoints)
+            for slot in range(len(order))
         ],
     }
 
@@ -180,6 +192,24 @@ def _serialize_gripper_controls(ctx: ConsoleContext) -> list[dict[str, str]]:
         {"side": "l", "label": "LEFT", "group": gripper_groups[0].name},
         {"side": "r", "label": "RIGHT", "group": gripper_groups[1].name},
     ]
+
+
+def _serialize_manual_qpos_limits(ctx: ConsoleContext) -> list[dict[str, float]]:
+    config = ctx.runtime.active_config or ctx.config
+    limits = [
+        {"min": -3.2, "max": 3.2, "step": 0.005}
+        for _ in range(ctx.runtime.robot.total_action_dim)
+    ]
+    gripper_min = float(min(config.robot.gripper_open, config.robot.gripper_close))
+    gripper_max = float(max(config.robot.gripper_open, config.robot.gripper_close))
+    gripper_step = float((gripper_max - gripper_min) / 1000.0)
+    offset = 0
+    for group in ctx.runtime.robot.actuator_groups:
+        if group.gripper_index is not None:
+            index = offset + group.gripper_index
+            limits[index] = {"min": gripper_min, "max": gripper_max, "step": gripper_step}
+        offset += group.dof
+    return limits
 
 
 def _resolve_dataset_dir(dataset_dir: str) -> str:
@@ -228,12 +258,14 @@ def _serialize_config(ctx: ConsoleContext) -> dict:
         ],
         "strategies": strategies,
         "gripper_controls": _serialize_gripper_controls(ctx),
+        "manual_qpos_limits": _serialize_manual_qpos_limits(ctx),
         "obs_mode": config.inference_cfg.obs_space.type,
         "policy_action_mode": config.inference_cfg.action_space.type,
         "publish_mode": "joint",
         "publish_rate": config.inference_cfg.publish_rate,
-        "manual_publish_rate": manual_publish_rate(config),
         "inference_rate": config.inference_cfg.inference_rate,
+        "hil_control_modes": ["absolute", "relative"],
+        "hil_control_mode": ctx.runtime.hil_control_mode,
         "collection": {
             "enabled": bool(config.collection.schema.columns),
             "fps": None,
@@ -289,10 +321,12 @@ def _serialize_status(ctx: ConsoleContext) -> dict:
         transport_connected = False
     else:
         transport_connected = bool(config.transport.type)
+    image_min_hz = reader.image_min_hz()
     return {
         "robot_type": config.robot.type,
         "transport_type": config.transport.type,
         "transport_connected": transport_connected,
+        "image_min_hz": image_min_hz,
         "policy_connected": r.policy is not None,
         "policy_error": r.last_policy_error,
         "cli_mode": s.mode.value,
@@ -340,6 +374,15 @@ def _serialize_status(ctx: ConsoleContext) -> dict:
         },
         "collection_teleop_armed": r.collection_teleop_armed,
         "collection_teleop_active": r.collection_teleop_active,
+        "rollout_intervention_active": r.rollout_intervention_active,
+        "rollout_intervention_active_frames": (
+            0
+            if r.rollout_intervention_active_segment is None
+            else len(r.rollout_intervention_active_segment.frames)
+        ),
+        "rollout_intervention_segments": len(r.rollout_intervention_segments),
+        "hil_control_mode": r.hil_control_mode,
+        "rollout": rollout_save_status(config, r),
         "collect": (
             r.episode_logger.status_snapshot(format_task_label(s.selected_collect_task))
             if r.episode_logger is not None
@@ -367,6 +410,28 @@ def _encode_jpeg(image: np.ndarray, convert_bgr_to_rgb: bool, quality: int = 60)
     if not ok:
         return None
     return buf.tobytes()
+
+
+def _camera_jpeg_payload(
+    reader: ObservationSource, key: str, convert_bgr_to_rgb: bool
+) -> tuple[bytes | None, tuple[Any, ...] | None]:
+    get_jpeg = getattr(reader, "get_camera_jpeg", None)
+    if get_jpeg is not None:
+        jpeg = get_jpeg(key)
+        if jpeg is not None:
+            return jpeg, ("jpeg", len(jpeg), jpeg[:64], jpeg[-64:])
+
+    get_one = getattr(reader, "get_camera_frame", None)
+    if get_one is not None:
+        image = get_one(key)
+    else:
+        frame = reader.get_frame()
+        image = None if frame is None else frame.images.get(key)
+    if image is None:
+        return None, None
+    arr = np.asarray(image)
+    sig = ("array", arr.shape, int(arr[::32, ::32].sum(dtype=np.int64)))
+    return _encode_jpeg(image, convert_bgr_to_rgb), sig
 
 
 def _list_camera_keys(ctx: ConsoleContext) -> list[str]:
@@ -897,22 +962,14 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
                 # Re-resolve per tick so mounting/clearing a replay source mid-stream
                 # swaps the feed without the client reopening the <img> connection.
                 reader = _observation_reader(ctx)
-                get_one = getattr(reader, "get_camera_frame", None)
-                if get_one is not None:
-                    image = get_one(key)
-                else:
-                    frame = reader.get_frame()
-                    image = None if frame is None else frame.images.get(key)
                 jpeg = None
-                if image is not None:
-                    arr = np.asarray(image)
-                    sig = (arr.shape, int(arr[::32, ::32].sum(dtype=np.int64)))
-                    if sig != last_sig:
-                        jpeg = _encode_jpeg(image, convert)
-                        last_sig = sig
-                        last_jpeg = jpeg
-                    elif last_jpeg is not None and tick - last_sent >= heartbeat:
-                        jpeg = last_jpeg
+                payload, sig = _camera_jpeg_payload(reader, key, convert)
+                if payload is not None and sig != last_sig:
+                    jpeg = payload
+                    last_sig = sig
+                    last_jpeg = jpeg
+                elif last_jpeg is not None and tick - last_sent >= heartbeat:
+                    jpeg = last_jpeg
                 if jpeg is not None:
                     part = (
                         b"--"
@@ -1322,8 +1379,15 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
     def _post_update_infer_params(self, body: dict) -> None:
         self._enqueue_ok("web:update_infer_params:" + json.dumps(body))
 
-    def _post_update_manual_params(self, body: dict) -> None:
-        self._enqueue_ok("web:update_manual_params:" + json.dumps(body))
+    def _post_rollout_intervention_mode(self, body: dict) -> None:
+        self._enqueue_ok(f"web:rollout_intervention_mode:{body.get('mode', '')}")
+
+    def _post_operator_action(self, body: dict) -> None:
+        intent = str(body.get("intent", "")).strip().lower()
+        if intent not in {"start", "accept", "cancel"}:
+            self._send_json(400, {"ok": False, "error": f"unsupported operator intent: {intent}"})
+            return
+        self._enqueue_ok(f"web:operator_action:{intent}:ui")
 
     def _post_manual_qpos(self, body: dict) -> None:
         qpos = body.get("qpos", [])
@@ -1454,6 +1518,9 @@ _POST_COMMANDS = {
     "/api/manual_home": "web:manual_home",
     "/api/collect_stop": "web:collect_stop",
     "/api/collect_cancel": "web:collect_cancel",
+    "/api/rollout_stop": "web:rollout_stop",
+    "/api/rollout_save": "web:rollout_save",
+    "/api/rollout_intervention_abandon": "web:rollout_intervention_abandon",
     "/api/warmup": "web:warmup",
     "/api/eval_stop": "web:stop",
     "/api/eval_reset": "web:reset",
@@ -1481,7 +1548,8 @@ _POST_ROUTES = {
     "/api/select_mode": ConsoleRequestHandler._post_select_mode,
     "/api/select_strategy": ConsoleRequestHandler._post_select_strategy,
     "/api/update_infer_params": ConsoleRequestHandler._post_update_infer_params,
-    "/api/update_manual_params": ConsoleRequestHandler._post_update_manual_params,
+    "/api/rollout_intervention_mode": ConsoleRequestHandler._post_rollout_intervention_mode,
+    "/api/operator_action": ConsoleRequestHandler._post_operator_action,
     "/api/manual_qpos": ConsoleRequestHandler._post_manual_qpos,
     "/api/manual_send": ConsoleRequestHandler._post_manual_send,
     "/api/manual_dispatch": ConsoleRequestHandler._post_manual_dispatch,
@@ -1515,6 +1583,7 @@ def start_console_server(
         )
     except Exception as exc:
         logger.warning("UrdfScene unavailable; 3D canvas disabled: %s", exc)
+    _ensure_ckpt_order(config, runtime)
     ctx = ConsoleContext(
         config=config,
         runtime=runtime,

--- a/src/core/app/console/static/index.html
+++ b/src/core/app/console/static/index.html
@@ -18,6 +18,7 @@
     <span class="tele-metric"><span class="lbl">infer</span> <span class="val tnum" id="t-infer">0ms</span></span>
     <span class="tele-metric"><span class="lbl">step</span> <span class="val tnum" id="t-step">0</span></span>
     <span class="tele-metric"><span class="lbl">t+</span> <span class="val tnum" id="t-elapsed">0.0s</span></span>
+    <span class="tele-metric"><span class="lbl">image</span> <span class="val tnum" id="t-image-hz">— hz</span></span>
   </div>
 
   <!-- ============ tab strip ============ -->
@@ -95,6 +96,27 @@
               <button class="btn primary full" id="b-run"><span class="rec-dot"></span><span class="rec-label">RUN ▶</span></button>
               <button class="btn full" id="b-reset">RESET ⟲</button>
             </div>
+            <button class="btn danger full" id="b-rollout-intervention-abandon" style="display:none;margin-top:8px">ABANDON</button>
+            <div id="rollout-save-panel" style="margin-top:8px">
+              <button class="btn primary full" id="b-rollout-save">SAVE ROLLOUT</button>
+              <div class="kv"><span class="k">pipeline</span><span class="v sig" id="rollout-save-pipeline">IDLE</span></div>
+              <div class="collect-progress"><i id="rollout-save-progress-fill"></i></div>
+              <div class="collect-queue-head">
+                <span><span id="rollout-save-count">0/0</span> saved</span>
+                <button class="btn" id="rollout-save-queue-toggle">EXPAND</button>
+              </div>
+              <div class="kv"><span class="k">eta</span><span class="v tnum" id="rollout-save-eta">—</span></div>
+              <div class="collect-tiles" id="rollout-save-queue-tiles"></div>
+              <div class="collect-list" id="rollout-save-queue-list" style="display:none"></div>
+              <div class="step-state" id="rollout-review-title">no rollout selected</div>
+              <div class="review-actions">
+                <button class="btn" id="b-rollout-qc-pass">PASS ✓</button>
+                <button class="btn danger" id="b-rollout-qc-fail">FAIL ✗</button>
+              </div>
+              <textarea class="review-note" id="rollout-qc-note" rows="3" placeholder="QC note (optional)"></textarea>
+              <div class="rollout-save-note" id="rollout-save-dir"></div>
+              <div class="errline" id="rollout-save-err"></div>
+            </div>
             <!-- breakpoint controls: shown for STEP (sim_real) mode -->
             <div id="control-step" style="display:none">
               <div class="step-state" id="step-state">IDLE</div>
@@ -119,6 +141,8 @@
         <div class="panel" id="panel-tune">
           <div class="panel-h">TUNING</div>
           <div class="card">
+            <div class="sub-h">HIL CONTROL</div>
+            <div class="row-2" id="hil-control-mode"></div>
             <div class="tune-row"><span>inference rate Hz</span><input type="number" id="tune-inference-rate" min="0.1" step="0.1" /></div>
             <div class="tune-row"><span>publish rate Hz</span><input type="number" id="tune-publish-rate" min="1" step="1" /></div>
             <div class="sub-h" id="tune-strategy-h">STRATEGY · <span id="tune-strategy-key">—</span></div>
@@ -164,7 +188,7 @@
             <div class="collect-progress"><i id="collect-progress-fill"></i></div>
             <div class="kv"><span class="k">eta</span><span class="v tnum" id="collect-eta">—</span></div>
             <div class="collect-tiles" id="collect-queue-tiles"></div>
-            <div class="collect-tiles-hint" id="collect-tiles-hint" style="display:none">Green means saved</div>
+            <div class="collect-tiles-hint" id="collect-tiles-hint" style="display:none">Pass green / fail red</div>
             <div class="collect-list" id="collect-queue-list" style="display:none"></div>
           </div>
         </div>
@@ -346,13 +370,6 @@
         </div>
 
         <div class="panel">
-          <div class="panel-h">TARGET QPOS</div>
-          <div class="card">
-            <div class="manual-sliders" id="manual-sliders-m"></div>
-          </div>
-        </div>
-
-        <div class="panel">
           <div class="panel-h">DISPATCH</div>
           <div class="card">
             <div class="btn-grid">
@@ -370,6 +387,13 @@
             <div class="tune-row"><span>publish rate Hz</span><input type="number" id="manual-tune-publish-rate" min="1" step="1" /></div>
             <button class="btn primary full" id="b-manual-tune-apply" style="margin-top:6px">APPLY ⤓</button>
             <div class="tune-status" id="manual-tune-status"></div>
+          </div>
+        </div>
+
+        <div class="panel">
+          <div class="panel-h">TARGET QPOS</div>
+          <div class="card">
+            <div class="manual-sliders" id="manual-sliders-m"></div>
           </div>
         </div>
       </div>

--- a/src/core/app/console/static/js/collect.js
+++ b/src/core/app/console/static/js/collect.js
@@ -1,7 +1,7 @@
 // collect.js: data-collection tab (collect) + QC/annotation review &
 // stage-video playback control (review).
 import { $, S, apiGet, apiPost } from "./core.js";
-import { collectTaskValue, setPanel, applyStatus } from "./run.js";
+import { collectTaskValue, setPanel, applyStatus, uiMode } from "./run.js";
 import { refreshCameraStreams, replayVideos } from "./replay.js";
 import { setActiveTab } from "./main.js";
 
@@ -17,7 +17,7 @@ async function startCollectFromTab() {
       S.STATUS.selected_collect_task = task;
       await apiPost("/api/select_collect_task", { task });
     }
-    await apiPost("/api/collect_start");
+    await apiPost("/api/operator_action", { intent: "start" });
   }
 
 function fmtEta(sec) {
@@ -41,6 +41,7 @@ function collectTone(item) {
     if (item.status === "failed") return "cq-fail";
     if (item.qc_verdict === "pass") return "cq-ok";
     if (item.qc_verdict === "fail") return "cq-fail";
+    if (item.quality === "red") return "cq-fail";
     return "cq-queued";
   }
 
@@ -61,8 +62,23 @@ function savedEpisodeId(item) {
 function selectCollectEpisode(item) {
     const episode = savedEpisodeId(item);
     if (episode == null) return;
+    const replay = S.STATUS.collection_replay || {};
+    const switchActiveReview = S.reviewKind === "collect" && replay.active &&
+      replay.episode_index !== episode && reviewEpisodeId !== episode;
     S.collectReplayEpisode = episode;
+    if (switchActiveReview) {
+      reviewEpisode("collect", item);
+      return;
+    }
     renderCollect();
+  }
+
+function selectRolloutSaveEpisode(item) {
+    const episode = savedEpisodeId(item);
+    if (episode == null) return;
+    S.rolloutSaveEpisode = episode;
+    reviewEpisode("rollout", item);
+    renderRolloutSave();
   }
 
 function selectCollectEpisodePointer(event, item) {
@@ -167,6 +183,111 @@ function renderCollectList(items) {
       }
       host.appendChild(row);
     });
+  }
+
+function pipeBadge(el, text) {
+    if (!el) return;
+    const state = String(text || "IDLE").toUpperCase();
+    el.textContent = state;
+    el.dataset.state = state;
+  }
+
+function renderRolloutSaveTiles(items) {
+    const host = $("rollout-save-queue-tiles");
+    if (!host) return;
+    host.innerHTML = "";
+    if (!items.length) {
+      const empty = document.createElement("span");
+      empty.className = "collect-empty";
+      empty.textContent = "no saved rollouts";
+      host.appendChild(empty);
+      return;
+    }
+    items.forEach((item) => {
+      const tile = document.createElement("button");
+      tile.type = "button";
+      tile.className = `collect-tile ${collectTone(item)}`;
+      const episode = savedEpisodeId(item);
+      if (episode != null) {
+        tile.classList.add("replayable");
+        if (episode === S.rolloutSaveEpisode) tile.classList.add("selected");
+        tile.onclick = () => selectRolloutSaveEpisode(item);
+      }
+      host.appendChild(tile);
+    });
+  }
+
+function renderRolloutSaveList(items) {
+    const host = $("rollout-save-queue-list");
+    if (!host) return;
+    host.style.display = S.rolloutSaveQueueExpanded ? "block" : "none";
+    $("rollout-save-queue-toggle").textContent = S.rolloutSaveQueueExpanded ? "COLLAPSE" : "EXPAND";
+    host.innerHTML = "";
+    if (!items.length) return;
+    items.slice().reverse().forEach((item) => {
+      const row = document.createElement("div");
+      const episode = savedEpisodeId(item);
+      row.className = `collect-row ${episode != null ? "replayable" : ""}${episode === S.rolloutSaveEpisode ? " selected" : ""}`;
+      const ep = document.createElement("span");
+      const frames = document.createElement("span");
+      const issue = document.createElement("span");
+      ep.textContent = `#${String(item.episode_index).padStart(3, "0")}`;
+      frames.textContent = `${item.length || 0}f`;
+      issue.className = "issue";
+      issue.textContent = collectIssueText(item);
+      row.appendChild(ep);
+      row.appendChild(frames);
+      row.appendChild(issue);
+      if (episode != null) row.onclick = () => selectRolloutSaveEpisode(item);
+      host.appendChild(row);
+    });
+  }
+
+function renderRolloutSave() {
+    const panel = $("rollout-save-panel");
+    if (!panel) return;
+    const hideRolloutSave = ["sim", "step"].includes(uiMode(S.STATUS.cli_mode));
+    panel.style.display = hideRolloutSave ? "none" : "";
+    if (hideRolloutSave) return;
+    const rollout = S.STATUS.rollout || {};
+    const enabled = !!rollout.enabled;
+    const saveReady = !!rollout.save_ready;
+    const saveBlocked = !!rollout.save_blocked_by_intervention;
+    const running = S.STATUS.session_status === "running";
+    const episodes = rollout.episodes || [];
+    const queue = rollout.queue || [];
+    const items = episodes.concat(queue);
+    const progress = Math.max(0, Math.min(1, Number(rollout.progress || 0)));
+    const savedComplete = enabled && !saveReady && queue.length === 0 && episodes.length > 0;
+
+    pipeBadge($("rollout-save-pipeline"), enabled ? (rollout.pipeline_state || "IDLE") : "DISABLED");
+    $("rollout-save-dir").style.display = savedComplete ? "block" : "none";
+    $("rollout-save-dir").textContent = savedComplete ? `saved to ${rollout.dataset_dir || "—"}` : "";
+    $("rollout-save-count").textContent = `${episodes.length}/${items.length}`;
+    $("rollout-save-progress-fill").style.width = `${progress * 100}%`;
+    $("rollout-save-eta").textContent = fmtEta(rollout.eta_sec);
+    const acceptedInterventions = Number(rollout.accepted_intervention_segments || 0);
+    const activeInterventionFrames = Number(rollout.active_intervention_frames || 0);
+    $("rollout-save-err").textContent = enabled
+      ? (saveBlocked
+          ? `continue or abandon intervention · active ${activeInterventionFrames}f · accepted ${acceptedInterventions}`
+          : (saveReady ? `ready after ${rollout.reason || "stop"}` : ""))
+      : "rollout saving is disabled";
+    $("b-rollout-save").disabled = !enabled || !saveReady || running || saveBlocked;
+    $("b-rollout-qc-pass").disabled = !enabled || S.rolloutSaveEpisode == null;
+    $("b-rollout-qc-fail").disabled = !enabled || S.rolloutSaveEpisode == null;
+
+    renderRolloutSaveTiles(items);
+    renderRolloutSaveList(items);
+
+    const replay = S.STATUS.collection_replay || {};
+    if (S.reviewKind === "rollout" && replay.active && replay.episode_index != null) {
+      S.rolloutSaveEpisode = replay.episode_index;
+      $("rollout-review-title").textContent = `episode ${replay.episode_index} · replay`;
+      syncReviewVideosToFrame(replay.frame_index);
+    } else if (S.rolloutSaveEpisode == null) {
+      $("rollout-review-title").textContent = "no rollout selected";
+    }
   }
 
 function renderCollect() {
@@ -281,28 +402,36 @@ let reviewVideoKeys = {};
 
 let reviewFps = 10;
 
+let reviewRequestId = 0;
+
 function reviewDatasetFor(kind) {
+    if (kind === "rollout") return (S.STATUS.rollout || {}).dataset_dir || "";
     return (S.STATUS.collect || {}).dataset_dir ||
       (S.CFG && S.CFG.collection ? (S.CFG.collection.dataset_dir || "") : "");
   }
 
 function reviewTitleFor(kind) {
+    if (kind === "rollout") return $("rollout-review-title");
     return $("collect-replay-status");
   }
 
 function reviewErrorFor(kind) {
+    if (kind === "rollout") return $("rollout-save-err");
     return $("collect-err");
   }
 
 function reviewNoteFor(kind) {
+    if (kind === "rollout") return $("rollout-qc-note");
     return $("collect-qc-note");
   }
 
 function reviewActiveInCurrentTab() {
-    return (S.reviewKind === "collect" && S.ACTIVE_TAB === "collect");
+    return (S.reviewKind === "collect" && S.ACTIVE_TAB === "collect") ||
+      (S.reviewKind === "rollout" && S.ACTIVE_TAB === "debug");
   }
 
 function clearReviewPlayback() {
+    reviewRequestId += 1;
     S.reviewKind = "";
     reviewVideoKeys = {};
     reviewDatasetDir = "";
@@ -442,7 +571,9 @@ function syncReviewVideosToFrame(frameIndex) {
 async function reviewEpisode(kind, item) {
     const episode = savedEpisodeId(item);
     if (episode == null) return;
-    S.collectReplayEpisode = episode;
+    const requestId = ++reviewRequestId;
+    if (kind === "rollout") S.rolloutSaveEpisode = episode;
+    else S.collectReplayEpisode = episode;
     S.reviewKind = kind;
     reviewDatasetDir = reviewDatasetFor(kind);
     reviewEpisodeId = episode;
@@ -455,6 +586,7 @@ async function reviewEpisode(kind, item) {
       dataset_dir: reviewDatasetDir,
       episode: String(reviewEpisodeId),
     });
+    if (requestId !== reviewRequestId) return;
     if (!r.ok) {
       if (err) err.textContent = r.error || "review failed";
       if (title) title.textContent = `episode ${episode} · unavailable`;
@@ -467,11 +599,14 @@ async function reviewEpisode(kind, item) {
     renderReviewVideos(reviewVideoKeys);
     setStageVideoLoading(true, "loading video");
     await waitForStageVideosReady("review");
+    if (requestId !== reviewRequestId) return;
     syncReviewVideosToFrame(0);
     await waitForStageVideosPainted("review");
+    if (requestId !== reviewRequestId) return;
     const start = await apiPost("/api/review_replay_start", {
       episode: String(reviewEpisodeId),
     });
+    if (requestId !== reviewRequestId) return;
     if (!start.ok) {
       if (err) err.textContent = start.error || "review start failed";
       if (title) title.textContent = `episode ${episode} · unavailable`;
@@ -483,7 +618,7 @@ async function reviewEpisode(kind, item) {
   }
 
 async function submitEpisodeQc(kind, verdict) {
-    const episode = S.collectReplayEpisode;
+    const episode = kind === "rollout" ? S.rolloutSaveEpisode : S.collectReplayEpisode;
     if (episode == null) return;
     S.reviewKind = kind;
     reviewDatasetDir = reviewDatasetFor(kind);
@@ -500,8 +635,8 @@ async function submitEpisodeQc(kind, verdict) {
   }
 
 async function submitEpisodeNote(kind) {
-    const episode = S.collectReplayEpisode;
-    const status = $("collect-qc-status");
+    const episode = kind === "rollout" ? S.rolloutSaveEpisode : S.collectReplayEpisode;
+    const status = kind === "rollout" ? $("rollout-save-err") : $("collect-qc-status");
     if (episode == null) { if (status) status.textContent = "✗ select an episode first"; return; }
     S.reviewKind = kind;
     reviewDatasetDir = reviewDatasetFor(kind);
@@ -559,7 +694,7 @@ function openBatchQc(dir, episode) {
 
 export {
   collectConfigured, collectEnabled, dotClass, renderCollect,
-  savedEpisodeId, startCollectFromTab, toggleSelectedCollectReplay,
+  renderRolloutSave, savedEpisodeId, startCollectFromTab, toggleSelectedCollectReplay,
   clearReviewPlayback, loadAnnotation, pauseStageVideos, playStageVideos,
   reviewActiveInCurrentTab, reviewEpisode, saveAnnotation, setStageVideoLoading,
   submitEpisodeNote, submitEpisodeQc, submitQc, syncReviewVideosToFrame,

--- a/src/core/app/console/static/js/core.js
+++ b/src/core/app/console/static/js/core.js
@@ -53,6 +53,8 @@ export const S = {
   collectQueueEnabled: false,
   collectArmEnabled: false,
   collectToggleBusy: null,
+  rolloutSaveQueueExpanded: false,
+  rolloutSaveEpisode: null,
   runToggleBusy: null,
   evalRunToggleBusy: null,
 };

--- a/src/core/app/console/static/js/main.js
+++ b/src/core/app/console/static/js/main.js
@@ -3,7 +3,7 @@
 import { $, LIVE, S, apiGet, apiPost } from "./core.js";
 import { closeChartModal, drawLiveCharts, liveDimsAll, onScrubInput, openChartModal, resetLiveSeries } from "./charts.js";
 import { applyTune, applyManualTune, renderConfig, manualConnect, manualDisconnect, manualDispatchToggle, enterManualSim, applyStatus, pauseSetup, replayIsLocalMode, resumeSetup, retrySetup, startRunFromDebug, updateGuide } from "./run.js";
-import { collectConfigured, renderCollect, startCollectFromTab, toggleSelectedCollectReplay, saveAnnotation, submitEpisodeNote, submitEpisodeQc, submitQc, clearReviewPlayback, reviewActiveInCurrentTab } from "./collect.js";
+import { collectConfigured, renderCollect, renderRolloutSave, startCollectFromTab, toggleSelectedCollectReplay, saveAnnotation, submitEpisodeNote, submitEpisodeQc, submitQc, clearReviewPlayback, reviewActiveInCurrentTab } from "./collect.js";
 import { evalEnabled, evalReset, evalSetup, evalRunToggle, evalResumeOnEnter, submitEvalScore, loadEvalResults, renderEvalSelectors, loadResultsAll, tpSeek, tpToggle, trialPopClose } from "./eval.js";
 import { replayPlay, replayStop, replayToggle, seekReplay, loop, pollFrame, pollScene, refreshCameraStreams, exitReplayMode } from "./replay.js";
 
@@ -213,7 +213,7 @@ $("b-run").onclick    = () => {
     setTimeout(() => {
       if (S.runToggleBusy !== null) { S.runToggleBusy = null; applyStatus(S.STATUS); }
     }, 1500);
-    return live ? apiPost("/api/halt") : startRunFromDebug();
+    return live ? apiPost("/api/operator_action", { intent: "start" }) : startRunFromDebug();
   };
 $("b-reset").onclick  = () => apiPost("/api/reset");
 $("b-step").onclick   = () => apiPost("/api/step_infer");
@@ -257,7 +257,7 @@ $("b-collect-toggle").onclick = () => {
     setTimeout(() => {
       if (S.collectToggleBusy !== null) { S.collectToggleBusy = null; renderCollect(); }
     }, 1500);
-    return live ? apiPost("/api/collect_stop") : startCollectFromTab();
+    return live ? apiPost("/api/operator_action", { intent: "accept" }) : startCollectFromTab();
   };
 $("collect-arm-enable").onchange = () => {
     const enabled = $("collect-arm-enable").checked;
@@ -273,11 +273,15 @@ $("collect-arm-enable").onchange = () => {
 $("b-collect-cancel").onclick = () => {
     S.collectQueueEnabled = false;
     renderCollect();
-    return apiPost("/api/collect_cancel");
+    return apiPost("/api/operator_action", { intent: "cancel" });
   };
 $("b-collect-qc-pass").onclick = () => submitEpisodeQc("collect", "pass");
 $("b-goto-qc").onclick = () => submitEpisodeQc("collect", "fail");
 $("b-collect-note-save").onclick = () => submitEpisodeNote("collect");
+$("b-rollout-save").onclick = () => apiPost("/api/operator_action", { intent: "accept" });
+$("b-rollout-intervention-abandon").onclick = () => apiPost("/api/operator_action", { intent: "cancel" });
+$("b-rollout-qc-pass").onclick = () => submitEpisodeQc("rollout", "pass");
+$("b-rollout-qc-fail").onclick = () => submitEpisodeQc("rollout", "fail");
 $("b-collect-replay-toggle").onclick = () => toggleSelectedCollectReplay();
 $("replay-b-qc-pass").onclick = () => submitQc("pass");
 $("replay-b-qc-fail").onclick = () => submitQc("fail");
@@ -285,6 +289,10 @@ $("replay-b-anno-save").onclick = () => saveAnnotation();
 $("collect-queue-toggle").onclick = () => {
     S.collectQueueExpanded = !S.collectQueueExpanded;
     renderCollect();
+  };
+$("rollout-save-queue-toggle").onclick = () => {
+    S.rolloutSaveQueueExpanded = !S.rolloutSaveQueueExpanded;
+    renderRolloutSave();
   };
 document.querySelector("#panel-setup .auto-setup-row").onclick = () => {
     if ($("panel-setup").dataset.st === "error") retrySetup();

--- a/src/core/app/console/static/js/replay.js
+++ b/src/core/app/console/static/js/replay.js
@@ -460,12 +460,24 @@ async function pollLiveSeries() {
   }
 
 let scenePolling = false;
+let lastScenePollAt = 0;
+const COLLECT_SCENE_POLL_MS = 80;
+
+function scenePollMinIntervalMs() {
+    return S.STATUS && S.STATUS.collect && S.STATUS.collect.collecting
+      ? COLLECT_SCENE_POLL_MS
+      : 0;
+  }
 
 async function pollScene() {
     if (scenePolling) return;
     // REPLAY drives the URDF per-frame off the scrub clock (replaySetUrdfFrame); don't
     // let the live /api/scene poll fight it for the shared Scene3D canvas.
     if (LIVE.replayMode) return;
+    const now = performance.now();
+    const minInterval = scenePollMinIntervalMs();
+    if (minInterval && now - lastScenePollAt < minInterval) return;
+    lastScenePollAt = now;
     scenePolling = true;
     try {
       // MANUAL streams the live real-robot pose + target ghost only when the real

--- a/src/core/app/console/static/js/run.js
+++ b/src/core/app/console/static/js/run.js
@@ -2,11 +2,16 @@
 // config & tuning panel (config); manual sim/connection control (manual).
 import { $, LIVE, RUN_CONTROLS, S, apiPost } from "./core.js";
 import { updateScrub } from "./charts.js";
-import { collectEnabled, dotClass, renderCollect, loadAnnotation } from "./collect.js";
+import { collectEnabled, dotClass, renderCollect, renderRolloutSave, loadAnnotation } from "./collect.js";
 import { applyEvalStatus, evalCfg, evalEnabled } from "./eval.js";
 import { maybeSyncReplayPlayer } from "./replay.js";
 
 // ===== run =====
+
+function formatImageHz(hz) {
+    const value = Number(hz);
+    return Number.isFinite(value) ? `${value.toFixed(1)} hz` : "— hz";
+  }
 
 function startRunFromDebug() {
     apiPost("/api/run");
@@ -66,7 +71,8 @@ function applyRunControlStatus(ids, s) {
 
     const ready = s.is_setup_done;
     const running = s.session_status === "running";
-    const continueRun = !running && (s.step_index || 0) > 0;
+    const intervention = !!s.rollout_intervention_active;
+    const continueRun = !running && ((s.step_index || 0) > 0 || intervention);
     if (ids.run === "b-run") {
       // Single RUN/STOP toggle (mirrors the collect record toggle): one click runs,
       // the next halts. `running` lags the click by a poll, so hold the button busy
@@ -74,10 +80,17 @@ function applyRunControlStatus(ids, s) {
       if (S.runToggleBusy !== null && running === S.runToggleBusy) S.runToggleBusy = null;
       const busy = S.runToggleBusy !== null;
       const run = $(ids.run);
-      run.querySelector(".rec-label").textContent = running ? "STOP ■" : (continueRun ? "CONTINUE ▶▶" : "RUN ▶");
+      run.querySelector(".rec-label").textContent = running
+        ? "STOP ■"
+        : (intervention ? "RESUME ▶" : (continueRun ? "CONTINUE ▶▶" : "RUN ▶"));
       run.classList.toggle("recording", running);
       run.classList.toggle("primary", !running);
       run.disabled = busy || (!running && !ready);
+      const abandon = $("b-rollout-intervention-abandon");
+      if (abandon) {
+        abandon.style.display = intervention ? "" : "none";
+        abandon.disabled = !intervention;
+      }
       $(ids.step).disabled = !ready || running;
       $(ids.commit).disabled = !armed;
       $(ids.stepHalt).disabled = !armed && !running;
@@ -123,6 +136,7 @@ function applyStatus(s) {
     $("t-infer").textContent = (s.last_infer_ms || 0) + "ms";
     $("t-step").textContent = s.step_index || 0;
     $("t-elapsed").textContent = ((s.run_elapsed_ms || 0) / 1000).toFixed(1) + "s";
+    $("t-image-hz").textContent = formatImageHz(s.image_min_hz);
 
     // active selections
     mark("prompt-list", "prompt", s.selected_task);
@@ -152,6 +166,7 @@ function applyStatus(s) {
     mark("mode-list", "mode", modeMark);
     mark("replay-mode-list", "mode", modeMark);
     mark("strategy-list", "strategy", s.selected_strategy);
+    syncHilControlMode(s);
     updateGuide();
 
     // canvas readout
@@ -187,6 +202,7 @@ function applyStatus(s) {
     $("err").textContent = s.last_error || "";
     $("replay-err").textContent = s.last_error || "";
     renderCollect();
+    renderRolloutSave();
     applyEvalStatus(s);
   }
 
@@ -577,6 +593,38 @@ function renderModeButtons(listId) {
     mark(listId, "mode", modes.includes("sim") ? "sim" : modes[0]);
   }
 
+function renderHilControlMode() {
+    const host = $("hil-control-mode");
+    if (!host || !S.CFG) return;
+    host.innerHTML = "";
+    const modes = S.CFG.hil_control_modes || ["absolute", "relative"];
+    host.style.setProperty("--mode-n", modes.length);
+    modes.forEach((mode) => {
+      const b = document.createElement("button");
+      b.className = "seg";
+      b.dataset.hil = mode;
+      b.innerHTML = `<span>${mode === "relative" ? "REL" : "ABS"}</span>`;
+      b.onclick = () => {
+        if (S.STATUS && S.STATUS.rollout_intervention_active) return;
+        mark("hil-control-mode", "hil", mode);
+        S.STATUS.hil_control_mode = mode;
+        apiPost("/api/rollout_intervention_mode", { mode });
+      };
+      host.appendChild(b);
+    });
+    syncHilControlMode(S.STATUS || {});
+  }
+
+function syncHilControlMode(status) {
+    const host = $("hil-control-mode");
+    if (!host || !S.CFG) return;
+    const mode = status.hil_control_mode || S.CFG.hil_control_mode || "absolute";
+    mark("hil-control-mode", "hil", mode);
+    host.querySelectorAll("button").forEach((b) => {
+      b.disabled = !!status.rollout_intervention_active;
+    });
+  }
+
 const GRIP_STATE = {};
 
 let GRIP_FORCE = true;
@@ -660,6 +708,7 @@ function renderConfig() {
     renderCollectTaskButtons();
     renderModeButtons("mode-list");
     renderModeButtons("replay-mode-list");
+    renderHilControlMode();
     // Pick the default run mode on the backend if nothing is chosen yet. Under eval the
     // mode is dictated by the config's cli_mode (e.g. REAL for table_tennis): push that so
     // a directly-entered eval runs on the real arm, instead of the SIM fallback below
@@ -875,7 +924,7 @@ function renderManualTune() {
     if (!S.CFG) return;
     const input = $("manual-tune-publish-rate");
     if (input && document.activeElement !== input) {
-      input.value = S.CFG.manual_publish_rate != null ? S.CFG.manual_publish_rate : "";
+      input.value = S.CFG.publish_rate != null ? S.CFG.publish_rate : "";
     }
   }
 
@@ -912,9 +961,11 @@ async function applyManualTune() {
     if (Number.isNaN(publishRate) || publishRate < 1) return;
     $("manual-tune-status").textContent = "applying…";
     try {
-      const r = await apiPost("/api/update_manual_params", { publish_rate: publishRate });
+      const r = await apiPost("/api/update_infer_params", { publish_rate: publishRate });
       if (r.ok) {
-        S.CFG.manual_publish_rate = publishRate;
+        S.CFG.publish_rate = publishRate;
+        const debugInput = $("tune-publish-rate");
+        if (debugInput && document.activeElement !== debugInput) debugInput.value = String(publishRate);
       }
       $("manual-tune-status").textContent = r.ok ? "applied" : "failed: " + (r.error || "unknown");
     } catch (e) {
@@ -1030,13 +1081,19 @@ function sendManualQpos() {
 function buildManualSliders(qpos) {
     if (S._manualSlidersBuilt || !qpos || !qpos.length) return;
     _manualQpos = qpos.slice();
+    const limits = S.CFG.manual_qpos_limits;
+    if (!limits || limits.length !== qpos.length) {
+      const nLimits = limits ? limits.length : 0;
+      throw new Error(`manual_qpos_limits length mismatch: got ${nLimits}, qpos ${qpos.length}`);
+    }
     const host = $("manual-sliders-m");
     host.innerHTML = "";
     qpos.forEach((v, i) => {
+      const limit = limits[i];
       const row = document.createElement("div"); row.className = "ms-row";
       row.innerHTML =
         `<span class="ms-j">j${String(i).padStart(2, "0")}</span>` +
-        `<input type="range" min="-3.2" max="3.2" step="0.005" value="${v}" data-j="${i}">` +
+        `<input type="range" min="${limit.min}" max="${limit.max}" step="${limit.step}" value="${v}" data-j="${i}">` +
         `<span class="ms-x" id="ms-x-${i}">${v.toFixed(3)}</span>`;
       const range = row.querySelector("input");
       range.oninput = (e) => {

--- a/src/core/app/handlers/control.py
+++ b/src/core/app/handlers/control.py
@@ -27,7 +27,9 @@ from core.app.handlers.recording import (
     collect_stop,
     collect_stop_teleop,
     end_episode,
+    mark_rollout_save_ready,
     record_executed_action,
+    start_rollout_intervention,
 )
 from core.app.handlers.utils import (
     _format_diag_vector,
@@ -38,6 +40,7 @@ from core.app.handlers.utils import (
     reset_run_state,
     reset_session_progress,
 )
+from core.app.operator_control import resolve_operator_event
 from core.app.state import (
     OutputTarget,
     RuntimeState,
@@ -72,12 +75,6 @@ _MOTION_INTERRUPTING_VERBS = frozenset(
 
 
 MANUAL_MAX_QPOS_STEP = 0.02
-
-
-def manual_publish_rate(config: ConfigDict) -> int:
-    """Return the configured MANUAL-mode robot publish rate in Hz."""
-    manual_cfg = config.get("manual_cfg") or {}
-    return int(manual_cfg.get("publish_rate", 15))
 
 
 def apply_gripper_control_overrides(
@@ -163,11 +160,13 @@ def apply_gripper_command(
         return False
     target_qpos = np.asarray(current_qpos, dtype=np.float32).copy()
     applied = False
+    gripper_targets: list[tuple[str, float]] = []
     for group, index, _ in iter_target_grippers(runtime.robot, side):
         if index >= len(target_qpos):
             continue
         value = decide(float(current_qpos[index]))
         target_qpos[index] = value
+        gripper_targets.append((group.name, value))
         if session is not None:
             if lock is True:
                 session.gripper_locks[group.name] = value
@@ -185,6 +184,8 @@ def apply_gripper_command(
             rate.sleep()
     else:
         publish_action(runtime, target_qpos, target=OutputTarget.REAL.value)
+    for group_name, value in gripper_targets:
+        runtime.transport.record_collection_gripper_action(group_name, value)
     return True
 
 
@@ -297,10 +298,13 @@ def _publish_manual_real_qpos(
     if start is None:
         start = target
     start = np.asarray(start, dtype=np.float32)
-    max_delta = float(np.max(np.abs(target - start))) if target.size else 0.0
+    gripper_mask = np.asarray(runtime.robot.gripper_mask, dtype=bool)
+    joint_delta = np.abs(target - start)[~gripper_mask]
+    max_delta = float(np.max(joint_delta)) if joint_delta.size else 0.0
     steps = max(1, int(np.ceil(max_delta / MANUAL_MAX_QPOS_STEP)))
-    rate = runtime.transport.create_rate(manual_publish_rate(config))
+    rate = runtime.transport.create_rate(config.inference_cfg.publish_rate)
     trajectory = build_linear_trajectory(start, target, steps + 1)[1:]
+    trajectory[:, gripper_mask] = target[gripper_mask]
     for action in trajectory:
         if poll_motion_commands(config, runtime, session):
             consume_motion_interrupt(session, session.status)
@@ -448,11 +452,57 @@ def handle_motion_command(
     # the mode/prompt/episode/checkpoint or trigger a reset must also interrupt the
     # motion, but are re-queued so the main loop applies them once it unwinds — this
     # is what lets a mode switch abort an in-progress setup instead of being dropped.
-    del config
-    verb = command.strip().lower().removeprefix("web:")
+    raw_verb = command.strip().lower().removeprefix("web:")
+    verb, _, arg = raw_verb.partition(":")
+    if verb == "operator_button":
+        button, _, source = arg.partition(":")
+        resolved_command = resolve_operator_event(
+            config,
+            runtime,
+            session,
+            button=button,
+            source=source or "cat",
+        )
+        return (
+            resolved_command is not None
+            and resolved_command != command
+            and handle_motion_command(resolved_command, config, runtime, session)
+        )
+    if verb == "operator_action":
+        intent, _, source = arg.partition(":")
+        resolved_command = resolve_operator_event(
+            config,
+            runtime,
+            session,
+            intent=intent,
+            source=source or "ui",
+        )
+        return (
+            resolved_command is not None
+            and resolved_command != command
+            and handle_motion_command(resolved_command, config, runtime, session)
+        )
+    if verb == "rollout_stop":
+        was_running = session.status is SessionStatus.RUNNING and session.mode in (
+            SessionMode.REAL,
+            SessionMode.SIM,
+        )
+        session.interrupt_requested = True
+        logger.info("Rollout stop requested; stopping current motion")
+        if was_running and not is_replay(runtime):
+            mark_rollout_save_ready(runtime, "stop")
+        return True
     if verb == "halt":
+        was_running = session.status is SessionStatus.RUNNING and session.mode in (
+            SessionMode.REAL,
+            SessionMode.SIM,
+        )
         session.interrupt_requested = True
         logger.info("Interrupt requested; stopping current motion")
+        if was_running and not is_replay(runtime):
+            mark_rollout_save_ready(runtime, "stop")
+            if session.mode is SessionMode.REAL and config.rollout.intervention.enabled:
+                start_rollout_intervention(config, runtime, session)
         return True
     if verb == "stop" and runtime.web_phase == "running":
         session.interrupt_requested = True
@@ -461,7 +511,7 @@ def handle_motion_command(
             runtime.command_queue.put(command)
         logger.info("Interrupting current motion to apply '%s'", verb)
         return True
-    if verb.partition(":")[0] in _MOTION_INTERRUPTING_VERBS:
+    if verb in _MOTION_INTERRUPTING_VERBS:
         session.interrupt_requested = True
         if runtime.command_queue is not None:
             runtime.command_queue.put(command)
@@ -548,12 +598,7 @@ def reset_with_setup(
     Raises:
         SystemExit: the transport shut down while waiting for feedback.
     """
-    publish_rate = (
-        manual_publish_rate(config)
-        if session.mode is SessionMode.MANUAL
-        else config.inference_cfg.publish_rate
-    )
-    rate = runtime.transport.create_rate(publish_rate)
+    rate = runtime.transport.create_rate(config.inference_cfg.publish_rate)
     logger.info("Resetting to initial joint position on %s target", output_target.value)
     set_setup_stage(runtime, "waiting for joint feedback")
     current_qpos = runtime.transport.get_latest_qpos()
@@ -1181,23 +1226,6 @@ def update_inference_params(
     )
 
 
-def update_manual_params(config: ConfigDict, runtime: RuntimeState, params: dict) -> None:
-    """Hot-patch MANUAL-mode robot publishing parameters onto the live runtime config.
-
-    Args:
-        params: {publish_rate?}; absent fields keep current values.
-    """
-    import copy
-
-    new_config = copy.deepcopy(config)
-    if not new_config.get("manual_cfg"):
-        new_config.manual_cfg = ConfigDict()
-    if params.get("publish_rate") is not None:
-        new_config.manual_cfg.publish_rate = int(params["publish_rate"])
-    runtime.active_config = new_config
-    logger.info("Updated manual params: publish_rate=%d", manual_publish_rate(new_config))
-
-
 def replace_inference_strategy(
     config: ConfigDict, runtime: RuntimeState, strategy_key: str
 ) -> None:
@@ -1255,7 +1283,7 @@ def select_mode(
     if mode is not SessionMode.COLLECT and runtime.collection_teleop_active:
         if session.mode is SessionMode.COLLECT and session.status is SessionStatus.RUNNING:
             collect_stop(config, runtime, session)
-        collect_stop_teleop(runtime, session)
+        collect_stop_teleop(config, runtime, session)
     session.mode = mode
     reset_session_progress(session)
     reset_infer_strategy(runtime)
@@ -1291,7 +1319,6 @@ def select_task(
 __all__ = [
     "_MOTION_INTERRUPTING_VERBS",
     "MANUAL_MAX_QPOS_STEP",
-    "manual_publish_rate",
     "apply_gripper_control_overrides",
     "iter_target_grippers",
     "apply_gripper_command",
@@ -1322,7 +1349,6 @@ __all__ = [
     "run_one_chunk_on_sim",
     "run_pending_chunk_on_real",
     "update_inference_params",
-    "update_manual_params",
     "replace_inference_strategy",
     "select_inference_strategy",
     "select_mode",

--- a/src/core/app/handlers/imaging.py
+++ b/src/core/app/handlers/imaging.py
@@ -5,7 +5,8 @@ and image preprocessing (resize/pad/layout).
 from __future__ import annotations
 
 import numpy as np
-from PIL import Image
+
+from core.utils.images import resize_direct, resize_with_pad
 
 
 def normalize_action_chunk(actions: object) -> np.ndarray:
@@ -27,6 +28,31 @@ def normalize_action_chunk(actions: object) -> np.ndarray:
     return chunk
 
 
+def snap_gripper_dims(
+    action: np.ndarray,
+    gripper_mask: tuple[bool, ...],
+    threshold: float = 0.5,
+    open_value: float = 1.0,
+    close_value: float = 0.0,
+) -> np.ndarray:
+    """Binarize configured gripper dimensions of an action in place.
+
+    Args:
+        action: Action vector [D].
+        gripper_mask: Per-dimension flags marking gripper entries.
+        threshold: Cutoff applied to each gripper value.
+        open_value: Command value for an open gripper.
+        close_value: Command value for a closed gripper.
+
+    Returns:
+        The same action array with gripper dims snapped to close/open values.
+    """
+    for idx, is_gripper in enumerate(gripper_mask):
+        if is_gripper and idx < len(action):
+            action[idx] = open_value if action[idx] >= threshold else close_value
+    return action
+
+
 def build_linear_trajectory(current: np.ndarray, target: np.ndarray, steps: int) -> np.ndarray:
     """Linearly interpolate between two vectors.
 
@@ -46,59 +72,6 @@ def build_linear_trajectory(current: np.ndarray, target: np.ndarray, steps: int)
             f"current={current_vector.shape}, target={target_vector.shape}"
         )
     return np.linspace(current_vector, target_vector, num=max(2, steps), dtype=np.float32)
-
-
-# --- Image utilities ---
-
-
-def resize_with_pad(image: np.ndarray, height: int, width: int) -> np.ndarray:
-    """Resize an image to fit a target size, preserving aspect ratio with padding.
-
-    Args:
-        image: Source image, HWC array.
-        height: Target height.
-        width: Target width.
-
-    Returns:
-        Padded resized HWC uint8 array.
-    """
-    src_h, src_w = image.shape[:2]
-    scale = min(width / src_w, height / src_h)
-    new_w = max(1, int(round(src_w * scale)))
-    new_h = max(1, int(round(src_h * scale)))
-    pil_image = Image.fromarray(image)
-    resized = np.asarray(
-        pil_image.resize((new_w, new_h), resample=Image.Resampling.BILINEAR),
-    )
-    top = (height - new_h) // 2
-    bottom = height - new_h - top
-    left = (width - new_w) // 2
-    right = width - new_w - left
-    if resized.ndim == 2:
-        padded = np.zeros((height, width), dtype=resized.dtype)
-        padded[top : height - bottom, left : width - right] = resized
-        return padded
-    padded = np.zeros((height, width, resized.shape[2]), dtype=resized.dtype)
-    padded[top : height - bottom, left : width - right, :] = resized
-    return padded
-
-
-def resize_direct(image: np.ndarray, height: int, width: int) -> np.ndarray:
-    """Resize an image directly to a target size without preserving aspect ratio.
-
-    Args:
-        image: Source image, HWC array.
-        height: Target height.
-        width: Target width.
-
-    Returns:
-        Directly resized HWC uint8 array.
-    """
-    pil_image = Image.fromarray(image)
-    resized = np.asarray(
-        pil_image.resize((width, height), resample=Image.Resampling.BILINEAR),
-    )
-    return resized
 
 
 def prepare_image(

--- a/src/core/app/handlers/io.py
+++ b/src/core/app/handlers/io.py
@@ -302,7 +302,12 @@ def _replay_action_at(config: ConfigDict, runtime: RuntimeState, index: int) -> 
         seed_qpos = _replay_qpos_at(runtime, index) if index == 0 else None
         action_chunk = ik_solver.solve_chunk(canonical_eef_chunk, seed_qpos=seed_qpos)
     action = action_chunk[0].astype(np.float32, copy=True)
-    runtime.robot.snap_grippers(action, config.robot.gripper_threshold)
+    runtime.robot.snap_grippers(
+        action,
+        config.robot.gripper_threshold,
+        config.robot.gripper_open,
+        config.robot.gripper_close,
+    )
     return action
 
 
@@ -371,7 +376,12 @@ def fetch_action_chunk(
         action_chunk = normalize_policy_action_chunk(
             config, runtime, original_chunk, response=response
         )
-        runtime.robot.snap_grippers(action_chunk, config.robot.gripper_threshold)
+        runtime.robot.snap_grippers(
+            action_chunk,
+            config.robot.gripper_threshold,
+            config.robot.gripper_open,
+            config.robot.gripper_close,
+        )
         step_index = session.step_index if session is not None else -1
         logger.info(
             "[INFER_CHUNK] step=%d infer_ms=%.1f raw_shape=%s action_shape=%s "

--- a/src/core/app/handlers/recording.py
+++ b/src/core/app/handlers/recording.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 
+from core.app.collection_capture import start_collection_capture, stop_collection_capture
 from core.app.handlers.imaging import prepare_image
 from core.app.handlers.utils import _resolve_runtime_path
 from core.app.state import (
@@ -22,7 +23,7 @@ from core.app.state import (
 from core.config import ConfigDict
 from core.recorder.episode import EpisodeLogger, sanitize_path_component
 from core.recorder.lerobot_meta import history_row
-from core.types import Observation
+from core.types import Observation, RolloutInterventionSegment
 
 logger = logging.getLogger(__name__)
 
@@ -176,6 +177,95 @@ def maybe_build_episode_logger(config: ConfigDict, runtime: RuntimeState) -> Non
     )
 
 
+def rollout_save_log_dir(config: ConfigDict) -> Path:
+    """Return the rollout save dataset dir, separate from collection/eval datasets."""
+    storage = config.rollout.storage
+    if storage.log_dir:
+        return _resolve_runtime_path(storage.log_dir)
+    return _resolve_runtime_path(
+        Path(config.get("work_dir") or "work_dirs") / "rollout" / config.robot.type
+    )
+
+
+def maybe_build_rollout_episode_logger(config: ConfigDict, runtime: RuntimeState) -> None:
+    """Construct the rollout EpisodeLogger when explicit rollout saving is enabled."""
+    storage = config.rollout.storage
+    if not storage.enabled or runtime.rollout_episode_logger is not None:
+        return
+    runtime.rollout_episode_logger = EpisodeLogger(
+        log_dir=rollout_save_log_dir(config),
+        robot=runtime.robot,
+        fps=storage.fps,
+        dataset_keys=config.transport.dataset_keys,
+        convert_bgr_to_rgb=config.transport.convert_bgr_to_rgb,
+        collection=None,
+        async_save=storage.async_save,
+        save_queue_max=storage.save_queue_max,
+        save_image_height=storage.get("image_height"),
+        save_image_width=storage.get("image_width"),
+    )
+
+
+def begin_rollout_save_episode(
+    config: ConfigDict, runtime: RuntimeState, session: SessionState
+) -> None:
+    """Start an in-memory rollout that can be saved after stop/reset."""
+    maybe_build_rollout_episode_logger(config, runtime)
+    logger_obj = runtime.rollout_episode_logger
+    if logger_obj is None:
+        return
+    if logger_obj.has_active_episode:
+        logger_obj.cancel_episode("superseded by new rollout")
+    runtime.rollout_save_ready = False
+    runtime.rollout_save_reason = ""
+    runtime.rollout_intervention_pre_qpos = None
+    runtime.rollout_intervention_active_segment = None
+    runtime.rollout_intervention_segments = []
+    runtime.rollout_intervention_next_segment_index = 0
+    logger_obj.start_episode(task=format_task_label(session.selected_task))
+
+
+def mark_rollout_save_ready(runtime: RuntimeState, reason: str) -> None:
+    """Mark the active rollout as eligible for explicit save."""
+    logger_obj = runtime.rollout_episode_logger
+    if logger_obj is None or not logger_obj.has_active_episode:
+        return
+    if logger_obj.active_frame_count <= 0:
+        logger_obj.cancel_episode("empty rollout")
+        runtime.rollout_save_ready = False
+        runtime.rollout_save_reason = ""
+        return
+    runtime.rollout_save_ready = True
+    runtime.rollout_save_reason = reason
+
+
+def save_rollout_episode(runtime: RuntimeState, session: SessionState) -> None:
+    """Persist the stopped rollout through its dedicated EpisodeLogger."""
+    logger_obj = runtime.rollout_episode_logger
+    if logger_obj is None:
+        session.last_error = "Rollout save is disabled"
+        return
+    if not runtime.rollout_save_ready or not logger_obj.has_active_episode:
+        session.last_error = "Stop or reset before saving the rollout"
+        return
+    if logger_obj.active_frame_count <= 0:
+        logger_obj.cancel_episode("empty rollout")
+        runtime.rollout_save_ready = False
+        runtime.rollout_save_reason = ""
+        session.last_error = "No rollout frames to save"
+        return
+    logger_obj.set_rollout_intervention_segments(runtime.rollout_intervention_segments)
+    saved = logger_obj.end_episode()
+    if not saved:
+        session.last_error = "No rollout frames to save"
+        return
+    runtime.rollout_save_ready = False
+    runtime.rollout_save_reason = ""
+    runtime.rollout_intervention_segments = []
+    runtime.rollout_intervention_next_segment_index = 0
+    session.last_error = ""
+
+
 def _load_saved_episode_history(dataset_dir: Path) -> list[dict[str, Any]]:
     history = []
     path = dataset_dir / "meta" / "episodes.jsonl"
@@ -189,6 +279,73 @@ def _load_saved_episode_history(dataset_dir: Path) -> list[dict[str, Any]]:
             row = json.loads(line)
             history.append(history_row(row, len(history)))
     return history
+
+
+def _rollout_intervention_save_status(runtime: RuntimeState) -> dict[str, Any]:
+    active_segment = runtime.rollout_intervention_active_segment
+    accepted_segments = runtime.rollout_intervention_segments
+    return {
+        "active_intervention_frames": 0 if active_segment is None else len(active_segment.frames),
+        "accepted_intervention_segments": len(accepted_segments),
+        "save_blocked_by_intervention": runtime.rollout_intervention_active,
+    }
+
+
+def rollout_save_status(config: ConfigDict, runtime: RuntimeState) -> dict[str, Any]:
+    """Return queue/progress state for the rollout save panel."""
+    dataset_path = rollout_save_log_dir(config)
+    dataset_dir = str(dataset_path)
+    saved_history = _load_saved_episode_history(dataset_path)
+    logger_obj = runtime.rollout_episode_logger
+    storage = config.rollout.storage
+    if not storage.enabled:
+        return {
+            "enabled": False,
+            "dataset_dir": dataset_dir,
+            "pipeline_state": "DISABLED",
+            "collecting": False,
+            "current_episode_frames": 0,
+            "completed_episodes": 0,
+            "save_queue_size": 0,
+            "save_queue_max": storage.save_queue_max,
+            "progress": 0.0,
+            "eta_sec": None,
+            "episodes": saved_history,
+            "queue": [],
+            "save_ready": False,
+            "reason": "",
+            **_rollout_intervention_save_status(runtime),
+        }
+    if logger_obj is None:
+        return {
+            "enabled": True,
+            "dataset_dir": dataset_dir,
+            "pipeline_state": "IDLE",
+            "collecting": False,
+            "current_episode_frames": 0,
+            "completed_episodes": len(saved_history),
+            "save_queue_size": 0,
+            "save_queue_max": storage.save_queue_max,
+            "progress": 1.0 if saved_history else 0.0,
+            "eta_sec": None,
+            "episodes": saved_history,
+            "queue": [],
+            "save_ready": False,
+            "reason": "",
+            **_rollout_intervention_save_status(runtime),
+        }
+    snapshot = logger_obj.status_snapshot()
+    snapshot["enabled"] = True
+    snapshot["dataset_dir"] = dataset_dir
+    snapshot["episodes"] = saved_history
+    snapshot["completed_episodes"] = len(saved_history)
+    snapshot["save_ready"] = bool(runtime.rollout_save_ready and logger_obj.active_frame_count > 0)
+    snapshot["reason"] = runtime.rollout_save_reason
+    if snapshot["save_ready"]:
+        snapshot["pipeline_state"] = "READY_TO_SAVE"
+        snapshot["collecting"] = False
+    snapshot.update(_rollout_intervention_save_status(runtime))
+    return snapshot
 
 
 def enable_default_recording(config: ConfigDict, output_dir: str) -> ConfigDict:
@@ -222,7 +379,12 @@ def eval_model_name(config: ConfigDict, runtime: RuntimeState | None) -> str:
         slot = (
             0 if runtime is None or runtime.active_ckpt_slot is None else runtime.active_ckpt_slot
         )
-        return eval_cfg.checkpoints[slot].name
+        order = (
+            runtime.ckpt_order
+            if (runtime and runtime.ckpt_order)
+            else list(range(len(eval_cfg.checkpoints)))
+        )
+        return eval_cfg.checkpoints[order[slot]].name
     return "model"
 
 
@@ -276,7 +438,176 @@ def end_episode(runtime: RuntimeState) -> None:
         runtime.episode_logger.end_episode()
 
 
-def collect_start_teleop(runtime: RuntimeState, session: SessionState) -> bool:
+def start_rollout_intervention(
+    config: ConfigDict, runtime: RuntimeState, session: SessionState
+) -> bool:
+    """Enable teleop takeover for a paused normal rollout."""
+    if runtime.rollout_intervention_active:
+        return True
+    if not config.rollout.intervention.enabled:
+        return False
+    if not runtime.transport.supports_collection():
+        session.last_error = "Rollout teleop intervention recording is not available"
+        return False
+    pre_qpos = runtime.transport.get_latest_qpos()
+    if pre_qpos is None:
+        session.last_error = "Cannot start rollout intervention without joint feedback"
+        return False
+    runtime.transport.reset_hil_control()
+    runtime.transport.start_collection()
+    runtime.transport.clear_collection_backlog()
+    if runtime.infer_strategy is not None:
+        runtime.infer_strategy.reset()
+    runtime.rollout_intervention_pre_qpos = np.asarray(pre_qpos, dtype=np.float32).copy()
+    runtime.rollout_intervention_active_segment = RolloutInterventionSegment(
+        segment_index=runtime.rollout_intervention_next_segment_index,
+        start_policy_frame_index=session.step_index,
+        pre_intervention_qpos=runtime.rollout_intervention_pre_qpos.copy(),
+    )
+    runtime.rollout_intervention_next_segment_index += 1
+    runtime.rollout_intervention_active = True
+    session.last_error = ""
+    logger.info("Rollout teleop intervention started")
+    return True
+
+
+def stop_rollout_intervention(
+    config: ConfigDict,
+    runtime: RuntimeState,
+    session: SessionState,
+    *,
+    required: bool,
+) -> bool:
+    """Disable rollout teleop takeover before policy resume or cleanup."""
+    if not runtime.rollout_intervention_active:
+        return True
+    runtime.transport.stop_collection()
+    runtime.rollout_intervention_active = False
+    logger.info("Rollout teleop intervention stopped")
+    _ = config, required
+    return True
+
+
+def _copy_observation(frame: Observation) -> Observation:
+    images = {key: np.asarray(value).copy() for key, value in frame.images.items()}
+    vectors = {}
+    for field in (
+        "state_qpos",
+        "state_eef",
+        "action_qpos",
+        "action_eef",
+    ):
+        value = getattr(frame, field)
+        vectors[field] = None if value is None else np.asarray(value, dtype=np.float32).copy()
+    return Observation(
+        timestamp=float(frame.timestamp if frame.timestamp is not None else 0.0),
+        images=images,
+        state_qpos=vectors["state_qpos"],
+        state_eef=vectors["state_eef"],
+        action_qpos=vectors["action_qpos"],
+        action_eef=vectors["action_eef"],
+    )
+
+
+def _record_rollout_intervention_frame(
+    runtime: RuntimeState, session: SessionState, frame: Observation
+) -> bool:
+    segment = runtime.rollout_intervention_active_segment
+    if segment is None:
+        return False
+    if frame.action_qpos is None and frame.action_eef is None:
+        return False
+    if frame.state_qpos is None and frame.state_eef is None:
+        segment.invalid_reason = "Intervention frame has no state"
+        session.last_error = segment.invalid_reason
+        return False
+    segment.frames.append(_copy_observation(frame))
+    return True
+
+
+def record_rollout_intervention_step(runtime: RuntimeState, session: SessionState) -> bool:
+    """Record available teleop frames while normal rollout intervention is active."""
+    if not runtime.rollout_intervention_active:
+        return False
+    segment = runtime.rollout_intervention_active_segment
+    if segment is None or segment.invalid_reason:
+        return False
+    frame = runtime.transport.get_collection_frame()
+    if frame is None:
+        return False
+    return _record_rollout_intervention_frame(runtime, session, frame)
+
+
+def accept_rollout_intervention_segment(
+    runtime: RuntimeState, session: SessionState
+) -> bool:
+    """Keep the active intervention segment so rollout SAVE can write it later."""
+    segment = runtime.rollout_intervention_active_segment
+    if segment is None:
+        runtime.rollout_intervention_pre_qpos = None
+        return True
+    if segment.invalid_reason:
+        session.last_error = segment.invalid_reason
+        return False
+    segment.resume_policy_frame_index = session.step_index
+    if segment.frames:
+        runtime.rollout_intervention_segments.append(segment)
+    runtime.rollout_intervention_active_segment = None
+    runtime.rollout_intervention_pre_qpos = None
+    return True
+
+
+def discard_rollout_intervention_segment(runtime: RuntimeState) -> None:
+    """Drop the active intervention segment without saving it."""
+    runtime.rollout_intervention_active_segment = None
+    runtime.rollout_intervention_pre_qpos = None
+
+
+def rollback_rollout_intervention(
+    config: ConfigDict, runtime: RuntimeState, session: SessionState
+) -> bool:
+    """Return the robot to the qpos captured before the active intervention."""
+    target = runtime.rollout_intervention_pre_qpos
+    if target is None:
+        session.last_error = "No pre-intervention qpos to roll back to"
+        return False
+    current_qpos = runtime.transport.get_latest_qpos()
+    if current_qpos is None:
+        session.last_error = "Cannot roll back intervention without joint feedback"
+        return False
+    from core.app.handlers.control import (
+        MANUAL_MAX_QPOS_STEP,
+        consume_motion_interrupt,
+        poll_motion_commands,
+        publish_action,
+    )
+    from core.app.handlers.imaging import build_linear_trajectory
+
+    current = np.asarray(current_qpos, dtype=np.float32)
+    target = np.asarray(target, dtype=np.float32)
+    gripper_mask = np.asarray(runtime.robot.gripper_mask, dtype=bool)
+    joint_delta = np.abs(target - current)[~gripper_mask]
+    max_delta = float(np.max(joint_delta)) if joint_delta.size else 0.0
+    steps = max(1, int(np.ceil(max_delta / MANUAL_MAX_QPOS_STEP)))
+    trajectory = build_linear_trajectory(current, target, steps + 1)[1:]
+    trajectory[:, gripper_mask] = target[gripper_mask]
+    rate = runtime.transport.create_rate(config.inference_cfg.publish_rate)
+    for action in trajectory:
+        if poll_motion_commands(config, runtime, session):
+            consume_motion_interrupt(session, SessionStatus.READY)
+            session.last_error = "Intervention rollback interrupted"
+            return False
+        if runtime.transport.has_sim_publishers():
+            publish_action(runtime, action, target="sim")
+        publish_action(runtime, action, target="real")
+        session.sim_preview_qpos = np.asarray(action, dtype=np.float32).copy()
+        rate.sleep()
+    return True
+
+
+def collect_start_teleop(
+    config: ConfigDict, runtime: RuntimeState, session: SessionState
+) -> bool:
     """Enter collect teleoperation without opening a recording episode."""
     runtime.collection_replay_qpos = None
     runtime.collection_replay_episode = None
@@ -292,6 +623,7 @@ def collect_start_teleop(runtime: RuntimeState, session: SessionState) -> bool:
     if not runtime.transport.supports_collection():
         session.last_error = "Transport does not support collection frames"
         return False
+    runtime.transport.reset_hil_control()
     runtime.transport.start_collection()
     runtime.collection_teleop_active = True
     runtime.last_collection_timestamp = None
@@ -303,20 +635,19 @@ def collect_start_teleop(runtime: RuntimeState, session: SessionState) -> bool:
     return True
 
 
-def collect_stop_teleop(runtime: RuntimeState, session: SessionState) -> None:
+def collect_stop_teleop(config: ConfigDict, runtime: RuntimeState, session: SessionState) -> None:
     """Leave collect teleoperation; callers close any active recording episode first."""
-    if runtime.collection_teleop_active:
-        try:
-            runtime.transport.stop_collection()
-        finally:
-            runtime.collection_teleop_active = False
-            runtime.last_collection_timestamp = None
+    stop_collection_capture(runtime)
+    runtime.transport.stop_collection()
+    runtime.collection_teleop_active = False
+    runtime.last_collection_timestamp = None
     if session.mode is SessionMode.COLLECT and session.status is not SessionStatus.RUNNING:
         session.status = SessionStatus.UNSET
     logger.info("Collection teleop stopped")
+    _ = config
 
 
-def collect_start(runtime: RuntimeState, session: SessionState) -> bool:
+def collect_start(config: ConfigDict, runtime: RuntimeState, session: SessionState) -> bool:
     """Begin one teleop collection episode. Backpressure: refuse to start when the
     async save queue is full so we never grow memory unbounded. Returns True when
     an episode was opened."""
@@ -330,12 +661,17 @@ def collect_start(runtime: RuntimeState, session: SessionState) -> bool:
     runtime.collection_replay_qpos = None
     runtime.collection_replay_episode = None
     if runtime.episode_logger.is_collection_enabled:
-        if not collect_start_teleop(runtime, session):
+        if not collect_start_teleop(config, runtime, session):
             return False
         collection_min_capture_time = runtime.transport.clear_collection_backlog()
         runtime.episode_logger.start_episode(
             task=format_task_label(session.selected_collect_task),
             collection_min_capture_time=collection_min_capture_time,
+        )
+        start_collection_capture(
+            runtime,
+            fps=config.inference_cfg.publish_rate,
+            max_raw_snapshots_per_tick=COLLECT_STEP_MAX_RAW_SNAPSHOTS,
         )
     else:
         runtime.episode_logger.start_episode(task=format_task_label(session.selected_collect_task))
@@ -356,14 +692,7 @@ def collect_step(config: ConfigDict, runtime: RuntimeState) -> bool:
     if runtime.episode_logger is None:
         return False
     if runtime.episode_logger.is_collection_enabled:
-        recorded = False
-        for _ in range(COLLECT_STEP_MAX_RAW_SNAPSHOTS):
-            snap = runtime.transport.acquire_collection_raw()
-            if snap is None:
-                return recorded
-            runtime.episode_logger.ingest_collection_snapshot(snap)
-            recorded = True
-        return recorded
+        return False
     frame = runtime.transport.get_frame()
     if frame is None:
         return False
@@ -379,14 +708,20 @@ def collect_step(config: ConfigDict, runtime: RuntimeState) -> bool:
 def collect_stop(config: ConfigDict, runtime: RuntimeState, session: SessionState) -> None:
     """End the collection episode and leave teleop active at its current pose."""
     if runtime.episode_logger is not None and runtime.episode_logger.is_collection_enabled:
+        stop_collection_capture(runtime)
         try:
             saved = runtime.episode_logger.end_episode()
         finally:
             session.status = SessionStatus.READY
         if not saved:
-            session.last_error = (
-                "Episode saved 0 frames (teleop action never arrived); nothing recorded"
-            )
+            diagnostics = runtime.transport.collection_diagnostics()
+            if diagnostics:
+                session.last_error = f"Episode saved 0 frames; {diagnostics}"
+            else:
+                session.last_error = (
+                    "Episode saved 0 frames (teleop action never arrived); nothing recorded"
+                )
+            logger.warning(session.last_error)
     else:
         if runtime.episode_logger is not None:
             runtime.episode_logger.end_episode()
@@ -397,6 +732,7 @@ def collect_stop(config: ConfigDict, runtime: RuntimeState, session: SessionStat
 def collect_cancel(runtime: RuntimeState, session: SessionState) -> None:
     """Discard the in-flight collection episode (no save, partial files removed)."""
     if runtime.episode_logger is not None and runtime.episode_logger.is_collection_enabled:
+        stop_collection_capture(runtime)
         try:
             runtime.episode_logger.cancel_episode("user cancel")
         finally:
@@ -410,7 +746,11 @@ def collect_cancel(runtime: RuntimeState, session: SessionState) -> None:
 
 def _active_loggers(runtime: RuntimeState) -> list:
     """The episode logger currently built (skips None)."""
-    return [logger_obj for logger_obj in (runtime.episode_logger,) if logger_obj is not None]
+    return [
+        logger_obj
+        for logger_obj in (runtime.episode_logger, runtime.rollout_episode_logger)
+        if logger_obj is not None
+    ]
 
 
 def record_executed_action(
@@ -441,13 +781,25 @@ __all__ = [
     "build_policy_observation",
     "resolve_storage",
     "maybe_build_episode_logger",
+    "rollout_save_log_dir",
+    "maybe_build_rollout_episode_logger",
+    "begin_rollout_save_episode",
+    "mark_rollout_save_ready",
+    "save_rollout_episode",
     "_load_saved_episode_history",
+    "rollout_save_status",
     "enable_default_recording",
     "eval_model_name",
     "eval_episode_dir",
     "rebuild_eval_episode_logger",
     "start_episode",
     "end_episode",
+    "start_rollout_intervention",
+    "stop_rollout_intervention",
+    "record_rollout_intervention_step",
+    "accept_rollout_intervention_segment",
+    "discard_rollout_intervention_segment",
+    "rollback_rollout_intervention",
     "collect_start_teleop",
     "collect_stop_teleop",
     "collect_start",

--- a/src/core/app/operator_control.py
+++ b/src/core/app/operator_control.py
@@ -1,0 +1,197 @@
+"""Operator action routing shared by UI and CAT controller events."""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+
+from core.app.state import RuntimeState, SessionMode, SessionState, SessionStatus
+from core.config import ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class OperatorEvent:
+    """Generic operator event after backend-specific normalization."""
+
+    intent: str | None = None
+    gripper_side: str | None = None
+    gripper_command: str | None = None
+
+
+def _collection_recording(runtime: RuntimeState, session: SessionState) -> bool:
+    logger_obj = runtime.episode_logger
+    return (
+        session.mode is SessionMode.COLLECT
+        and session.status is SessionStatus.RUNNING
+        and logger_obj is not None
+        and logger_obj.has_active_episode
+    )
+
+
+def _gripper_command(event: OperatorEvent) -> str | None:
+    side = (event.gripper_side or "").strip().lower()
+    command = (event.gripper_command or "").strip().lower()
+    if side in {"left", "l"}:
+        side_key = "l"
+    elif side in {"right", "r"}:
+        side_key = "r"
+    else:
+        return None
+    if command not in {"open", "close"}:
+        return None
+    return f"web:gripper:{side_key}:{command}:0"
+
+
+def _normalize_button_event(
+    button: str,
+    runtime: RuntimeState,
+    session: SessionState,
+) -> OperatorEvent:
+    value = button.strip().lower()
+    if value == "y":
+        return OperatorEvent(intent="accept")
+    if value == "x":
+        if _collection_recording(runtime, session) or runtime.rollout_intervention_active:
+            return OperatorEvent(intent="cancel")
+        return OperatorEvent(intent="start")
+    for side in ("left", "right", "l", "r"):
+        for command in ("open", "close"):
+            if value == f"{side}_gripper_{command}":
+                return OperatorEvent(gripper_side=side, gripper_command=command)
+    return OperatorEvent()
+
+
+def _resolve_event_command(
+    runtime: RuntimeState,
+    session: SessionState,
+    event: OperatorEvent,
+) -> str | None:
+    command = _gripper_command(event)
+    if command is not None:
+        return command
+
+    resolved_intent = event.intent
+    if resolved_intent not in {"start", "accept", "cancel"}:
+        return None
+
+    if resolved_intent == "start":
+        if session.mode is SessionMode.COLLECT and session.status is not SessionStatus.RUNNING:
+            return "web:collect_start"
+        if session.status is SessionStatus.RUNNING and session.mode in (
+            SessionMode.REAL,
+            SessionMode.SIM,
+        ):
+            return "web:halt"
+        if runtime.rollout_intervention_active:
+            return "web:run"
+    if resolved_intent == "accept":
+        if _collection_recording(runtime, session):
+            return "web:collect_stop"
+        if runtime.rollout_intervention_active:
+            return "web:run"
+        if runtime.rollout_save_ready:
+            return "web:rollout_save"
+    if resolved_intent == "cancel":
+        if _collection_recording(runtime, session):
+            return "web:collect_cancel"
+        if runtime.rollout_intervention_active:
+            return "web:rollout_intervention_abandon"
+    return None
+
+
+def resolve_operator_event(
+    config: ConfigDict,
+    runtime: RuntimeState,
+    session: SessionState,
+    *,
+    intent: str | None = None,
+    button: str | None = None,
+    source: str = "ui",
+) -> str | None:
+    """Resolve a UI/CAT operator event into one existing web command.
+
+    Args:
+        config: Active config.
+        runtime: Current runtime state.
+        session: Current session state.
+        intent: High-level UI intent: start, accept, or cancel.
+        button: Physical CAT button: x or y.
+        source: Human-readable event source used only for logs.
+
+    Returns:
+        A concrete ``web:*`` command for ``handle_command`` to execute, or None
+        when the event is invalid in the current state.
+    """
+    event = OperatorEvent(intent=intent)
+    if button is not None:
+        event = _normalize_button_event(button, runtime, session)
+
+    if event.intent not in {"start", "accept", "cancel", None}:
+        session.last_error = f"Unsupported operator event: intent={intent!r} button={button!r}"
+        return None
+
+    command = _resolve_event_command(runtime, session, event)
+    if command is None and event.intent is None:
+        session.last_error = f"Unsupported operator event: intent={intent!r} button={button!r}"
+        return None
+
+    if command is None:
+        resolved_intent = event.intent
+        session.last_error = (
+            f"Operator action {resolved_intent!r} is not valid in "
+            f"mode={session.mode.value} status={session.status.value}"
+        )
+        logger.info(
+            "[OPERATOR] source=%s intent=%s button=%s ignored mode=%s status=%s",
+            source,
+            resolved_intent,
+            button,
+            session.mode.value,
+            session.status.value,
+        )
+        return None
+
+    session.last_error = ""
+    logger.info(
+        "[OPERATOR] source=%s intent=%s button=%s resolved=%s",
+        source,
+        event.intent,
+        button,
+        command,
+    )
+    return command
+
+
+def maybe_start_operator_button_listener(
+    config: ConfigDict,
+    runtime: RuntimeState,
+) -> None:
+    """Subscribe to the CAT operator button topic and enqueue internal web commands."""
+    operator_cfg = config.get("operator_control") or {}
+    if not operator_cfg.get("enabled", False):
+        return
+    if config.transport.type != "ros2":
+        logger.warning("operator_control requires ros2 transport, got %s", config.transport.type)
+        return
+    if runtime.command_queue is None:
+        raise RuntimeError("operator_control requires runtime.command_queue")
+    command_queue = runtime.command_queue
+
+    from std_msgs.msg import String
+
+    from transport.ros2 import get_ros2_runtime
+
+    topic = str(operator_cfg.get("button_topic", "/eva/operator_button"))
+    ros_runtime = get_ros2_runtime(config.transport.node_name)
+
+    def on_button(msg: String) -> None:
+        button_value = msg.data.strip().lower()
+        if not button_value:
+            logger.warning("[OPERATOR] ignored empty operator event")
+            return
+        command_queue.put(f"web:operator_button:{button_value}:cat")
+
+    ros_runtime.node.create_subscription(String, topic, on_button, 10)
+    logger.info("[OPERATOR] listening for CAT buttons on %s", topic)

--- a/src/core/app/run.py
+++ b/src/core/app/run.py
@@ -16,6 +16,8 @@ import numpy as np
 from core.app.console.server import start_console_server
 from core.app.handlers import (
     _anchor_buffer_to_current_qpos,
+    accept_rollout_intervention_segment,
+    begin_rollout_save_episode,
     clear_replay,
     collect_cancel,
     collect_start,
@@ -24,6 +26,7 @@ from core.app.handlers import (
     collect_stop,
     collect_stop_teleop,
     connect_policy,
+    discard_rollout_intervention_segment,
     disconnect_policy,
     enable_default_recording,
     end_episode,
@@ -32,12 +35,15 @@ from core.app.handlers import (
     load_replay_dataset,
     manual_home,
     manual_send,
+    mark_rollout_save_ready,
     maybe_build_episode_logger,
     publish_next_action,
     rebuild_eval_episode_logger,
+    record_rollout_intervention_step,
     reset_ik_solver,
     reset_infer_strategy,
     reset_session_progress,
+    rollback_rollout_intervention,
     run_init_done,
     run_init_move,
     run_one_chunk_on_sim,
@@ -45,6 +51,7 @@ from core.app.handlers import (
     run_reset,
     run_setup,
     run_warmup_and_start,
+    save_rollout_episode,
     select_episode,
     select_inference_strategy,
     select_mode,
@@ -55,9 +62,14 @@ from core.app.handlers import (
     set_replay_fps,
     start_episode,
     start_inference_loop,
+    start_rollout_intervention,
+    stop_rollout_intervention,
     toggle_gripper_immediate,
     update_inference_params,
-    update_manual_params,
+)
+from core.app.operator_control import (
+    maybe_start_operator_button_listener,
+    resolve_operator_event,
 )
 from core.app.state import (
     RuntimeState,
@@ -78,6 +90,7 @@ logger = logging.getLogger(__name__)
 # Halt an active run if the frontend hasn't polled /api/status within this window.
 # The poll cadence is ~250ms, so this tolerates dozens of missed polls before tripping.
 CLIENT_WATCHDOG_TIMEOUT_S = 3.0
+_HIL_CONTROL_MODES = frozenset({"absolute", "relative"})
 
 
 def _target_loop_rate_hz(
@@ -165,7 +178,7 @@ def _activate_ckpt_slot(
     Returns the adopted active config on success, or None if the policy connect failed
     (caller sets web_phase=idle). Does NOT touch web_phase otherwise.
     """
-    ckpt = eval_cfg.checkpoints[slot]
+    ckpt = eval_cfg.checkpoints[runtime.ckpt_order[slot]]
     import copy
     config = copy.deepcopy(ckpt.config)
     config.eval = eval_cfg
@@ -261,8 +274,8 @@ def _handle_web_command(
         # Blind multi-ckpt: start on slot 0 (Model A). Run the SAME full activation a
         # switch_ckpt does, so a directly-launched Model A is initialized identically to a
         # switched-to model (force-reconnect + reset session/strategy/IK + rebuild logger +
-        # arm pre-start reset).
-        if eval_cfg.checkpoints:
+        # arm pre-start reset). ckpt_order is set by the web server before bootstrap fires.
+        if eval_cfg.checkpoints and runtime.ckpt_order:
             adopted = _activate_ckpt_slot(0, eval_cfg, runtime, session)
             if adopted is None:
                 logger.error("Bootstrap: policy connect failed")
@@ -309,6 +322,8 @@ def _handle_web_command(
         if runtime.web_phase in {"starting", "running", "stopping", "resetting"}:
             logger.warning("Ignored switch_task while phase=%s", runtime.web_phase)
             return
+        stop_rollout_intervention(config, runtime, session, required=False)
+        discard_rollout_intervention_segment(runtime)
         select_task(arg, config, session, runtime)
         return
 
@@ -316,20 +331,23 @@ def _handle_web_command(
         if runtime.web_phase != "ready":
             logger.warning("Ignored start: phase=%s (must be ready)", runtime.web_phase)
             return
-        if session.selected_task is None:
-            logger.warning("Ignored start: no task selected")
-            return
-        logger.info("[START] task=%r", session.selected_task)
         # Bind this trial's task NOW (from the cell stamped by /api/eval_start), before
-        # the reset trajectory goes out. Otherwise the separate web:switch_task the
-        # frontend queued when the operator clicked the trial could still be sitting in the
-        # queue and would interrupt the in-flight reset trajectory (switch_task is a
-        # motion-interrupting verb) — cutting the init short. Selecting it here makes that
-        # queued switch_task a no-op (task unchanged) so the trajectory completes.
+        # the no-task gate and before the reset trajectory goes out. Otherwise eval_start
+        # can carry a prompt but still be rejected because no prompt was selected in the
+        # DEBUG task picker.
         cell = runtime.current_cell or {}
         cell_prompt = cell.get("prompt")
         if isinstance(cell_prompt, str) and session.selected_task != cell_prompt:
             select_task(cell_prompt, config, session, runtime)
+        if session.selected_task is None:
+            logger.warning("Ignored start: no task selected")
+            return
+        logger.info("[START] task=%r", session.selected_task)
+        # The separate web:switch_task the
+        # frontend queued when the operator clicked the trial could still be sitting in the
+        # queue and would interrupt the in-flight reset trajectory (switch_task is a
+        # motion-interrupting verb) — cutting the init short. Selecting it here makes that
+        # queued switch_task a no-op (task unchanged) so the trajectory completes.
         # run_setup() must FULLY complete its init before we run: clear any stale interrupt
         # flag (a leftover from a prior aborted motion would otherwise cut the reset
         # trajectory short), then run setup and only start if it reported success. This
@@ -442,9 +460,11 @@ def _handle_web_command(
             return
         eval_cfg = config.eval
         slot = int(arg)
-        if slot < 0 or slot >= len(eval_cfg.checkpoints):
+        if slot < 0 or slot >= len(runtime.ckpt_order):
             logger.warning("Ignored switch_ckpt: slot %d out of range", slot)
             return
+        stop_rollout_intervention(config, runtime, session, required=False)
+        discard_rollout_intervention_segment(runtime)
         if _activate_ckpt_slot(slot, eval_cfg, runtime, session) is None:
             logger.error("switch_ckpt: connect failed for slot %d", slot)
             set_phase(runtime, "idle")
@@ -454,6 +474,32 @@ def _handle_web_command(
         return
 
     # --- console verbs (eval-independent; drive the debug mainline directly) ---
+
+    if verb == "operator_action":
+        intent, _, source = arg.partition(":")
+        resolved_command = resolve_operator_event(
+            config,
+            runtime,
+            session,
+            intent=intent,
+            source=source or "ui",
+        )
+        if resolved_command is not None:
+            handle_command(resolved_command, config, runtime, session)
+        return
+
+    if verb == "operator_button":
+        button, _, source = arg.partition(":")
+        resolved_command = resolve_operator_event(
+            config,
+            runtime,
+            session,
+            button=button,
+            source=source or "cat",
+        )
+        if resolved_command is not None:
+            handle_command(resolved_command, config, runtime, session)
+        return
 
     if verb == "connect":
         connect_policy(config, runtime, session)
@@ -523,11 +569,6 @@ def _handle_web_command(
         update_inference_params(config, runtime, session, params)
         return
 
-    if verb == "update_manual_params":
-        params = json.loads(arg) if arg else {}
-        update_manual_params(config, runtime, params)
-        return
-
     if verb == "setup":
         if session.selected_task is None or session.mode is SessionMode.SELECT:
             logger.warning("console setup: select task and mode first")
@@ -544,6 +585,24 @@ def _handle_web_command(
     if verb == "run":
         runtime.collection_replay_qpos = None
         runtime.collection_replay_episode = None
+        if getattr(runtime, "rollout_intervention_active", False):
+            segment = getattr(runtime, "rollout_intervention_active_segment", None)
+            if segment is not None and segment.invalid_reason:
+                session.last_error = segment.invalid_reason
+                return
+            if not stop_rollout_intervention(config, runtime, session, required=True):
+                return
+            if not accept_rollout_intervention_segment(runtime, session):
+                return
+            runtime.rollout_save_ready = False
+            runtime.rollout_save_reason = ""
+            session.action_chunk = None
+            session.chunk_index = 0
+            if not run_warmup_and_start(config, runtime, session):
+                return
+            session.run_start_time = time.monotonic()
+            set_status(session, SessionStatus.RUNNING, reason="resume after teleop intervention")
+            return
         if (
             session.mode in (SessionMode.REAL, SessionMode.SIM)
             and session.status is SessionStatus.READY
@@ -564,6 +623,8 @@ def _handle_web_command(
                 _anchor_buffer_to_current_qpos(runtime)
                 start_inference_loop(config, runtime, session)
             session.last_error = ""
+            runtime.rollout_save_ready = False
+            runtime.rollout_save_reason = ""
             session.run_start_time = time.monotonic()
             set_status(session, SessionStatus.RUNNING, reason="continue")
             return
@@ -574,11 +635,77 @@ def _handle_web_command(
 
     if verb == "halt":
         # Stop continuous run / cancel a pending sim chunk — reuse the 'c' dispatch.
+        was_running = session.status is SessionStatus.RUNNING and session.mode in (
+            SessionMode.REAL,
+            SessionMode.SIM,
+        )
         _dispatch_halt(config, runtime, session)
+        if was_running and not is_replay(runtime):
+            mark_rollout_save_ready(runtime, "stop")
+            if session.mode is SessionMode.REAL and config.rollout.intervention.enabled:
+                start_rollout_intervention(config, runtime, session)
+        return
+
+    if verb == "rollout_intervention_abandon":
+        if not getattr(runtime, "rollout_intervention_active", False):
+            session.last_error = "No active rollout intervention to abandon"
+            return
+        if not stop_rollout_intervention(config, runtime, session, required=True):
+            return
+        if not rollback_rollout_intervention(config, runtime, session):
+            discard_rollout_intervention_segment(runtime)
+            return
+        discard_rollout_intervention_segment(runtime)
+        runtime.rollout_save_ready = False
+        runtime.rollout_save_reason = ""
+        session.action_chunk = None
+        session.chunk_index = 0
+        if not run_warmup_and_start(config, runtime, session):
+            return
+        session.run_start_time = time.monotonic()
+        set_status(session, SessionStatus.RUNNING, reason="resume after abandoned intervention")
+        return
+
+    if verb == "rollout_intervention_mode":
+        if arg not in _HIL_CONTROL_MODES:
+            allowed = ", ".join(sorted(_HIL_CONTROL_MODES))
+            session.last_error = f"Unsupported HIL control mode {arg!r}; expected: {allowed}"
+            return
+        if runtime.rollout_intervention_active:
+            session.last_error = "Stop or resume the active intervention before changing HIL mode"
+            return
+        setter = getattr(runtime.transport, "set_hil_control_mode", None)
+        if setter is None:
+            session.last_error = "Transport does not support HIL control mode"
+            return
+        setter(arg)
+        runtime.hil_control_mode = arg
+        session.last_error = ""
         return
 
     if verb == "console_reset":
+        stop_rollout_intervention(config, runtime, session, required=False)
+        discard_rollout_intervention_segment(runtime)
+        if not is_replay(runtime) and session.mode in (SessionMode.REAL, SessionMode.SIM):
+            mark_rollout_save_ready(runtime, "reset")
         run_reset(config, runtime, session)
+        return
+
+    if verb == "rollout_save":
+        if getattr(runtime, "rollout_intervention_active", False):
+            session.last_error = "Continue or abandon the active intervention before saving"
+            return
+        save_rollout_episode(runtime, session)
+        return
+
+    if verb == "rollout_stop":
+        was_running = session.status is SessionStatus.RUNNING and session.mode in (
+            SessionMode.REAL,
+            SessionMode.SIM,
+        )
+        _dispatch_halt(config, runtime, session)
+        if was_running and not is_replay(runtime):
+            mark_rollout_save_ready(runtime, "stop")
         return
 
     if verb == "tab_switch":
@@ -597,10 +724,12 @@ def _handle_web_command(
             runtime.collection_teleop_armed = False
         runtime.collection_replay_qpos = None
         runtime.collection_replay_episode = None
+        stop_rollout_intervention(config, runtime, session, required=False)
+        discard_rollout_intervention_segment(runtime)
         if session.mode is SessionMode.COLLECT and session.status is SessionStatus.RUNNING:
             collect_stop(config, runtime, session)
         if runtime.collection_teleop_active:
-            collect_stop_teleop(runtime, session)
+            collect_stop_teleop(config, runtime, session)
         _dispatch_halt(config, runtime, session)
         end_episode(runtime)
         reset_session_progress(session)
@@ -609,7 +738,7 @@ def _handle_web_command(
         session.last_error = ""
         set_status(session, SessionStatus.UNSET, reason="tab switch")
         if arg == "collect" and getattr(runtime, "collection_teleop_armed", False):
-            collect_start_teleop(runtime, session)
+            collect_start_teleop(config, runtime, session)
         elif arg == "eval" and config.eval is not None:
             # EVAL runs on the mode fixed by the config (cli_mode, normally REAL); the
             # generic SELECT reset below would force the operator to re-pick a mode that
@@ -679,7 +808,7 @@ def _handle_web_command(
     # --- data collection (teleoperation) verbs ---
 
     if verb == "collect_start":
-        collect_start(runtime, session)
+        collect_start(config, runtime, session)
         return
 
     if verb == "collect_stop":
@@ -747,6 +876,7 @@ def _dispatch_run(config: ConfigDict, runtime: RuntimeState, session: SessionSta
             return
         if not is_replay(runtime):
             start_episode(runtime, session)
+            begin_rollout_save_episode(config, runtime, session)
         session.run_start_time = time.monotonic()
         set_status(session, SessionStatus.RUNNING, reason="start")
         return
@@ -837,6 +967,13 @@ def run(
         selected_inference_strategy_key=None,
         infer_strategy=None,
     )
+    runtime.hil_control_mode = str(
+        getattr(
+            transport,
+            "hil_control_mode",
+            config.rollout.intervention.get("control_mode", "absolute"),
+        )
+    )
     _select_only_inference_strategy_if_needed(config, runtime, session)
     # Record every trial as an episode so results can be previewed (URDF/camera/chart),
     # rooting the dataset inside the eval results tree. Dataset replay has nothing to
@@ -858,6 +995,7 @@ def run(
     prompt_ready.set()
     runtime.command_queue = command_queue
     runtime.prompt_ready = prompt_ready
+    maybe_start_operator_button_listener(config, runtime)
     loop_rate = transport.create_rate(config.inference_cfg.publish_rate)
     loop_rate_hz = config.inference_cfg.publish_rate
 
@@ -915,8 +1053,11 @@ def run(
                 else:
                     publish_next_action(effective, runtime, session)
 
+            if getattr(runtime, "rollout_intervention_active", False):
+                record_rollout_intervention_step(runtime, session)
+
             if session.mode is SessionMode.COLLECT and session.status is SessionStatus.RUNNING:
-                collect_step(config, runtime)
+                collect_step(effective, runtime)
 
             # Reconcile web_phase with the real session state. A run can leave RUNNING via
             # paths that DON'T go through the eval web:stop verb — the client-liveness
@@ -932,9 +1073,15 @@ def run(
 
             loop_rate.sleep()
     finally:
+        stop_rollout_intervention(config, runtime, session, required=False)
+        discard_rollout_intervention_segment(runtime)
         end_episode(runtime)
         if runtime.episode_logger is not None:
             runtime.episode_logger.finalize()
+        if runtime.rollout_episode_logger is not None:
+            if runtime.rollout_episode_logger.has_active_episode:
+                runtime.rollout_episode_logger.cancel_episode("shutdown")
+            runtime.rollout_episode_logger.finalize()
         if runtime.infer_strategy is not None:
             runtime.infer_strategy.close()
         transport.close()

--- a/src/core/app/state.py
+++ b/src/core/app/state.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from core.config import ConfigDict
 from core.recorder.episode import EpisodeLogger
+from core.types import RolloutInterventionSegment
 from policy_client.base import PolicyClient
 from robots.base import Robot
 from strategy.base_strategy import BaseInferStrategy
@@ -24,6 +25,7 @@ from transport.base import TransportBridge
 if TYPE_CHECKING:
     from tqdm import tqdm
 
+    from core.app.collection_capture import CollectionCaptureRunner
     from transport.dataset import DatasetTransport
 
 logger = logging.getLogger(__name__)
@@ -145,6 +147,8 @@ class RuntimeState:
             local activation switch on; required before teleop can affect hardware.
         collection_teleop_active: True while a teleop collection run is active.
         last_collection_timestamp: Timestamp of the last recorded collection frame.
+        collection_capture_runner: Background raw snapshot capture loop for the
+            active collection episode.
         collection_replay_qpos: qpos sequence loaded for collection replay.
         collection_replay_episode: Episode index currently loaded for collection replay.
         collection_replay_started: Monotonic timestamp when collection replay started.
@@ -166,8 +170,9 @@ class RuntimeState:
             identity.
         needs_pre_start_reset: True after a stop/ckpt-switch that left the robot un-reset.
             The next start auto-resets.
-        active_ckpt_slot: operator-facing checkpoint slot (0->Model A, 1->Model B, ...),
-            indexing directly into config.eval.checkpoints.
+        ckpt_order: blind multi-ckpt — ckpt_order[slot] -> index into
+            config.eval.checkpoints.
+        active_ckpt_slot: operator-facing checkpoint slot (0->Model A, 1->Model B, ...).
         eval_output_dir: eval results root (work_dirs/<eval config>/). Each model records
             into a per-model lerobot dataset at <eval_output_dir>/<model_name>/episodes,
             so a model's prior eval episodes (and their embedded scores) auto-resume next
@@ -192,6 +197,16 @@ class RuntimeState:
             fps on load so playback matches data collection; the operator can override it
             live.
         replay_exec_steps: Number of action steps to execute per replay frame.
+        rollout_episode_logger: explicit rollout save. Separate from episode_logger
+            because collection configs use episode_logger for teleop datasets.
+        rollout_save_ready: True when a rollout is staged and ready to be saved.
+        rollout_save_reason: Human-readable reason/label for the pending rollout save.
+        rollout_intervention_active: True while normal rollout is paused under teleop.
+        rollout_intervention_pre_qpos: Robot qpos captured before the active intervention.
+        rollout_intervention_active_segment: Temporary segment being captured.
+        rollout_intervention_segments: Accepted segments saved with the rollout.
+        rollout_intervention_next_segment_index: Monotonic segment id inside the rollout.
+        hil_control_mode: HIL relay mode, either "absolute" or "relative".
     """
 
     robot: Robot
@@ -208,6 +223,7 @@ class RuntimeState:
     collection_teleop_armed: bool = False
     collection_teleop_active: bool = False
     last_collection_timestamp: float | None = None
+    collection_capture_runner: CollectionCaptureRunner | None = None
     collection_replay_qpos: np.ndarray | None = None
     collection_replay_episode: int | None = None
     collection_replay_started: float = 0.0
@@ -219,6 +235,7 @@ class RuntimeState:
     current_clip_id: str | None = None
     current_cell: dict[str, object] | None = None
     needs_pre_start_reset: bool = False
+    ckpt_order: list[int] = dataclasses.field(default_factory=list)
     active_ckpt_slot: int | None = None
     eval_output_dir: str = ""
     active_config: ConfigDict | None = None
@@ -233,6 +250,17 @@ class RuntimeState:
     replay_fps: int = 10
     replay_exec_steps: int = 1
     replay_pbar: tqdm | None = None
+    rollout_episode_logger: EpisodeLogger | None = None
+    rollout_save_ready: bool = False
+    rollout_save_reason: str = ""
+    rollout_intervention_active: bool = False
+    rollout_intervention_pre_qpos: np.ndarray | None = None
+    rollout_intervention_active_segment: RolloutInterventionSegment | None = None
+    rollout_intervention_segments: list[RolloutInterventionSegment] = dataclasses.field(
+        default_factory=list
+    )
+    rollout_intervention_next_segment_index: int = 0
+    hil_control_mode: str = "absolute"
     # EVAL-tab INIT panel: when init_qpos is set, the arm's reset target becomes this
     # recorded start pose instead of robot.initial_qpos (home). init_ready latches once
     # the operator clicks DONE, gating RUN until the arm is positioned + gripper set.

--- a/src/core/recorder/collection.py
+++ b/src/core/recorder/collection.py
@@ -1,9 +1,9 @@
 """Teleop collection episode writer — the EpisodeLogger sub-component that turns a
 stream of raw teleop snapshots into one LeRobot v2.1 collection episode.
 
-Decode/copy work runs on a background ingest thread so the capture loop never
-blocks; ``end_episode`` drains it, validates each frame, and packs the per-frame
-columns into a SaveJob the parent EpisodeLogger flushes to disk.
+Recording only stores raw snapshots; the save worker later extracts raw samples,
+aligns the full episode, validates each frame, and packs the per-frame columns
+into a SaveJob the parent EpisodeLogger flushes to disk.
 """
 
 from __future__ import annotations
@@ -11,8 +11,8 @@ from __future__ import annotations
 import dataclasses
 import json
 import logging
-import queue
 import threading
+import time
 from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -20,7 +20,10 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 import pyarrow.parquet as pq
 
-from core.app.handlers.imaging import resize_direct
+from core.recorder.collection_alignment import (
+    CollectionAlignmentReport,
+    align_collection_samples,
+)
 from core.recorder.episode import (
     _COLLECTION_VECTOR_FIELDS,
     QualityIssue,
@@ -30,7 +33,8 @@ from core.recorder.episode import (
     _to_rgb_uint8,
 )
 from core.recorder.lerobot_meta import build_info
-from core.types import Observation
+from core.types import CollectionRawBatch, Observation
+from core.utils.images import resize_direct
 
 if TYPE_CHECKING:
     from core.config import ConfigDict
@@ -54,6 +58,16 @@ _COLUMN_TO_FIELD = {
 }
 
 
+@dataclasses.dataclass
+class CollectionSavePayload:
+    """Frozen collection episode input prepared by the save worker."""
+
+    raw_snapshots: list[RawCollectionSnapshot]
+    quality_issues: list[QualityIssue]
+    min_capture_time: float | None
+    max_capture_time: float | None
+
+
 def _is_hwc3(arr: np.ndarray) -> bool:
     """True when arr is a HWC image with 3 channels (the only shape we record)."""
     return arr.ndim == 3 and arr.shape[2] == 3
@@ -62,13 +76,10 @@ def _is_hwc3(arr: np.ndarray) -> bool:
 class CollectionEpisodeWriter:
     """Builds one teleop collection episode for its parent EpisodeLogger.
 
-    Decode/copy work runs on a background ingest thread (fed via ``ingest``) so the
-    capture loop never blocks; ``end_episode`` drains it, validates every frame's
-    timestamps / images / vector dims (recording QualityIssue flags), and packs the
-    per-frame columns into a SaveJob the parent flushes to a LeRobot v2.1 parquet.
+    The capture path only stores RawCollectionSnapshot references. Raw extraction,
+    alignment, validation, image decode, and video packing all run on the save
+    worker so recording competes as little as possible with live robot/UI updates.
     """
-
-    _INGEST_HIGH_WATER = 300
 
     def __init__(self, episode_logger: EpisodeLogger, collection: ConfigDict) -> None:
         self._logger = episode_logger
@@ -76,18 +87,18 @@ class CollectionEpisodeWriter:
         self._schema = collection.schema
         self._records: list[Observation] = []
         self._quality_issues: list[QualityIssue] = []
+        self._raw_batch = CollectionRawBatch()
+        self._raw_snapshots: list[RawCollectionSnapshot] = []
+        self._alignment_report: CollectionAlignmentReport | None = None
         self._image_shapes: dict[str, tuple[int, int]] = {}
-        self._ingest_queue: queue.Queue[RawCollectionSnapshot | None] = queue.Queue()
-        self._ingest_thread: threading.Thread | None = None
-        self._ingest_error: BaseException | None = None
-        self._high_water_logged = False
+        self._state_lock = threading.Lock()
         self._received_snapshots = 0
         self._skipped_before_start = 0
-        self._skipped_no_action = 0
         self._min_capture_time: float | None = None
+        self._max_capture_time: float | None = None
 
     def start_episode(self, min_capture_time: float | None = None) -> None:
-        """Reset buffers and launch the background ingest thread for a new episode.
+        """Reset buffers for a new collection episode.
 
         Args:
             min_capture_time: Source timestamp cutoff; frames at or before it are
@@ -95,133 +106,158 @@ class CollectionEpisodeWriter:
         """
         self._records = []
         self._quality_issues = []
-        self._ingest_queue = queue.Queue()
-        self._ingest_error = None
-        self._high_water_logged = False
+        self._raw_batch = CollectionRawBatch(start_time=min_capture_time)
+        self._raw_snapshots = []
+        self._alignment_report = None
         self._received_snapshots = 0
         self._skipped_before_start = 0
-        self._skipped_no_action = 0
         self._min_capture_time = min_capture_time
-        self._ingest_thread = threading.Thread(
-            target=self._ingest_loop, name="collection-ingest", daemon=True
-        )
-        self._ingest_thread.start()
+        self._max_capture_time = None
 
     def ingest(self, snapshot: RawCollectionSnapshot) -> None:
-        """Hand one pre-decode snapshot to the ingest thread. O(1), never blocks.
+        """Store one pre-decode snapshot. O(1), never decodes raw messages.
 
-        The capture loop calls this; all decode/copy/convert work happens on the
-        ingest thread. The queue is unbounded so a busy ingest never stalls the
-        main loop or drops frames — sustained overload only grows memory, flagged
-        once via a high-water warning.
+        The capture loop calls this while recording. Raw extraction is intentionally
+        deferred to the save worker so start-record does not add image/vector decode
+        work to the live UI/control path.
         """
-        if self._ingest_error is not None:
-            raise RuntimeError("collection ingest thread failed") from self._ingest_error
         if self._is_before_episode_start(snapshot.timestamp):
-            self._skipped_before_start += 1
+            with self._state_lock:
+                self._skipped_before_start += 1
             return
-        self._ingest_queue.put(snapshot)
-        self._received_snapshots += 1
-        if not self._high_water_logged and self._ingest_queue.qsize() > self._INGEST_HIGH_WATER:
-            self._high_water_logged = True
-            logger.warning(
-                "collection ingest backlog above %d frames; processing slower than capture rate",
-                self._INGEST_HIGH_WATER,
-            )
+        with self._state_lock:
+            self._received_snapshots += 1
+            if snapshot.timestamp > 0.0:
+                self._max_capture_time = (
+                    snapshot.timestamp
+                    if self._max_capture_time is None
+                    else max(self._max_capture_time, snapshot.timestamp)
+                )
+            self._raw_snapshots.append(snapshot)
 
-    def _ingest_loop(self) -> None:
-        while True:
-            snapshot = self._ingest_queue.get()
-            try:
-                if snapshot is None:
-                    return
-                frame = snapshot.decode()
-                if self._is_before_episode_start(frame.timestamp):
-                    self._received_snapshots = max(0, self._received_snapshots - 1)
-                    self._skipped_before_start += 1
-                    continue
-                # Teleop action lags source frames at episode start (node publishes
-                # no action until calibration completes); skip those rather than
-                # record zero-action rows, matching the pre-async behavior.
-                if frame.action_qpos is None:
-                    self._skipped_no_action += 1
-                    continue
-                self.record_frame(frame, copy_images=False)
-            except BaseException as exc:  # surface to end_episode; keep buffers intact
-                self._ingest_error = exc
-                logger.exception("collection ingest failed")
-                return
-            finally:
-                self._ingest_queue.task_done()
-
-    def _drain_ingest(self) -> None:
-        """Block until the ingest thread has consumed every queued snapshot."""
-        thread = self._ingest_thread
-        if thread is None:
-            return
-        self._ingest_queue.put(None)
-        thread.join()
-        self._ingest_thread = None
-        if self._ingest_error is not None:
-            raise RuntimeError("collection ingest thread failed") from self._ingest_error
-
-    def record_frame(self, frame: Observation, *, copy_images: bool = True) -> None:
-        """Append one decoded frame and run per-frame QC checks.
+    def _append_aligned_frame(self, frame: Observation) -> None:
+        """Append one fixed-clock aligned frame and run per-frame QC checks.
 
         Args:
-            frame: Decoded collection frame with HWC camera images and vector fields.
-            copy_images: Copy image arrays before storing them. Public callers keep
-                the default; raw snapshot ingest can pass False because decode()
-                yields episode-private arrays.
+            frame: Aligned collection frame with HWC camera images and vector fields.
         """
         if frame.timestamp is None or frame.state_qpos is None:
             raise ValueError("collection frame missing timestamp or state_qpos")
-        frame_index = len(self._records)
-        images = {
-            key: np.asarray(value).copy() if copy_images else np.asarray(value)
-            for key, value in frame.images.items()
-        }
-        vectors = {
-            field: (
-                None
-                if getattr(frame, field) is None
-                else np.asarray(getattr(frame, field), dtype=np.float32).copy()
+        with self._state_lock:
+            frame_index = len(self._records)
+            images = {
+                key: np.asarray(value) for key, value in frame.images.items()
+            }
+            vectors = {
+                field: (
+                    None
+                    if getattr(frame, field) is None
+                    else np.asarray(getattr(frame, field), dtype=np.float32).copy()
+                )
+                for field in _COLLECTION_VECTOR_FIELDS
+                if field != "state_qpos"
+            }
+            record = Observation(
+                timestamp=float(frame.timestamp),
+                images=images,
+                state_qpos=np.asarray(frame.state_qpos, dtype=np.float32).copy(),
+                **vectors,
             )
-            for field in _COLLECTION_VECTOR_FIELDS
-            if field != "state_qpos"
-        }
-        record = Observation(
-            timestamp=float(frame.timestamp),
-            images=images,
-            state_qpos=np.asarray(frame.state_qpos, dtype=np.float32).copy(),
-            **vectors,
-        )
-        self._records.append(record)
-        self._check_timestamp(float(frame.timestamp), frame_index)
-        self._check_images(record, frame_index)
+            self._records.append(record)
+            self._check_timestamp(float(frame.timestamp), frame_index)
+            self._check_images(record, frame_index)
+            self._max_capture_time = (
+                record.timestamp
+                if self._max_capture_time is None
+                else max(self._max_capture_time, record.timestamp)
+            )
 
     def frame_counts(self) -> dict[str, int]:
         """Return live collection counters for UI status.
 
         received counts raw snapshots accepted by the main loop. recorded counts
-        decoded rows that will be saved. pending bridges the ingest lag between
+        aligned rows that will be saved. pending bridges the ingest lag between
         those two so the UI does not show zero while frames are queued.
         """
-        recorded = len(self._records)
-        received = max(self._received_snapshots, recorded)
-        pending = max(0, received - self._skipped_no_action - recorded)
-        return {
-            "received": received,
-            "recorded": recorded,
-            "pending": pending,
-            "skipped_before_start": self._skipped_before_start,
-            "skipped_no_action": self._skipped_no_action,
-        }
+        with self._state_lock:
+            recorded = len(self._records)
+            received = max(self._received_snapshots, recorded)
+            pending = max(0, received - recorded)
+            return {
+                "received": received,
+                "recorded": recorded,
+                "pending": pending,
+                "skipped_before_start": self._skipped_before_start,
+            }
 
     def _is_before_episode_start(self, timestamp: float | None) -> bool:
         if self._min_capture_time is None or timestamp is None or timestamp <= 0.0:
             return False
         return timestamp <= self._min_capture_time
+
+    def _merge_raw_batch(self, batch: CollectionRawBatch) -> None:
+        with self._state_lock:
+            if batch.start_time is not None:
+                self._raw_batch.start_time = (
+                    batch.start_time
+                    if self._raw_batch.start_time is None
+                    else max(self._raw_batch.start_time, batch.start_time)
+                )
+            if batch.end_time is not None:
+                self._raw_batch.end_time = (
+                    batch.end_time
+                    if self._raw_batch.end_time is None
+                    else max(self._raw_batch.end_time, batch.end_time)
+                )
+            for key, samples in batch.images.items():
+                self._raw_batch.images.setdefault(key, []).extend(samples)
+                self._track_raw_sample_times(samples)
+            for key, samples in batch.vectors.items():
+                self._raw_batch.vectors.setdefault(key, []).extend(samples)
+                self._track_raw_sample_times(samples)
+
+    def _track_raw_sample_times(self, samples: list[Any]) -> None:
+        for sample in samples:
+            self._max_capture_time = (
+                sample.timestamp
+                if self._max_capture_time is None
+                else max(self._max_capture_time, sample.timestamp)
+            )
+
+    def _has_raw_samples(self) -> bool:
+        return any(self._raw_batch.images.values()) or any(self._raw_batch.vectors.values())
+
+    def _raw_sample_count(self) -> int:
+        return sum(len(samples) for samples in self._raw_batch.images.values()) + sum(
+            len(samples) for samples in self._raw_batch.vectors.values()
+        )
+
+    def _decode_raw_snapshots(self, snapshots: Iterable[RawCollectionSnapshot]) -> None:
+        for snapshot in snapshots:
+            self._merge_raw_batch(snapshot.decode_raw())
+
+    def _image_skew_tolerance_sec(self) -> float:
+        fps = float(self._logger._fps)
+        if fps <= 1.0:
+            return 0.5 / fps
+        return 1.0 / (2.0 * (fps - 1.0))
+
+    def _align_raw_records(self) -> None:
+        self._records = []
+        fields = tuple(_COLUMN_TO_FIELD[column] for column in self._schema.columns)
+        frames, report = align_collection_samples(
+            self._raw_batch,
+            robot=self._logger._robot,
+            camera_keys=tuple(self._schema.cameras.keys()),
+            vector_fields=fields,
+            fps=float(self._logger._fps),
+            image_skew_sec=self._image_skew_tolerance_sec(),
+        )
+        self._alignment_report = report
+        for issue in report.issues:
+            self._add_issue(issue.code, issue.detail)
+        for frame in frames:
+            self._append_aligned_frame(frame)
 
     def expected_dim(self, field: str) -> int:
         """Expected vector length for a collection field (joints / eef).
@@ -235,40 +271,98 @@ class CollectionEpisodeWriter:
         raise ValueError(f"unknown collection field: {field}")
 
     def end_episode(self) -> SaveJob | None:
-        """Drain ingest, validate frames, and pack the episode into a SaveJob.
+        """Pack raw episode snapshots into a background SaveJob.
 
         Returns:
-            A SaveJob carrying the cleaned per-frame columns + episode meta row for
-            the parent logger to flush, or None when no frames were recorded.
+            A SaveJob carrying frozen raw snapshots for the parent logger's
+            save worker, or None when no samples were recorded.
         """
-        self._drain_ingest()
-        if not self._records:
+        started = time.perf_counter()
+        with self._state_lock:
+            raw_snapshots = list(self._raw_snapshots)
+            max_capture_time = self._max_capture_time
+        has_raw = bool(raw_snapshots)
+        if not has_raw:
             logger.warning(
                 "collection episode produced 0 frames; nothing saved "
-                "(teleop action never arrived — calibration likely incomplete)"
+                "(no raw collection snapshots arrived)"
             )
             return None
+
+        task = self._logger._task or ""
+        dataset_dir = self._logger._collection_dataset_dir(task)
+        episode_index = self._logger._next_collection_episode_index(dataset_dir)
+        task_index = 0
+        package_done = time.perf_counter()
+
+        job = SaveJob(
+            episode_index=episode_index,
+            task=task,
+            task_index=task_index,
+            global_index=-1,
+            steps=[],
+            episode_meta=dict(self._logger._episode_meta),
+            task_to_index={task: task_index},
+            collection_payload=CollectionSavePayload(
+                raw_snapshots=raw_snapshots,
+                quality_issues=list(self._quality_issues),
+                min_capture_time=self._min_capture_time,
+                max_capture_time=max_capture_time,
+            ),
+            video_fps=float(self._logger._fps),
+            dataset_dir=dataset_dir,
+        )
+        self._records = []
+        self._quality_issues = []
+        self._raw_batch = CollectionRawBatch()
+        self._raw_snapshots = []
+        self._alignment_report = None
+        self._max_capture_time = None
+        logger.info(
+            "collection end_episode queued raw=%s raw_snapshots=%d: package=%.1fms "
+            "total=%.1fms",
+            has_raw,
+            len(raw_snapshots),
+            (package_done - started) * 1000.0,
+            (package_done - started) * 1000.0,
+        )
+        return job
+
+    def prepare_save_job(self, job: SaveJob) -> None:
+        """Prepare a queued collection SaveJob on the save worker thread."""
+        if job.collection_payload is None:
+            return
+        payload = job.collection_payload
+        preparer = CollectionEpisodeWriter(self._logger, self._collection)
+        preparer._quality_issues = list(payload.quality_issues)
+        preparer._raw_batch = CollectionRawBatch(start_time=payload.min_capture_time)
+        preparer._min_capture_time = payload.min_capture_time
+        preparer._max_capture_time = payload.max_capture_time
+        preparer._image_shapes = dict(self._image_shapes)
+        preparer._decode_raw_snapshots(payload.raw_snapshots)
+        if preparer._raw_batch.end_time is None:
+            preparer._raw_batch.end_time = payload.max_capture_time
+        preparer._build_prepared_save_job(job)
+        self._image_shapes.update(preparer._image_shapes)
+
+    def _build_prepared_save_job(self, job: SaveJob) -> None:
+        started = time.perf_counter()
+        self._align_raw_records()
+        aligned = time.perf_counter()
+        if not self._records:
+            raise ValueError(self._alignment_failure_detail())
         if len(self._records) < self._schema.min_episode_frames:
             self._add_issue(
                 "episode_too_short",
                 f"episode has {len(self._records)} frames, expected at least "
                 f"{self._schema.min_episode_frames}",
             )
-        # measured fps stays in episodes.jsonl as a capture-jitter diagnostic only;
-        # mp4 frame rate must match the synthesized timestamp grid (target fps).
+
         collection_fps = self._episode_average_fps()
         videos = self._snapshot_videos()
-
-        task = self._logger._task or ""
-        dataset_dir = self._logger._collection_dataset_dir(task)
-        episode_index = self._logger._next_collection_episode_index(dataset_dir)
-        task_index = 0
+        video_prepared = time.perf_counter()
         n_frames = len(self._records)
-        global_index = self._logger._next_collection_global_index(dataset_dir, n_frames)
 
-        # LeRobot v2.1 requires each camera's mp4 frame count == data-table row count;
-        # a dropped/corrupt frame is skipped in _snapshot_videos but still occupies a
-        # parquet row, so the counts diverge and the episode crashes on load. Flag it.
         if self._logger._save_video:
             for video_key in self._schema.cameras.values():
                 got = len(videos.get(video_key, [])) if videos else 0
@@ -285,10 +379,11 @@ class CollectionEpisodeWriter:
                 self._clean_vector(field, getattr(record, field), frame_index).tolist()
                 for frame_index, record in enumerate(self._records)
             ]
-        # LeRobot requires timestamp[i] == i/fps (strictly equal-interval, tol 1e-4),
-        # so synthesize it from the target fps. The real hardware capture time (raw,
-        # jittery uptime seconds) is preserved out-of-band in ``capture_time``.
         fps = float(self._logger._fps)
+        dataset_dir = job.dataset_dir or self._logger._collection_dataset_dir(job.task)
+        global_index = job.global_index
+        if global_index < 0:
+            global_index = self._logger._next_collection_global_index(dataset_dir, n_frames)
         columns.update(
             {
                 "timestamp": [i / fps for i in range(n_frames)],
@@ -297,51 +392,94 @@ class CollectionEpisodeWriter:
                     for record in self._records
                 ],
                 "frame_index": list(range(n_frames)),
-                "episode_index": [episode_index] * n_frames,
+                "episode_index": [job.episode_index] * n_frames,
                 "index": list(range(global_index, global_index + n_frames)),
-                "task_index": [task_index] * n_frames,
+                "task_index": [job.task_index] * n_frames,
             }
         )
 
         row: dict[str, Any] = {
-            "episode_index": episode_index,
-            "tasks": [task],
+            "episode_index": job.episode_index,
+            "tasks": [job.task],
             "length": n_frames,
             "quality": "red" if self._quality_issues else "green",
             "quality_issues": [dataclasses.asdict(issue) for issue in self._quality_issues],
         }
         if collection_fps is not None:
             row["collection_fps"] = collection_fps
-        if self._logger._episode_meta:
-            row.update(self._logger._episode_meta)
+        if self._alignment_report is not None:
+            row.update(
+                {
+                    "alignment_fps": fps,
+                    "alignment_grid_start": self._alignment_report.grid_start,
+                    "alignment_grid_end": self._alignment_report.grid_end,
+                    "alignment_image_skew_tolerance_sec": self._image_skew_tolerance_sec(),
+                    "alignment_image_max_skew_sec": self._alignment_report.image_max_skew,
+                    "alignment_image_stream_stats": (
+                        self._alignment_report.image_stream_stats
+                    ),
+                }
+            )
+        if job.episode_meta:
+            row.update(job.episode_meta)
+        columns_packed = time.perf_counter()
 
-        job = SaveJob(
-            episode_index=episode_index,
-            task=task,
-            task_index=task_index,
-            global_index=global_index,
-            steps=[],
-            episode_meta={},
-            task_to_index={task: task_index},
-            collection_columns=columns,
-            collection_episode_row=row,
-            videos=videos,
-            video_fps=fps,
-            dataset_dir=dataset_dir,
+        job.global_index = global_index
+        job.collection_columns = columns
+        job.collection_episode_row = row
+        job.videos = videos
+        job.video_fps = fps
+        job.dataset_dir = dataset_dir
+        job.collection_payload = None
+        logger.info(
+            "collection save worker prepared %d frames: align=%.1fms video=%.1fms "
+            "columns=%.1fms total=%.1fms",
+            n_frames,
+            (aligned - started) * 1000.0,
+            (video_prepared - aligned) * 1000.0,
+            (columns_packed - video_prepared) * 1000.0,
+            (columns_packed - started) * 1000.0,
         )
-        self._records = []
-        self._quality_issues = []
-        return job
+
+    def _alignment_failure_detail(self) -> str:
+        issues = []
+        if self._alignment_report is not None:
+            issues = [
+                f"{issue.code}: {issue.detail}" for issue in self._alignment_report.issues
+            ]
+        issue_text = "; ".join(issues) if issues else "none"
+        return (
+            "collection episode produced 0 frames; "
+            f"alignment_issues={issue_text}; raw_streams={self._raw_stream_summary()}"
+        )
+
+    def _raw_stream_summary(self) -> str:
+        parts = []
+        for family, streams in (
+            ("images", self._raw_batch.images),
+            ("vectors", self._raw_batch.vectors),
+        ):
+            stream_parts = []
+            for key in sorted(streams):
+                samples = streams[key]
+                if samples:
+                    stream_parts.append(
+                        f"{key}:{len(samples)}[{samples[0].timestamp:.6f},"
+                        f"{samples[-1].timestamp:.6f}]"
+                    )
+                else:
+                    stream_parts.append(f"{key}:0")
+            parts.append(f"{family}=" + (",".join(stream_parts) if stream_parts else "none"))
+        return " ".join(parts)
 
     def cancel_episode(self) -> None:
-        """Discard the in-flight episode: drain the ingest thread and drop all buffers."""
-        try:
-            self._drain_ingest()
-        except BaseException:
-            logger.exception("Error draining ingest thread during cancel")
-            self._ingest_thread = None
+        """Discard the in-flight episode and drop all raw snapshot buffers."""
         self._records = []
         self._quality_issues = []
+        self._raw_batch = CollectionRawBatch()
+        self._raw_snapshots = []
+        self._alignment_report = None
+        self._max_capture_time = None
 
     def finalize(self, dataset_dir: Path | None = None) -> None:
         if dataset_dir is None:
@@ -396,7 +534,7 @@ class CollectionEpisodeWriter:
                 if not _is_hwc3(arr):
                     continue
                 rgb = _to_rgb_uint8(arr, self._logger._convert_bgr_to_rgb)
-                if size is not None:
+                if size is not None and rgb.shape[:2] != size:
                     rgb = resize_direct(rgb, size[0], size[1])
                 frames.append(rgb)
             if frames:
@@ -420,10 +558,9 @@ class CollectionEpisodeWriter:
                     f"frame {frame_index} camera {camera_key} has shape {list(arr.shape)}",
                 )
                 continue
-            rgb = _to_rgb_uint8(arr, self._logger._convert_bgr_to_rgb)
             if video_key not in self._image_shapes:
                 self._image_shapes[video_key] = (
-                    size if size is not None else (rgb.shape[0], rgb.shape[1])
+                    size if size is not None else (arr.shape[0], arr.shape[1])
                 )
 
     def _clean_vector(self, field: str, value: np.ndarray | None, frame_index: int) -> np.ndarray:

--- a/src/core/recorder/collection_alignment.py
+++ b/src/core/recorder/collection_alignment.py
@@ -1,0 +1,521 @@
+"""Fixed-clock alignment for teleop collection raw streams."""
+
+from __future__ import annotations
+
+import bisect
+import dataclasses
+import math
+from collections.abc import Iterable
+from typing import Any
+
+import numpy as np
+
+from core.types import CollectionRawBatch, CollectionRawImage, CollectionRawSample, Observation
+from robots.base import Robot
+
+
+@dataclasses.dataclass(frozen=True)
+class AlignmentIssue:
+    """One QC issue found while aligning raw collection samples."""
+
+    code: str
+    detail: str
+
+
+@dataclasses.dataclass(frozen=True)
+class CollectionAlignmentReport:
+    """Diagnostics from fixed-grid collection alignment."""
+
+    grid_start: float
+    grid_end: float
+    image_max_skew: dict[str, float]
+    image_stream_stats: dict[str, dict[str, Any]]
+    issues: list[AlignmentIssue]
+
+
+@dataclasses.dataclass(frozen=True)
+class _VectorComponent:
+    field: str
+    key: str
+    samples: list[CollectionRawSample]
+    group: Any | None
+    gripper_samples: list[CollectionRawSample] | None = None
+    default_gripper: float | None = None
+
+
+def align_collection_samples(
+    batch: CollectionRawBatch,
+    *,
+    robot: Robot,
+    camera_keys: Iterable[str],
+    vector_fields: Iterable[str],
+    fps: float,
+    image_skew_sec: float,
+    start_time: float | None = None,
+    end_time: float | None = None,
+) -> tuple[list[Observation], CollectionAlignmentReport]:
+    """Align raw collection streams to a fixed fps grid.
+
+    Args:
+        batch: Raw image/vector samples keyed by camera observation key and vector field.
+            Each vector sample is a flat float array, typically [robot.total_action_dim]
+            for qpos/action or [8 * n_arms] for eef/action_eef.
+        robot: Robot metadata used to hold gripper dimensions instead of interpolating them.
+        camera_keys: Required camera observation keys.
+        vector_fields: Required vector fields: state_qpos, state_eef, action_qpos, action_eef.
+        fps: Target fixed grid rate in Hz.
+        image_skew_sec: Maximum accepted nearest-neighbor image skew before QC is marked red.
+        start_time: Optional episode lower bound in source-clock seconds. Defaults to
+            batch.start_time.
+        end_time: Optional episode upper bound in source-clock seconds. Defaults to
+            batch.end_time.
+
+    Returns:
+        frames: Observations on the fixed grid. Images are nearest-neighbor selected;
+            continuous vector dimensions are linearly interpolated; gripper dimensions
+            are latest-before held.
+        report: Alignment diagnostics including max image skew and QC issues.
+    """
+    if fps <= 0.0:
+        raise ValueError(f"collection alignment fps must be positive, got {fps}")
+    lower_bound = batch.start_time if start_time is None else start_time
+    upper_bound = batch.end_time if end_time is None else end_time
+    required_images = tuple(camera_keys)
+    required_vectors = tuple(vector_fields)
+    image_series: dict[str, list[CollectionRawSample]] = {
+        key: _sorted_samples(batch.images.get(key, [])) for key in required_images
+    }
+    vector_series = {
+        field: _vector_components(batch, field, robot) for field in required_vectors
+    }
+    issues: list[AlignmentIssue] = []
+    coverage_starts: list[float] = []
+    coverage_ends: list[float] = []
+    image_stream_stats: dict[str, dict[str, Any]] = {}
+    for key, samples in image_series.items():
+        if not samples:
+            return _empty_alignment_report(
+                AlignmentIssue("missing_image_stream", f"{key} has no samples")
+            )
+        bounded_samples = _bounded_samples(samples, lower_bound, upper_bound)
+        if not bounded_samples:
+            return _empty_alignment_report(
+                AlignmentIssue(
+                    "image_stream_outside_episode",
+                    f"{key} has no samples within [{lower_bound}, {upper_bound}]",
+                )
+            )
+        image_series[key] = bounded_samples
+        image_stream_stats[key] = _stream_stats(bounded_samples, image_skew_sec)
+        start = bounded_samples[0].timestamp
+        end = bounded_samples[-1].timestamp
+        coverage_starts.append(start)
+        coverage_ends.append(end)
+    for components in vector_series.values():
+        if not components:
+            return _empty_alignment_report(
+                AlignmentIssue("missing_vector_field", "required vector field has no streams"),
+                image_stream_stats,
+            )
+        for component in components:
+            if not component.samples:
+                return _empty_alignment_report(
+                    AlignmentIssue(
+                        "missing_vector_stream",
+                        f"{component.key} has no samples",
+                    ),
+                    image_stream_stats,
+                )
+            coverage = _bounded_coverage(component.samples, lower_bound, upper_bound)
+            if coverage is None:
+                return _empty_alignment_report(
+                    AlignmentIssue(
+                        "vector_stream_outside_episode",
+                        f"{component.key} has no samples within [{lower_bound}, {upper_bound}]",
+                    ),
+                    image_stream_stats,
+                )
+            start, end = coverage
+            if component.field in {"action_qpos", "action_eef"} and upper_bound is not None:
+                end = upper_bound
+            coverage_starts.append(start)
+            coverage_ends.append(end)
+            if component.gripper_samples is not None:
+                if not component.gripper_samples:
+                    return _empty_alignment_report(
+                        AlignmentIssue(
+                            "missing_gripper_stream",
+                            f"{component.key} gripper has no samples",
+                        ),
+                        image_stream_stats,
+                    )
+    if not coverage_starts:
+        return _empty_alignment_report(
+            AlignmentIssue("missing_required_streams", "no required stream coverage"),
+            image_stream_stats,
+        )
+
+    grid_start = max(coverage_starts)
+    grid_end = min(coverage_ends)
+    if grid_end < grid_start:
+        return _empty_alignment_report(
+            AlignmentIssue(
+                "no_common_coverage",
+                f"required streams do not overlap: start={grid_start:.6f} end={grid_end:.6f}",
+            ),
+            image_stream_stats,
+            grid_start,
+            grid_end,
+        )
+
+    interval = 1.0 / fps
+    n_frames = int(math.floor((grid_end - grid_start) / interval + 1e-9)) + 1
+    tail_tolerance = min(image_skew_sec, 0.5 * interval)
+    next_timestamp = grid_start + n_frames * interval
+    if next_timestamp <= grid_end + tail_tolerance:
+        n_frames += 1
+    image_max_skew = {key: 0.0 for key in required_images}
+    frames: list[Observation] = []
+    discrete_masks: dict[str, np.ndarray | None] = {}
+
+    for frame_index in range(n_frames):
+        timestamp = grid_start + frame_index * interval
+        images: dict[str, np.ndarray] = {}
+        for key, samples in image_series.items():
+            sample = _nearest_sample(samples, timestamp)
+            skew = abs(sample.timestamp - timestamp)
+            image_max_skew[key] = max(image_max_skew[key], skew)
+            if skew > image_skew_sec:
+                issues.append(
+                    AlignmentIssue(
+                        code="image_skew_exceeded",
+                        detail=(
+                            f"frame {frame_index} camera {key} skew {skew:.6f}s "
+                            f"exceeds {image_skew_sec:.6f}s"
+                        ),
+                    )
+                )
+            images[key] = _image_sample_value(sample)
+
+        vectors: dict[str, np.ndarray] = {}
+        for field, components in vector_series.items():
+            parts: list[np.ndarray] = []
+            for component in components:
+                if component.key not in discrete_masks:
+                    discrete_masks[component.key] = _discrete_mask(
+                        field, component.samples[0].value, robot, component.group
+                    )
+                parts.append(
+                    _interpolate_component(
+                        component,
+                        timestamp,
+                        discrete_masks[component.key],
+                    )
+                )
+            vectors[field] = parts[0] if len(parts) == 1 else np.concatenate(parts, axis=0)
+
+        frames.append(
+            Observation(
+                timestamp=timestamp,
+                images=images,
+                state_qpos=vectors.get("state_qpos", np.zeros(0, dtype=np.float32)),
+                state_eef=vectors.get("state_eef"),
+                action_qpos=vectors.get("action_qpos"),
+                action_eef=vectors.get("action_eef"),
+            )
+        )
+
+    return frames, CollectionAlignmentReport(
+        grid_start, grid_end, image_max_skew, image_stream_stats, issues
+    )
+
+
+def _empty_alignment_report(
+    issue: AlignmentIssue,
+    image_stream_stats: dict[str, dict[str, Any]] | None = None,
+    grid_start: float = 0.0,
+    grid_end: float = 0.0,
+) -> tuple[list[Observation], CollectionAlignmentReport]:
+    return [], CollectionAlignmentReport(
+        grid_start,
+        grid_end,
+        {},
+        {} if image_stream_stats is None else image_stream_stats,
+        [issue],
+    )
+
+
+def _sorted_samples(samples: Iterable[CollectionRawSample]) -> list[CollectionRawSample]:
+    return sorted(samples, key=lambda sample: sample.timestamp)
+
+
+def _image_sample_value(sample: CollectionRawSample) -> np.ndarray:
+    value = sample.value
+    if isinstance(value, CollectionRawImage):
+        return value.decode()
+    return np.ascontiguousarray(np.asarray(value))
+
+
+def _bounded_coverage(
+    samples: list[CollectionRawSample],
+    lower_bound: float | None,
+    upper_bound: float | None,
+) -> tuple[float, float] | None:
+    start = samples[0].timestamp
+    end = samples[-1].timestamp
+    if lower_bound is not None:
+        start_index = bisect.bisect_left([sample.timestamp for sample in samples], lower_bound)
+        if start_index == len(samples):
+            return None
+        start = samples[start_index].timestamp
+    if upper_bound is not None:
+        end_index = bisect.bisect_right([sample.timestamp for sample in samples], upper_bound) - 1
+        if end_index < 0:
+            return None
+        end = samples[end_index].timestamp
+    if end < start:
+        return None
+    return start, end
+
+
+def _bounded_samples(
+    samples: list[CollectionRawSample],
+    lower_bound: float | None,
+    upper_bound: float | None,
+) -> list[CollectionRawSample]:
+    times = [sample.timestamp for sample in samples]
+    start_index = 0 if lower_bound is None else bisect.bisect_left(times, lower_bound)
+    end_index = len(samples) if upper_bound is None else bisect.bisect_right(times, upper_bound)
+    return samples[start_index:end_index]
+
+
+def _stream_stats(
+    samples: list[CollectionRawSample],
+    gap_tolerance_sec: float,
+) -> dict[str, Any]:
+    count = len(samples)
+    start_time = samples[0].timestamp
+    end_time = samples[-1].timestamp
+    gaps = [
+        samples[index].timestamp - samples[index - 1].timestamp
+        for index in range(1, count)
+    ]
+    duration = end_time - start_time
+    estimated_hz = None
+    if count > 1 and duration > 0.0:
+        estimated_hz = (count - 1) / duration
+    if not gaps:
+        return {
+            "sample_count": count,
+            "start_time": start_time,
+            "end_time": end_time,
+            "estimated_hz": estimated_hz,
+            "max_gap_sec": 0.0,
+            "p99_gap_sec": 0.0,
+            "gaps_over_tolerance": 0,
+            "max_gap_start_time": None,
+            "max_gap_end_time": None,
+        }
+    max_gap_index = max(range(len(gaps)), key=lambda index: gaps[index])
+    max_gap = gaps[max_gap_index]
+    return {
+        "sample_count": count,
+        "start_time": start_time,
+        "end_time": end_time,
+        "estimated_hz": estimated_hz,
+        "max_gap_sec": round(max_gap, 6),
+        "p99_gap_sec": round(_percentile(gaps, 0.99), 6),
+        "gaps_over_tolerance": sum(gap > gap_tolerance_sec for gap in gaps),
+        "max_gap_start_time": samples[max_gap_index].timestamp,
+        "max_gap_end_time": samples[max_gap_index + 1].timestamp,
+    }
+
+
+def _percentile(values: list[float], q: float) -> float:
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, max(0, math.ceil(q * len(ordered)) - 1))
+    return ordered[index]
+
+
+def _vector_components(
+    batch: CollectionRawBatch,
+    field: str,
+    robot: Robot,
+) -> list[_VectorComponent]:
+    full = _sorted_samples(batch.vectors.get(field, []))
+    if full:
+        return [_VectorComponent(field, field, full, None)]
+
+    groups = robot.arm_groups if field in {"state_eef", "action_eef"} else robot.actuator_groups
+    components: list[_VectorComponent] = []
+    for group in groups:
+        key = f"{field}:{group.name}"
+        samples = _sorted_samples(batch.vectors.get(key, []))
+        gripper_samples = None
+        default_gripper = None
+        if field in {"state_qpos", "action_qpos"}:
+            samples, gripper_samples = _split_group_gripper_samples(
+                batch, field, group, samples
+            )
+            if group.gripper_index is not None:
+                default_gripper = _initial_gripper_value(robot, group)
+        components.append(
+            _VectorComponent(field, key, samples, group, gripper_samples, default_gripper)
+        )
+    return components
+
+
+def _nearest_sample(samples: list[CollectionRawSample], timestamp: float) -> CollectionRawSample:
+    times = [sample.timestamp for sample in samples]
+    index = bisect.bisect_left(times, timestamp)
+    if index == 0:
+        return samples[0]
+    if index == len(samples):
+        return samples[-1]
+    before = samples[index - 1]
+    after = samples[index]
+    if abs(timestamp - before.timestamp) <= abs(after.timestamp - timestamp):
+        return before
+    return after
+
+
+def _interpolate_component(
+    component: _VectorComponent,
+    timestamp: float,
+    discrete_mask: np.ndarray | None,
+) -> np.ndarray:
+    if (
+        component.group is not None
+        and component.group.gripper_index is not None
+        and (component.gripper_samples is not None or component.default_gripper is not None)
+    ):
+        arm = _interpolate_samples(component.samples, timestamp, None)
+        if component.gripper_samples is None:
+            gripper_value = component.default_gripper
+            assert gripper_value is not None
+        elif (
+            component.default_gripper is not None
+            and timestamp < component.gripper_samples[0].timestamp
+        ):
+            gripper_value = component.default_gripper
+        else:
+            gripper = _latest_discrete_sample(component.gripper_samples, timestamp)
+            value = np.asarray(gripper.value, dtype=np.float32).reshape(-1)
+            gripper_value = float(value[0])
+        return np.insert(arm, component.group.gripper_index, gripper_value).astype(np.float32)
+    return _interpolate_samples(component.samples, timestamp, discrete_mask)
+
+
+def _split_group_gripper_samples(
+    batch: CollectionRawBatch,
+    field: str,
+    group: Any,
+    samples: list[CollectionRawSample],
+) -> tuple[list[CollectionRawSample], list[CollectionRawSample] | None]:
+    if group.gripper_index is None:
+        return samples, None
+
+    arm_samples: list[CollectionRawSample] = []
+    gripper_samples: list[CollectionRawSample] = []
+    for sample in samples:
+        value = np.asarray(sample.value, dtype=np.float32)
+        if value.shape == (group.dof,):
+            gripper_samples.append(
+                CollectionRawSample(
+                    timestamp=sample.timestamp,
+                    value=np.asarray([value[group.gripper_index]], dtype=np.float32),
+                )
+            )
+            arm_samples.append(
+                CollectionRawSample(
+                    timestamp=sample.timestamp,
+                    value=np.delete(value, group.gripper_index).astype(np.float32),
+                )
+            )
+            continue
+        arm_samples.append(sample)
+
+    for key in (f"gripper:{field}:{group.name}", f"{field}:gripper:{group.name}"):
+        for sample in batch.vectors.get(key, []):
+            value = np.asarray(sample.value, dtype=np.float32).reshape(-1)
+            if value.shape[0] == 0:
+                continue
+            gripper_samples.append(
+                CollectionRawSample(
+                    timestamp=sample.timestamp,
+                    value=np.asarray([value[0]], dtype=np.float32),
+                )
+            )
+
+    if not gripper_samples:
+        return arm_samples, None
+    return arm_samples, _sorted_samples(gripper_samples)
+
+
+def _latest_discrete_sample(
+    samples: list[CollectionRawSample], timestamp: float
+) -> CollectionRawSample:
+    times = [sample.timestamp for sample in samples]
+    index = bisect.bisect_right(times, timestamp)
+    if index == 0:
+        return samples[0]
+    return samples[index - 1]
+
+
+def _initial_gripper_value(robot: Robot, group: Any) -> float:
+    offset = 0
+    for candidate in robot.actuator_groups:
+        if candidate.name == group.name:
+            assert group.gripper_index is not None
+            return float(robot.initial_qpos[offset + group.gripper_index])
+        offset += candidate.dof
+    raise ValueError(f"unknown actuator group {group.name!r}")
+
+
+def _interpolate_samples(
+    samples: list[CollectionRawSample],
+    timestamp: float,
+    discrete_mask: np.ndarray | None,
+) -> np.ndarray:
+    times = [sample.timestamp for sample in samples]
+    index = bisect.bisect_left(times, timestamp)
+    if index == 0:
+        return np.asarray(samples[0].value, dtype=np.float32).copy()
+    if index < len(samples) and times[index] == timestamp:
+        return np.asarray(samples[index].value, dtype=np.float32).copy()
+    if index == len(samples):
+        return np.asarray(samples[-1].value, dtype=np.float32).copy()
+    before = samples[index - 1]
+    after = samples[index]
+    left = np.asarray(before.value, dtype=np.float32)
+    right = np.asarray(after.value, dtype=np.float32)
+    duration = after.timestamp - before.timestamp
+    if duration <= 0.0:
+        out = right.copy()
+    else:
+        alpha = float((timestamp - before.timestamp) / duration)
+        out = (left + (right - left) * alpha).astype(np.float32)
+    if discrete_mask is not None and discrete_mask.shape == out.shape:
+        out[discrete_mask] = left[discrete_mask]
+    return out
+
+
+def _discrete_mask(
+    field: str,
+    value: Any,
+    robot: Robot,
+    group: Any | None = None,
+) -> np.ndarray | None:
+    arr = np.asarray(value)
+    if field in {"state_qpos", "action_qpos"} and group is not None:
+        mask = np.zeros(arr.shape[0], dtype=bool)
+        if group.gripper_index is not None and group.gripper_index < arr.shape[0]:
+            mask[group.gripper_index] = True
+        return mask
+    if field in {"state_qpos", "action_qpos"} and arr.shape == (robot.total_action_dim,):
+        return np.asarray(robot.gripper_mask, dtype=bool)
+    if field in {"state_eef", "action_eef"} and arr.ndim == 1 and arr.shape[0] % 8 == 0:
+        mask = np.zeros(arr.shape[0], dtype=bool)
+        mask[7::8] = True
+        return mask
+    return None

--- a/src/core/recorder/episode.py
+++ b/src/core/recorder/episode.py
@@ -19,6 +19,7 @@ Two tables, deliberately different shapes, joined by ``absolute_step``:
 
 from __future__ import annotations
 
+import bisect
 import dataclasses
 import datetime as _dt
 import json
@@ -35,7 +36,14 @@ import pyarrow.parquet as pq
 
 from core.config import resolve_video_key
 from core.recorder.lerobot_meta import build_info, history_row
-from core.types import Observation
+from core.types import (
+    CollectionRawBatch,
+    CollectionRawSample,
+    Observation,
+    RolloutInterventionSegment,
+)
+from core.utils.images import resize_direct
+from core.recorder.collection_alignment import align_collection_samples
 
 if TYPE_CHECKING:
     from core.config import ConfigDict
@@ -53,6 +61,12 @@ _EVAL_META_KEYS = ("score", "max_score", "milestones", "note", "scored_at", "dur
 
 # Observation vector fields (everything except timestamp/images) recorded per collection frame.
 _COLLECTION_VECTOR_FIELDS = (
+    "state_qpos",
+    "state_eef",
+    "action_qpos",
+    "action_eef",
+)
+_INTERVENTION_VECTOR_FIELDS = (
     "state_qpos",
     "state_eef",
     "action_qpos",
@@ -105,9 +119,14 @@ class SaveJob:
     task_to_index: dict[str, int]
     collection_columns: dict[str, Any] | None = None
     collection_episode_row: dict[str, Any] | None = None
+    collection_payload: Any | None = None
+    raw_episode_payload: Any | None = None
     videos: dict[str, list[np.ndarray]] | None = None
     video_fps: float | None = None
     dataset_dir: Path | None = None
+    intervention_segments: list[RolloutInterventionSegment] = dataclasses.field(
+        default_factory=list
+    )
     reason: str = ""
     # When True the episodes.jsonl row + tasks.jsonl were already written synchronously
     # (eval path: the meta row lands on STOP so the trial is immediately scorable); the
@@ -118,6 +137,23 @@ class SaveJob:
     queued_wall_time: float = 0.0
     started_wall_time: float = 0.0
     finished_wall_time: float = 0.0
+
+
+@dataclasses.dataclass(frozen=True)
+class RawEpisodeFrameLabel:
+    """Per-source-frame label copied into the fixed-clock episode rows."""
+
+    timestamp: float
+    intervention: bool
+    segment_index: int
+
+
+@dataclasses.dataclass
+class RawEpisodeSavePayload:
+    """Frozen raw eval/rollout episode input prepared at STOP time."""
+
+    raw_batch: CollectionRawBatch
+    frame_labels: list[RawEpisodeFrameLabel]
 
 
 class EpisodeLogger:
@@ -187,8 +223,10 @@ class EpisodeLogger:
         self._task: str | None = None
         self._steps: list[Observation] = []
         self._episode_meta: dict[str, Any] = {}
-        self._video_frames: dict[str, list[np.ndarray]] = {}
         self._image_shape: tuple[int, int] | None = None  # (h, w) from first frame
+        self._intervention_segments: list[RolloutInterventionSegment] = []
+        self._raw_episode_batch = CollectionRawBatch()
+        self._raw_episode_frame_labels: list[RawEpisodeFrameLabel] = []
 
         # async save queue (data-collection mode): end_episode hands a SaveJob
         # snapshot to a background worker so the main loop can start the next
@@ -226,7 +264,9 @@ class EpisodeLogger:
         self._task = task
         self._steps = []
         self._episode_meta = {}
-        self._video_frames = {}
+        self._intervention_segments = []
+        self._raw_episode_batch = CollectionRawBatch()
+        self._raw_episode_frame_labels = []
         if self._collection_writer is not None:
             self._collection_writer.start_episode(collection_min_capture_time)
             return
@@ -251,34 +291,24 @@ class EpisodeLogger:
         """
         if not self._active:
             return
-        obs.timestamp = time.time() if timestamp is None else timestamp
-        obs.state_qpos = np.asarray(obs.state_qpos, dtype=np.float32).copy()
-        if obs.state_eef is not None:
-            obs.state_eef = np.asarray(obs.state_eef, dtype=np.float32).copy()
-        obs.action_qpos = np.asarray(action, dtype=np.float32).copy()
-        self._steps.append(obs)
-        if self._save_video:
-            for cam_key in self._camera_keys:
-                frame = obs.images.get(cam_key)
-                if frame is not None:
-                    rgb = _to_rgb_uint8(frame, self._convert_bgr_to_rgb)
-                    if self._image_shape is None:
-                        self._image_shape = (rgb.shape[0], rgb.shape[1])
-                    video_key = resolve_video_key(self._keys, cam_key)
-                    if video_key is None:
-                        continue
-                    self._video_frames.setdefault(video_key, []).append(
-                        np.ascontiguousarray(rgb).copy()
-                    )
-
-    def record_collection_frame(self, frame: Observation) -> None:
-        """Record one already-decoded teleop frame into the active collection episode."""
-        if not self._active or self._collection_writer is None:
-            return
-        self._collection_writer.record_frame(frame)
+        source_timestamp = self._record_step_timestamp(obs, timestamp)
+        record = _copy_observation(obs)
+        record.timestamp = source_timestamp
+        record.action_qpos = np.asarray(action, dtype=np.float32).copy()
+        self._steps.append(record)
+        self._append_raw_episode_observation(
+            self._raw_episode_batch,
+            record,
+            RawEpisodeFrameLabel(
+                timestamp=source_timestamp,
+                intervention=False,
+                segment_index=-1,
+            ),
+            self._raw_episode_frame_labels,
+        )
 
     def ingest_collection_snapshot(self, snapshot: RawCollectionSnapshot) -> None:
-        """Hand a pre-decode snapshot to the collection ingest thread (O(1))."""
+        """Hand one pre-decode snapshot to the collection writer (O(1))."""
         if not self._active or self._collection_writer is None:
             return
         self._collection_writer.ingest(snapshot)
@@ -286,6 +316,14 @@ class EpisodeLogger:
     def set_episode_meta(self, **fields: Any) -> None:
         """Attach eval metadata (score, milestones, ...) to the current episode."""
         self._episode_meta.update(fields)
+
+    def set_rollout_intervention_segments(
+        self, segments: list[RolloutInterventionSegment]
+    ) -> None:
+        """Attach accepted rollout intervention segments to the active episode."""
+        self._intervention_segments = [
+            _copy_intervention_segment(segment) for segment in segments if segment.frames
+        ]
 
     def patch_episode_meta(self, episode_index: int, **fields: Any) -> bool:
         """Post-hoc: merge fields into an already-written episodes.jsonl row.
@@ -367,22 +405,29 @@ class EpisodeLogger:
             self._remember_finished_job(job)
             self._completed_episodes += 1
             return True
-        if not self._steps:
+        if not self._has_raw_episode_samples():
             self._active = False
             self._task = None
-            self._video_frames = {}
+            self._intervention_segments = []
+            self._raw_episode_batch = CollectionRawBatch()
+            self._raw_episode_frame_labels = []
             return False
 
         episode_index = self._episode_index
         task = self._task or ""
         task_index = self._resolve_task_index(task)
-        n_frames = len(self._steps)
-        global_index = self._global_index
-        episode_fps = self._steps_average_fps(self._steps)
         episode_meta = dict(self._episode_meta)
-        if episode_fps is not None:
-            episode_meta["episode_fps"] = episode_fps
-        videos = self._snapshot_videos()
+        intervention_segments = [
+            _copy_intervention_segment(segment)
+            for segment in self._intervention_segments
+            if segment.frames
+        ]
+        if intervention_segments:
+            episode_meta["has_intervention"] = True
+            episode_meta["intervention_segments"] = len(intervention_segments)
+            episode_meta["intervention_frames"] = sum(
+                len(segment.frames) for segment in intervention_segments
+            )
 
         # Eval re-run: if this (prompt, trial) cell already has a recorded episode, reuse
         # its index and overwrite that episode's data IN PLACE (parquet + video + meta row)
@@ -391,57 +436,50 @@ class EpisodeLogger:
         reuse_index = self._eval_existing_episode_index(episode_meta) if self._eval_mode else None
         if reuse_index is not None:
             episode_index = reuse_index
+            global_index = self._existing_episode_global_start(episode_index)
+            if global_index is None:
+                global_index = -1
         else:
-            self._global_index += n_frames
+            global_index = -1
             self._episode_index += 1
         self._active = False
+        raw_batch = self._copy_raw_episode_batch(self._raw_episode_batch)
+        frame_labels = list(self._raw_episode_frame_labels)
+        self._append_intervention_segments_to_raw_episode(
+            raw_batch,
+            frame_labels,
+            intervention_segments,
+        )
 
-        if self._async_save:
-            job = SaveJob(
-                episode_index=episode_index,
-                task=task,
-                task_index=task_index,
-                global_index=global_index,
-                steps=self._steps,
-                episode_meta=episode_meta,
-                task_to_index=dict(self._task_to_index),
-                videos=videos,
-                video_fps=float(self._fps),
-                queued_wall_time=time.time(),
-            )
-            self._steps = []
-            self._episode_meta = {}
-            self._video_frames = {}
-            self._task = None
-            self._enqueue_save_job(job)
-            return True
-
-        # Eval path: write EVERYTHING synchronously now (parquet + video + episodes.jsonl
-        # row + tasks.jsonl), so when STOP returns the trial's data is fully on disk —
-        # immediately scorable, and the RESULT popup / re-score always read fresh files.
-        # On a re-run (reuse_index set) the parquet/video/row REPLACE the prior take's data
-        # IN PLACE (same episode_index -> same file paths), and the old score is dropped so
-        # the fresh take is re-scored from scratch. No background worker, no async race.
         episode_meta = dict(episode_meta)
         episode_meta.setdefault("recorded_at", _dt.datetime.now().isoformat(timespec="seconds"))
-        # On reuse, keep the parquet `index` column starting where the original episode did
-        # so the dataset-global index stays consistent for that episode.
-        if reuse_index is not None:
-            prior_start = self._existing_episode_global_start(episode_index)
-            if prior_start is not None:
-                global_index = prior_start
-        with self._lock:
-            self._write_main_parquet_rows(episode_index, task_index, global_index, self._steps)
-            self._write_videos(episode_index, videos, float(self._fps))
-            self._upsert_episode_row_locked(episode_index, task, n_frames, episode_meta)
-            self._write_tasks_jsonl_from(self._task_to_index)
-            if self._eval_mode:
-                self._write_info_json()
+        job = SaveJob(
+            episode_index=episode_index,
+            task=task,
+            task_index=task_index,
+            global_index=global_index,
+            steps=[],
+            episode_meta=episode_meta,
+            task_to_index=dict(self._task_to_index),
+            raw_episode_payload=RawEpisodeSavePayload(raw_batch, frame_labels),
+            video_fps=float(self._fps),
+            queued_wall_time=time.time(),
+        )
         self._steps = []
         self._episode_meta = {}
-        self._video_frames = {}
+        self._intervention_segments = []
+        self._raw_episode_batch = CollectionRawBatch()
+        self._raw_episode_frame_labels = []
         self._task = None
+        if self._async_save:
+            self._enqueue_save_job(job)
+            return True
+        job.started_wall_time = job.queued_wall_time
+        self._write_raw_episode_job(job)
+        job.status = "saved"
+        job.finished_wall_time = time.time()
         self._completed_episodes += 1
+        self._remember_finished_job(job)
         return True
 
     def cancel_episode(self, reason: str = "cancelled") -> None:
@@ -454,14 +492,18 @@ class EpisodeLogger:
             self._collection_writer.cancel_episode()
             self._steps = []
             self._episode_meta = {}
-            self._video_frames = {}
+            self._intervention_segments = []
+            self._raw_episode_batch = CollectionRawBatch()
+            self._raw_episode_frame_labels = []
             self._active = False
             self._task = None
             logger.info("Cancelled episode %d (%s)", self._episode_index, reason)
             return
-        self._video_frames = {}
         self._steps = []
         self._episode_meta = {}
+        self._intervention_segments = []
+        self._raw_episode_batch = CollectionRawBatch()
+        self._raw_episode_frame_labels = []
         self._active = False
         self._task = None
         logger.info("Cancelled episode %d (%s)", self._episode_index, reason)
@@ -517,23 +559,324 @@ class EpisodeLogger:
 
     def _write_job(self, job: SaveJob) -> None:
         """Background-thread disk write from a frozen snapshot (no live buffers)."""
-        if job.collection_columns is not None:
+        if job.collection_columns is not None or job.collection_payload is not None:
             self._write_collection_job(job)
             return
-        self._write_main_parquet_rows(
-            job.episode_index, job.task_index, job.global_index, job.steps
-        )
-        self._write_videos(job.episode_index, job.videos, job.video_fps)
-        # Eval jobs already wrote the episodes.jsonl row + tasks.jsonl synchronously on
-        # STOP (meta_written); only the parquet/video above is deferred here.
-        if not job.meta_written:
-            with self._lock:
-                self._append_episode_row_locked(
-                    job.episode_index, job.task, len(job.steps), job.episode_meta
+        if job.raw_episode_payload is not None:
+            self._write_raw_episode_job(job)
+            return
+        raise ValueError("save job missing raw payload")
+
+    def _record_step_timestamp(
+        self, obs: Observation, timestamp: float | None
+    ) -> float:
+        if timestamp is not None:
+            return float(timestamp)
+        if obs.timestamp is not None:
+            return float(obs.timestamp)
+        if self._raw_episode_frame_labels:
+            return self._raw_episode_frame_labels[-1].timestamp + 1.0 / float(self._fps)
+        return 0.0
+
+    def _append_raw_episode_observation(
+        self,
+        batch: CollectionRawBatch,
+        frame: Observation,
+        label: RawEpisodeFrameLabel,
+        labels: list[RawEpisodeFrameLabel],
+    ) -> None:
+        timestamp = float(label.timestamp)
+        for key, image in frame.images.items():
+            batch.images.setdefault(key, []).append(
+                CollectionRawSample(timestamp, np.asarray(image).copy())
+            )
+        for field in _COLLECTION_VECTOR_FIELDS:
+            value = getattr(frame, field)
+            if value is None:
+                continue
+            batch.vectors.setdefault(field, []).append(
+                CollectionRawSample(
+                    timestamp,
+                    np.asarray(value, dtype=np.float32).copy(),
                 )
-                self._write_tasks_jsonl_from(job.task_to_index)
+            )
+        if batch.start_time is None or timestamp < batch.start_time:
+            batch.start_time = timestamp
+        if batch.end_time is None or timestamp > batch.end_time:
+            batch.end_time = timestamp
+        labels.append(label)
+
+    def _append_intervention_segments_to_raw_episode(
+        self,
+        batch: CollectionRawBatch,
+        labels: list[RawEpisodeFrameLabel],
+        segments: list[RolloutInterventionSegment],
+    ) -> None:
+        for segment in segments:
+            for frame in segment.frames:
+                timestamp = (
+                    float(frame.timestamp)
+                    if frame.timestamp is not None
+                    else self._next_raw_episode_timestamp(labels)
+                )
+                record = _copy_observation(frame)
+                record.timestamp = timestamp
+                self._append_raw_episode_observation(
+                    batch,
+                    record,
+                    RawEpisodeFrameLabel(
+                        timestamp=timestamp,
+                        intervention=True,
+                        segment_index=segment.segment_index,
+                    ),
+                    labels,
+                )
+
+    def _next_raw_episode_timestamp(self, labels: list[RawEpisodeFrameLabel]) -> float:
+        if labels:
+            return labels[-1].timestamp + 1.0 / float(self._fps)
+        return time.time()
+
+    def _has_raw_episode_samples(self) -> bool:
+        return any(self._raw_episode_batch.vectors.values()) or any(
+            segment.frames for segment in self._intervention_segments
+        )
+
+    def _copy_raw_episode_batch(self, batch: CollectionRawBatch) -> CollectionRawBatch:
+        return CollectionRawBatch(
+            images={
+                key: [
+                    CollectionRawSample(sample.timestamp, _copy_raw_value(sample.value))
+                    for sample in samples
+                ]
+                for key, samples in batch.images.items()
+            },
+            vectors={
+                key: [
+                    CollectionRawSample(sample.timestamp, _copy_raw_value(sample.value))
+                    for sample in samples
+                ]
+                for key, samples in batch.vectors.items()
+            },
+            start_time=batch.start_time,
+            end_time=batch.end_time,
+        )
+
+    def _raw_episode_vector_fields(self, batch: CollectionRawBatch) -> tuple[str, ...]:
+        fields = []
+        for field in _COLLECTION_VECTOR_FIELDS:
+            if field in batch.vectors or any(
+                key.startswith(f"{field}:") for key in batch.vectors
+            ):
+                fields.append(field)
+        if "state_qpos" not in fields:
+            raise ValueError("raw episode missing state_qpos samples")
+        if "action_qpos" not in fields:
+            raise ValueError("raw episode missing action_qpos samples")
+        return tuple(fields)
+
+    def _raw_episode_image_skew_tolerance_sec(self) -> float:
+        fps = float(self._fps)
+        if fps <= 1.0:
+            return 0.5 / fps
+        return 1.0 / (2.0 * (fps - 1.0))
+
+    def _write_raw_episode_job(self, job: SaveJob) -> None:
+        if job.raw_episode_payload is not None:
+            self._prepare_raw_episode_job(job)
+        columns = job.collection_columns
+        row = job.collection_episode_row
+        if columns is None or row is None:
+            raise ValueError("raw episode save job missing columns or episode row")
+        path = self._parquet_path(job.episode_index)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        pq.write_table(pa.table(columns), str(path))
+        self._write_videos(job.episode_index, job.videos, job.video_fps)
+        with self._lock:
+            if self._eval_mode:
+                self._upsert_episode_dict_row_locked(row)
+            else:
+                self._append_episode_dict_row_locked(row)
+            self._write_tasks_jsonl_from(job.task_to_index)
+            if self._eval_mode:
+                self._write_info_json()
+
+    def _prepare_raw_episode_job(self, job: SaveJob) -> None:
+        payload = job.raw_episode_payload
+        if payload is None:
+            return
+        fields = self._raw_episode_vector_fields(payload.raw_batch)
+        camera_keys = tuple(payload.raw_batch.images.keys())
+        frames, report = align_collection_samples(
+            payload.raw_batch,
+            robot=self._robot,
+            camera_keys=camera_keys,
+            vector_fields=fields,
+            fps=float(self._fps),
+            image_skew_sec=self._raw_episode_image_skew_tolerance_sec(),
+        )
+        if not frames:
+            raise ValueError("raw episode produced 0 frames")
+        issues = [
+            QualityIssue("red", issue.code, issue.detail) for issue in report.issues
+        ]
+        labels = self._labels_for_aligned_frames(frames, payload.frame_labels)
+        n_frames = len(frames)
+        global_index = job.global_index
+        if global_index < 0:
+            global_index = self._next_episode_global_index(n_frames)
+        fps = float(self._fps)
+        columns: dict[str, Any] = {
+            self._keys.state_key: [
+                np.asarray(frame.state_qpos, dtype=np.float32).tolist()
+                for frame in frames
+            ],
+            self._keys.action_key: [
+                np.asarray(frame.action_qpos, dtype=np.float32).tolist()
+                for frame in frames
+            ],
+            "timestamp": [i / fps for i in range(n_frames)],
+            "capture_time": [
+                float(frame.timestamp if frame.timestamp is not None else 0.0)
+                for frame in frames
+            ],
+            "frame_index": list(range(n_frames)),
+            "episode_index": [job.episode_index] * n_frames,
+            "index": list(range(global_index, global_index + n_frames)),
+            "task_index": [job.task_index] * n_frames,
+        }
+        if any(frame.state_eef is not None for frame in frames):
+            columns[self._keys.eef_key] = [
+                None
+                if frame.state_eef is None
+                else np.asarray(frame.state_eef, dtype=np.float32).tolist()
+                for frame in frames
+            ]
+        if any(label.intervention for label in labels):
+            columns["intervention"] = [label.intervention for label in labels]
+            columns["intervention_segment_index"] = [
+                label.segment_index for label in labels
+            ]
+        videos = self._videos_from_records(frames, camera_keys)
+        if self._save_video and videos:
+            for video_key, video_frames in videos.items():
+                if len(video_frames) != n_frames:
+                    issues.append(
+                        QualityIssue(
+                            "red",
+                            "frame_count_mismatch",
+                            f"video {video_key} has {len(video_frames)} frames but "
+                            f"data table has {n_frames} rows",
+                        )
+                    )
+        row: dict[str, Any] = {
+            "episode_index": job.episode_index,
+            "tasks": [job.task],
+            "length": n_frames,
+            "quality": "red" if issues else "green",
+            "quality_issues": [dataclasses.asdict(issue) for issue in issues],
+            "alignment_fps": fps,
+            "alignment_grid_start": report.grid_start,
+            "alignment_grid_end": report.grid_end,
+            "alignment_image_skew_tolerance_sec": (
+                self._raw_episode_image_skew_tolerance_sec()
+            ),
+            "alignment_image_max_skew_sec": report.image_max_skew,
+            "alignment_image_stream_stats": report.image_stream_stats,
+        }
+        episode_fps = self._raw_episode_average_fps(payload.raw_batch)
+        if episode_fps is not None:
+            row["episode_fps"] = episode_fps
+        if job.episode_meta:
+            row.update(job.episode_meta)
+        job.global_index = global_index
+        job.collection_columns = columns
+        job.collection_episode_row = row
+        job.videos = videos
+        job.video_fps = fps
+        job.raw_episode_payload = None
+
+    def _labels_for_aligned_frames(
+        self,
+        frames: list[Observation],
+        source_labels: list[RawEpisodeFrameLabel],
+    ) -> list[RawEpisodeFrameLabel]:
+        if not source_labels:
+            return [
+                RawEpisodeFrameLabel(
+                    timestamp=float(frame.timestamp or 0.0),
+                    intervention=False,
+                    segment_index=-1,
+                )
+                for frame in frames
+            ]
+        labels = sorted(source_labels, key=lambda label: label.timestamp)
+        times = [label.timestamp for label in labels]
+        aligned = []
+        for frame in frames:
+            timestamp = float(frame.timestamp if frame.timestamp is not None else 0.0)
+            index = bisect.bisect_right(times, timestamp) - 1
+            if index < 0:
+                index = 0
+            label = labels[index]
+            aligned.append(
+                RawEpisodeFrameLabel(
+                    timestamp=timestamp,
+                    intervention=label.intervention,
+                    segment_index=label.segment_index,
+                )
+            )
+        return aligned
+
+    def _raw_episode_average_fps(self, batch: CollectionRawBatch) -> float | None:
+        samples = batch.vectors.get("state_qpos") or batch.vectors.get("action_qpos")
+        if samples is None or len(samples) < 2:
+            return None
+        timestamps = sorted(float(sample.timestamp) for sample in samples)
+        duration = timestamps[-1] - timestamps[0]
+        if duration <= 0.0:
+            return None
+        return (len(timestamps) - 1) / duration
+
+    def _videos_from_records(
+        self,
+        records: list[Observation],
+        camera_keys: tuple[str, ...],
+    ) -> dict[str, list[np.ndarray]] | None:
+        if not self._save_video:
+            return None
+        size = self._save_size()
+        videos: dict[str, list[np.ndarray]] = {}
+        for cam_key in camera_keys:
+            video_key = resolve_video_key(self._keys, cam_key)
+            if video_key is None:
+                continue
+            frames = []
+            for record in records:
+                image = record.images.get(cam_key)
+                if image is None:
+                    continue
+                rgb = _to_rgb_uint8(image, self._convert_bgr_to_rgb)
+                if size is not None and rgb.shape[:2] != size:
+                    rgb = resize_direct(rgb, size[0], size[1])
+                if self._image_shape is None:
+                    self._image_shape = (rgb.shape[0], rgb.shape[1])
+                frames.append(np.ascontiguousarray(rgb))
+            if frames:
+                videos[video_key] = frames
+        return videos or None
+
+    def _next_episode_global_index(self, n_frames: int) -> int:
+        with self._lock:
+            index = self._global_index
+            self._global_index += n_frames
+            return index
 
     def _write_collection_job(self, job: SaveJob) -> None:
+        if job.collection_payload is not None:
+            if self._collection_writer is None:
+                raise ValueError("collection save job has payload but no collection writer")
+            self._collection_writer.prepare_save_job(job)
         columns = job.collection_columns
         row = job.collection_episode_row
         if columns is None or row is None:
@@ -614,7 +957,6 @@ class EpisodeLogger:
         current_episode_recorded_frames = 0
         current_episode_pending_frames = 0
         current_episode_skipped_before_start = 0
-        current_episode_skipped_no_action = 0
         active_for_task = self._active and (task is None or self._task == task)
         if active_for_task:
             if self._collection_writer is not None:
@@ -623,7 +965,6 @@ class EpisodeLogger:
                 current_episode_recorded_frames = counts["recorded"]
                 current_episode_pending_frames = counts["pending"]
                 current_episode_skipped_before_start = counts["skipped_before_start"]
-                current_episode_skipped_no_action = counts["skipped_no_action"]
             else:
                 current_episode_frames = len(self._steps)
                 current_episode_recorded_frames = len(self._steps)
@@ -652,7 +993,6 @@ class EpisodeLogger:
             "current_episode_recorded_frames": current_episode_recorded_frames,
             "current_episode_pending_frames": current_episode_pending_frames,
             "current_episode_skipped_before_start": current_episode_skipped_before_start,
-            "current_episode_skipped_no_action": current_episode_skipped_no_action,
             "completed_episodes": (
                 len(history) if self._collection_writer else self._completed_episodes
             ),
@@ -797,43 +1137,6 @@ class EpisodeLogger:
         self._write_info_json()
         self._write_stats_json()
 
-    # -- parquet writers --------------------------------------------------------
-
-    def _write_main_parquet_rows(
-        self,
-        episode_index: int,
-        task_index: int,
-        global_index: int,
-        steps: list[Observation],
-    ) -> None:
-        path = self._parquet_path(episode_index)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        states = [s.state_qpos.tolist() for s in steps]
-        actions = [cast(np.ndarray, s.action_qpos).tolist() for s in steps]
-        n = len(steps)
-        fps = float(self._fps)
-        columns = {
-            self._keys.state_key: states,
-            self._keys.action_key: actions,
-            # LeRobot v2.1 requires timestamp[i] == i/fps (equal-interval, tol 1e-4);
-            # synthesize it from target fps. Raw wall-clock kept out-of-band in capture_time.
-            "timestamp": [i / fps for i in range(n)],
-            "capture_time": [float(cast(float, s.timestamp)) for s in steps],
-            "frame_index": list(range(n)),
-            "episode_index": [episode_index] * n,
-            "index": list(range(global_index, global_index + n)),
-            "task_index": [task_index] * n,
-        }
-        # Second state column: FK-derived eef alongside raw qpos. Skipped entirely only
-        # when no row carries an eef (joint-only deployment).
-        if any(s.state_eef is not None for s in steps):
-            columns[self._keys.eef_key] = [
-                None if s.state_eef is None else s.state_eef.tolist() for s in steps
-            ]
-        # Eval scores live only in meta/episodes.jsonl, never in the parquet data table.
-        table = pa.table(columns)
-        pq.write_table(table, str(path))
-
     def _steps_average_fps(self, steps: list[Observation]) -> float | None:
         if len(steps) < 2:
             return None
@@ -842,25 +1145,14 @@ class EpisodeLogger:
             return None
         return (len(steps) - 1) / duration
 
-    def _snapshot_videos(self) -> dict[str, list[np.ndarray]] | None:
-        if not self._save_video:
+    def _save_size(self) -> tuple[int, int] | None:
+        h = self._save_image_height
+        w = self._save_image_width
+        if h is None or w is None:
             return None
-        videos = {video_key: list(frames) for video_key, frames in self._video_frames.items()}
-        return videos or None
+        return int(h), int(w)
 
     # -- meta writers -----------------------------------------------------------
-
-    def _append_episode_row_locked(
-        self, episode_index: int, task: str, length: int, episode_meta: dict[str, Any]
-    ) -> None:
-        row: dict[str, Any] = {
-            "episode_index": episode_index,
-            "tasks": [task],
-            "length": length,
-        }
-        if episode_meta:
-            row.update(episode_meta)
-        self._append_episode_dict_row_locked(row)
 
     def _eval_existing_episode_index(self, episode_meta: dict[str, Any]) -> int | None:
         """Episode index of a prior recording of this (prompt, trial) cell, or None.
@@ -926,6 +1218,24 @@ class EpisodeLogger:
         with path.open("w") as f:
             for r in rows:
                 f.write(json.dumps(r, ensure_ascii=False) + "\n")
+
+    def _upsert_episode_dict_row_locked(self, row: dict[str, Any]) -> None:
+        episode_index = int(row["episode_index"])
+        path = self._meta_path("episodes.jsonl")
+        rows = _read_jsonl(path)
+        replaced = False
+        for index, existing in enumerate(rows):
+            if int(existing.get("episode_index", -1)) == episode_index:
+                rows[index] = row
+                replaced = True
+                break
+        if not replaced:
+            self._append_episode_dict_row_locked(row)
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w") as f:
+            for existing in rows:
+                f.write(json.dumps(existing, ensure_ascii=False) + "\n")
 
     def _append_episode_dict_row_locked(
         self, row: dict[str, Any], dataset_dir: Path | None = None
@@ -1218,6 +1528,39 @@ class _StatAccumulator:
             "mean": mean.tolist(),
             "std": std.tolist(),
         }
+
+
+def _copy_observation(frame: Observation) -> Observation:
+    images = {key: np.asarray(value).copy() for key, value in frame.images.items()}
+    vectors = {}
+    for field in _INTERVENTION_VECTOR_FIELDS:
+        value = getattr(frame, field)
+        vectors[field] = None if value is None else np.asarray(value, dtype=np.float32).copy()
+    return Observation(
+        timestamp=float(frame.timestamp if frame.timestamp is not None else 0.0),
+        images=images,
+        state_qpos=vectors["state_qpos"],
+        state_eef=vectors["state_eef"],
+        action_qpos=vectors["action_qpos"],
+        action_eef=vectors["action_eef"],
+    )
+
+
+def _copy_raw_value(value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.copy()
+    return value
+
+
+def _copy_intervention_segment(segment: RolloutInterventionSegment) -> RolloutInterventionSegment:
+    return RolloutInterventionSegment(
+        segment_index=segment.segment_index,
+        start_policy_frame_index=segment.start_policy_frame_index,
+        pre_intervention_qpos=np.asarray(segment.pre_intervention_qpos, dtype=np.float32).copy(),
+        frames=[_copy_observation(frame) for frame in segment.frames],
+        resume_policy_frame_index=segment.resume_policy_frame_index,
+        invalid_reason=segment.invalid_reason,
+    )
 
 
 def _vector_episode_stats(values: list[list[float]]) -> dict[str, Any]:

--- a/src/core/types.py
+++ b/src/core/types.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import dataclasses
 import enum
 from collections.abc import Callable
+from typing import Any
 
 import numpy as np
 
@@ -40,21 +41,70 @@ class Observation:
 
 
 @dataclasses.dataclass
+class CollectionRawSample:
+    """One timestamped raw collection value before fixed-grid alignment."""
+
+    timestamp: float
+    value: Any
+
+
+@dataclasses.dataclass
+class CollectionRawImage:
+    """A lazily decoded raw collection image sample."""
+
+    decoder: Callable[[], np.ndarray | None]
+    _decoded: np.ndarray | None = dataclasses.field(default=None, init=False, repr=False)
+    _decoded_once: bool = dataclasses.field(default=False, init=False, repr=False)
+
+    def decode(self) -> np.ndarray:
+        """Decode the raw image message once and return a contiguous HWC array."""
+        if not self._decoded_once:
+            image = self.decoder()
+            if image is None:
+                raise ValueError("collection raw image decode returned None")
+            self._decoded = np.ascontiguousarray(image)
+            self._decoded_once = True
+        assert self._decoded is not None
+        return self._decoded
+
+
+@dataclasses.dataclass
+class CollectionRawBatch:
+    """A batch of raw collection stream samples captured since the previous tick."""
+
+    images: dict[str, list[CollectionRawSample]] = dataclasses.field(default_factory=dict)
+    vectors: dict[str, list[CollectionRawSample]] = dataclasses.field(default_factory=dict)
+    start_time: float | None = None
+    end_time: float | None = None
+
+
+@dataclasses.dataclass
 class RawCollectionSnapshot:
     """Pre-decode collection snapshot crossing the main->ingest thread boundary.
 
     Filled by the main loop in O(1): the source capture time plus raw source
     references (zmq raw bytes / pinned ROS msgs), WITHOUT decoding images,
-    copying, or color-converting. The ingest thread later calls decode() to
-    produce an Observation, keeping all heavy work off the capture loop.
+    copying, or color-converting. The ingest thread stores timestamped raw stream
+    samples; the save worker later aligns the whole episode to a fixed clock.
 
     Args:
         timestamp: source capture time used for alignment and dedup
             (zmq wire ``t`` / ROS ``header.stamp``). Stamped on the main thread
             so ingest backpressure can never shift it.
-        decode: thread-safe closure the ingest thread runs to turn the pinned
-            raw references into a fully decoded Observation.
+        decode_raw: Thread-safe closure returning timestamped raw stream samples.
     """
 
     timestamp: float
-    decode: Callable[[], Observation]
+    decode_raw: Callable[[], CollectionRawBatch]
+
+
+@dataclasses.dataclass
+class RolloutInterventionSegment:
+    """One in-memory teleop intervention segment inside a normal rollout."""
+
+    segment_index: int
+    start_policy_frame_index: int
+    pre_intervention_qpos: np.ndarray
+    frames: list[Observation] = dataclasses.field(default_factory=list)
+    resume_policy_frame_index: int | None = None
+    invalid_reason: str = ""

--- a/src/core/utils/images.py
+++ b/src/core/utils/images.py
@@ -1,0 +1,56 @@
+"""Image resize helpers shared by app handlers and recorders."""
+
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+
+
+def resize_with_pad(image: np.ndarray, height: int, width: int) -> np.ndarray:
+    """Resize an image to fit a target size, preserving aspect ratio with padding.
+
+    Args:
+        image: Source image, HWC array.
+        height: Target height.
+        width: Target width.
+
+    Returns:
+        Padded resized HWC uint8 array.
+    """
+    src_h, src_w = image.shape[:2]
+    scale = min(width / src_w, height / src_h)
+    new_w = max(1, int(round(src_w * scale)))
+    new_h = max(1, int(round(src_h * scale)))
+    pil_image = Image.fromarray(image)
+    resized = np.asarray(
+        pil_image.resize((new_w, new_h), resample=Image.Resampling.BILINEAR),
+    )
+    top = (height - new_h) // 2
+    bottom = height - new_h - top
+    left = (width - new_w) // 2
+    right = width - new_w - left
+    if resized.ndim == 2:
+        padded = np.zeros((height, width), dtype=resized.dtype)
+        padded[top : height - bottom, left : width - right] = resized
+        return padded
+    padded = np.zeros((height, width, resized.shape[2]), dtype=resized.dtype)
+    padded[top : height - bottom, left : width - right, :] = resized
+    return padded
+
+
+def resize_direct(image: np.ndarray, height: int, width: int) -> np.ndarray:
+    """Resize an image directly to a target size without preserving aspect ratio.
+
+    Args:
+        image: Source image, HWC array.
+        height: Target height.
+        width: Target width.
+
+    Returns:
+        Directly resized HWC uint8 array.
+    """
+    pil_image = Image.fromarray(image)
+    resized = np.asarray(
+        pil_image.resize((width, height), resample=Image.Resampling.BILINEAR),
+    )
+    return resized

--- a/src/robots/base.py
+++ b/src/robots/base.py
@@ -173,11 +173,28 @@ class Robot:
             offset += group.dof
         return tuple(parts)
 
-    def snap_grippers(self, action: np.ndarray, threshold: float | None) -> np.ndarray:
-        """Binarize this robot's gripper dims of an action in-place (no-op if threshold None).
+    def snap_grippers(
+        self,
+        action: np.ndarray,
+        threshold: float | None,
+        open_value: float = 1.0,
+        close_value: float = 0.0,
+    ) -> np.ndarray:
+        """Binarize this robot's gripper dimensions of an action, in-place.
 
-        Handles both a single vector [D] and a chunk [T, D] by snapping each row to
-        1.0 if >= threshold else 0.0.
+        No-op (returns ``action`` unchanged) when ``threshold`` is None or the robot
+        has no gripper dimensions. Handles both a single action vector [D] and a
+        chunk [T, D] by snapping each row.
+
+        Args:
+            action: action vector [D] or chunk [T, D]; gripper dims set to
+                open_value/close_value.
+            threshold: cutoff applied to each gripper value; None disables snapping.
+            open_value: command value for an open gripper.
+            close_value: command value for a closed gripper.
+
+        Returns:
+            The same ``action`` array with gripper dims snapped.
         """
         mask = self.gripper_mask
         if threshold is None or not any(mask):
@@ -186,5 +203,5 @@ class Robot:
         for row in rows:
             for idx, is_gripper in enumerate(mask):
                 if is_gripper and idx < len(row):
-                    row[idx] = 1.0 if row[idx] >= threshold else 0.0
+                    row[idx] = open_value if row[idx] >= threshold else close_value
         return action

--- a/src/robots/zoo/r1_lite/__init__.py
+++ b/src/robots/zoo/r1_lite/__init__.py
@@ -23,7 +23,18 @@ from robots.base import (
     RobotVisConfig,
     VisPart,
 )
-from robots.kinematics.pyroki import PyrokiDualArm, PyrokiSingleArm
+
+try:
+    from robots.kinematics.pyroki import PyrokiDualArm, PyrokiSingleArm
+except ImportError as exc:
+    _PYROKI_IMPORT_ERROR: ImportError | None = exc
+
+    class PyrokiDualArm:  # type: ignore[no-redef]
+        pass
+
+    PyrokiSingleArm = None  # type: ignore[assignment]
+else:
+    _PYROKI_IMPORT_ERROR = None
 
 
 class R1LiteKinematicsSolver(PyrokiDualArm):
@@ -101,7 +112,11 @@ class R1Lite(Robot):
                 ActuatorGroup("left_arm", 7, self.LEFT_JOINTS, gripper_index=6),
                 ActuatorGroup("right_arm", 7, self.RIGHT_JOINTS, gripper_index=6),
             ),
-            initial_qpos=np.zeros(14, dtype=np.float32),
+            initial_qpos=np.array(
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0,
+                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0],
+                dtype=np.float32,
+            ),
             observation_schema=ObservationSchema(
                 cameras=(
                     CameraSpec("head", "cam_high"),
@@ -126,6 +141,10 @@ class R1Lite(Robot):
         )
 
     def build_kinematics(self, *, reference_frame: str | None = None, **kwargs: Any) -> Any:
+        if _PYROKI_IMPORT_ERROR is not None:
+            raise ImportError("R1 Lite kinematics requires the PyRoki/JAX dependencies") from (
+                _PYROKI_IMPORT_ERROR
+            )
         frame = reference_frame or self.DEFAULT_FRAME
         if frame not in self.SUPPORTED_FRAMES:
             allowed = ", ".join(self.SUPPORTED_FRAMES)

--- a/src/transport/base.py
+++ b/src/transport/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import abc
 import collections
+import contextlib
 import dataclasses
 import importlib.util
 import logging
@@ -16,9 +17,15 @@ from typing import Any, Protocol, cast
 import numpy as np
 
 from core.config import ConfigDict
-from core.types import Observation, RawCollectionSnapshot
+from core.types import (
+    CollectionRawBatch,
+    CollectionRawImage,
+    CollectionRawSample,
+    Observation,
+    RawCollectionSnapshot,
+)
 from robots.base import Robot
-from transport.utils import StreamFreshness, _SimpleRate
+from transport.utils import ImageRateTracker, StreamFreshness, _SimpleRate
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +48,10 @@ class ObservationSource(Protocol):
 
     def seconds_since_last_recv(self) -> float | None:
         """Return seconds since the last received message, or None if never received."""
+        ...
+
+    def image_min_hz(self) -> float | None:
+        """Return the minimum image receive rate across cameras, or None if unknown."""
         ...
 
 
@@ -115,6 +126,10 @@ class TransportBridge(abc.ABC):
         """
         return None
 
+    def image_min_hz(self) -> float | None:
+        """Minimum image receive rate across cameras, or None until enough samples."""
+        return None
+
     def supports_collection(self) -> bool:
         """True if this transport can record data-collection frames."""
         return False
@@ -146,16 +161,34 @@ class TransportBridge(abc.ABC):
 
         The capture loop calls this every tick: it must only grab source
         references (undecoded bytes / pinned messages) and stamp the source
-        capture time, deferring all decode/copy/convert work to the returned
-        snapshot's decode() closure run on the ingest thread. Returns None when
-        no new source frame is available (the source timestamp has not strictly
-        advanced), which also serves as dedup. Non-collection transports keep
-        the default and stay on the synchronous get_collection_frame() path.
+        capture time. The returned snapshot yields timestamped raw stream samples
+        for episode-level fixed-clock alignment at save time. Returns None when
+        no new source frame is available.
         """
         return None
 
+    def collection_diagnostics(self) -> str:
+        """Human-readable reason collection frames are not currently available."""
+        return ""
+
     def stop_collection(self) -> None:
         """Signal the source to stop emitting collection frames (no-op default)."""
+        return None
+
+    def reset_hil_control(self) -> None:
+        """Reset backend HIL relay state before a new intervention/collection."""
+        return None
+
+    def set_hil_control_mode(self, mode: str) -> None:
+        """Set backend HIL relay mode when supported."""
+        _ = mode
+        return None
+
+    def record_collection_gripper_action(
+        self, group_name: str, value: float, stamp: Any | None = None
+    ) -> None:
+        """Record a collection-only gripper action target when supported."""
+        _ = group_name, value, stamp
         return None
 
     def create_observation_reader(self) -> ObservationSource:
@@ -313,6 +346,7 @@ class _RosTransportBase(TransportBridge):
     _robot: Robot
     _bridge: Any
     _freshness: StreamFreshness
+    _image_rate: ImageRateTracker
     _camera_deques: dict[str, collections.deque]
     _collection_qpos_deques: dict[str, collections.deque]
     _collection_eef_deques: dict[str, collections.deque]
@@ -341,11 +375,29 @@ class _RosTransportBase(TransportBridge):
         """The backend's ``config.collection.transport.ros{1,2}`` section."""
         ...
 
+    def _deque_guard(self) -> Any:
+        return getattr(self, "_deque_lock", contextlib.nullcontext())
+
     def _append_msg(self, deque: collections.deque, msg: Any) -> None:
-        if len(deque) >= _COLLECTION_DEQUE_MAX:
-            deque.popleft()
-        deque.append(msg)
+        with self._deque_guard():
+            if len(deque) >= _COLLECTION_DEQUE_MAX:
+                deque.popleft()
+            deque.append(msg)
         self._freshness.mark()
+
+    def _append_camera_msg(
+        self,
+        camera_name: str,
+        deque: collections.deque,
+        msg: Any,
+        timestamp: float | None = None,
+    ) -> None:
+        self._image_rate.mark(camera_name, timestamp)
+        self._append_msg(deque, msg)
+
+    def image_min_hz(self) -> float | None:
+        """Minimum camera topic receive rate across subscribed cameras."""
+        return self._image_rate.min_hz(self._camera_deques.keys())
 
     def seconds_since_last_recv(self) -> float | None:
         """Seconds since the last message landed on any subscription (link health)."""
@@ -360,6 +412,7 @@ class _RosTransportBase(TransportBridge):
         frame_time = self._collection_frame_time()
         if frame_time is not None:
             self._last_acquire_stamp = frame_time
+        self._reset_collection_raw_cursors()
         return frame_time
 
     def _latest_before_or_at(self, deque: collections.deque, frame_time: float) -> Any | None:
@@ -460,9 +513,9 @@ class _RosTransportBase(TransportBridge):
             required.append(deque)
 
         columns = self._config.collection.schema.columns
-        if "state_qpos" in columns:
+        if "qpos" in columns:
             required.extend(self._collection_qpos_deques.values())
-        if "state_eef" in columns:
+        if "eef" in columns:
             required.extend(self._collection_eef_deques.values())
         if "action_qpos" in columns:
             required.extend(self._collection_action_qpos_deques.values())
@@ -485,11 +538,11 @@ class _RosTransportBase(TransportBridge):
         """
         columns = self._config.collection.schema.columns
         state_qpos = state_eef = action_qpos = action_eef = None
-        if "state_qpos" in columns:
+        if "qpos" in columns:
             state_qpos = self._collection_joint_vector(self._collection_qpos_deques, frame_time)
             if state_qpos is None:
                 return None
-        if "state_eef" in columns:
+        if "eef" in columns:
             state_eef = self._collection_eef_vector(self._collection_eef_deques, frame_time)
             if state_eef is None:
                 return None
@@ -538,56 +591,213 @@ class _RosTransportBase(TransportBridge):
             timestamp=frame_time,
         )
 
-    def acquire_collection_raw(self) -> RawCollectionSnapshot | None:
-        """O(1) capture: pin image msgs + compute cheap value vectors; defer the
-        expensive per-image decode to the snapshot's decode() closure.
+    def _collection_raw_cursors(self) -> dict[str, float]:
+        cursors = getattr(self, "_collection_raw_cursor_state", None)
+        if cursors is None:
+            cursors = {}
+            self._collection_raw_cursor_state = cursors
+        return cursors
 
-        Dedup is the strict-monotonic frame_time gate: when the camera header
-        stamp has not advanced, returns None instead of re-recording the msg the
-        ingest thread already holds.
-        """
-        if not self._config.collection.schema.columns:
-            return None
-        frame_time = self._collection_frame_time()
-        if frame_time is None:
-            return None
-        if self._last_acquire_stamp is not None and frame_time <= self._last_acquire_stamp:
-            return None
-
-        gathered = self._gather_collection_columns(frame_time)
-        if gathered is None:
-            return None
-        state_qpos, state_eef, action_qpos, action_eef = gathered
-
-        # Pin the still-encoded image msgs without decoding; missing any camera
-        # invalidates the whole frame, matching get_collection_frame semantics.
-        image_msgs: dict[str, tuple[str, Any]] = {}
+    def _collection_raw_streams(self) -> list[tuple[str, str, str, Any, collections.deque]]:
+        streams: list[tuple[str, str, str, Any, collections.deque]] = []
         for camera in self._collection_camera_specs():
             deque = self._camera_deques.get(camera.name)
-            if deque is None:
+            if deque is not None:
+                streams.append(("image", camera.observation_key, camera.name, camera, deque))
+
+        columns = self._config.collection.schema.columns
+        if "qpos" in columns:
+            for group in self._robot.actuator_groups:
+                deque = self._collection_qpos_deques.get(group.name)
+                if deque is not None:
+                    streams.append(("vector", "state_qpos", group.name, group, deque))
+        if "eef" in columns:
+            for group in self._robot.actuator_groups:
+                deque = self._collection_eef_deques.get(group.name)
+                if deque is not None:
+                    streams.append(("vector", "state_eef", group.name, group, deque))
+        if "action_qpos" in columns:
+            for group in self._robot.actuator_groups:
+                deque = self._collection_action_qpos_deques.get(group.name)
+                if deque is not None:
+                    streams.append(("vector", "action_qpos", group.name, group, deque))
+        if "action_eef" in columns:
+            for group in self._robot.actuator_groups:
+                deque = self._collection_action_eef_deques.get(group.name)
+                if deque is not None:
+                    streams.append(("vector", "action_eef", group.name, group, deque))
+        return streams
+
+    def _collection_raw_context_streams(self) -> list[tuple[str, collections.deque]]:
+        return []
+
+    def _reset_collection_raw_cursors(self) -> None:
+        cursors = self._collection_raw_cursors()
+        cursors.clear()
+        for kind, field, source_name, _source, deque in self._collection_raw_streams():
+            if len(deque) > 0:
+                cursors[f"{kind}:{field}:{source_name}"] = self._stamp_to_sec(deque[-1])
+
+    def _collection_raw_joint_value(
+        self,
+        field: str,
+        group: Any,
+        msg: Any,
+        timestamp: float,
+        pinned_streams: dict[str, list[Any]],
+    ) -> np.ndarray:
+        _ = field, group, timestamp, pinned_streams
+        return np.asarray(msg.position, dtype=np.float32)
+
+    def _collection_raw_eef_value(
+        self,
+        field: str,
+        group: Any,
+        msg: Any,
+        timestamp: float,
+        pinned_streams: dict[str, list[Any]],
+    ) -> np.ndarray:
+        _ = field, pinned_streams
+        return self._eef_from_msg(group, msg, timestamp)
+
+    def _collection_raw_batch_from_msgs(
+        self,
+        new_messages: dict[str, list[Any]],
+        pinned_streams: dict[str, list[Any]],
+    ) -> CollectionRawBatch:
+        batch = CollectionRawBatch()
+        for kind, field, source_name, source, _deque in self._collection_raw_streams():
+            key = f"{kind}:{field}:{source_name}"
+            messages = new_messages.get(key, [])
+            if kind == "image":
+                for msg in messages:
+                    batch.images.setdefault(field, []).append(
+                        CollectionRawSample(
+                            timestamp=self._stamp_to_sec(msg),
+                            value=CollectionRawImage(
+                                lambda camera_name=source.name, raw_msg=msg: (
+                                    self._decode_image_msg(camera_name, raw_msg)
+                                )
+                            ),
+                        )
+                    )
+                continue
+
+            sample_key = f"{field}:{source_name}"
+            for msg in messages:
+                timestamp = self._stamp_to_sec(msg)
+                if field in {"state_qpos", "action_qpos"}:
+                    value = self._collection_raw_joint_value(
+                        field, source, msg, timestamp, pinned_streams
+                    )
+                else:
+                    value = self._collection_raw_eef_value(
+                        field, source, msg, timestamp, pinned_streams
+                    )
+                batch.vectors.setdefault(sample_key, []).append(
+                    CollectionRawSample(timestamp=timestamp, value=value.astype(np.float32))
+                )
+        return batch
+
+    def _collection_fresh_messages(
+        self,
+        source_deque: collections.deque,
+        last_stamp: float | None,
+    ) -> tuple[list[Any], float | None, float | None]:
+        if not source_deque:
+            return [], None, None
+        if last_stamp is None:
+            messages = list(source_deque)
+            first_stamp = self._stamp_to_sec(messages[0])
+            latest_stamp = self._stamp_to_sec(messages[-1])
+            return messages, first_stamp, latest_stamp
+
+        fresh_reversed: list[Any] = []
+        first_stamp = None
+        latest_stamp = None
+        for msg in reversed(source_deque):
+            stamp = self._stamp_to_sec(msg)
+            if stamp <= last_stamp:
+                break
+            first_stamp = stamp
+            if latest_stamp is None:
+                latest_stamp = stamp
+            fresh_reversed.append(msg)
+        if latest_stamp is None:
+            return [], None, None
+        fresh_reversed.reverse()
+        return fresh_reversed, first_stamp, latest_stamp
+
+    def _collection_context_messages(
+        self,
+        source_deque: collections.deque,
+        start_time: float,
+        end_time: float,
+    ) -> list[Any]:
+        selected_reversed: list[Any] = []
+        latest_before_start = None
+        for msg in reversed(source_deque):
+            stamp = self._stamp_to_sec(msg)
+            if stamp > end_time:
+                continue
+            if stamp < start_time:
+                latest_before_start = msg
+                break
+            selected_reversed.append(msg)
+        selected_reversed.reverse()
+        if latest_before_start is None:
+            return selected_reversed
+        return [latest_before_start, *selected_reversed]
+
+    def acquire_collection_raw(self) -> RawCollectionSnapshot | None:
+        """O(1) capture of raw collection stream messages since the previous tick."""
+        if not self._config.collection.schema.columns:
+            return None
+        streams = self._collection_raw_streams()
+        if not streams:
+            return None
+
+        cursors = self._collection_raw_cursors()
+        new_messages: dict[str, list[Any]] = {}
+        pinned_streams: dict[str, list[Any]] = {}
+        snapshot_timestamp: float | None = None
+        first_fresh_timestamp: float | None = None
+        with self._deque_guard():
+            for kind, field, source_name, _source, deque in streams:
+                key = f"{kind}:{field}:{source_name}"
+                last_stamp = cursors.get(key)
+                fresh, first_stamp, latest = self._collection_fresh_messages(
+                    deque, last_stamp
+                )
+                if not fresh:
+                    continue
+                new_messages[key] = fresh
+                assert first_stamp is not None and latest is not None
+                cursors[key] = latest
+                first_fresh_timestamp = (
+                    first_stamp
+                    if first_fresh_timestamp is None
+                    else min(first_fresh_timestamp, first_stamp)
+                )
+                snapshot_timestamp = (
+                    latest if snapshot_timestamp is None else max(snapshot_timestamp, latest)
+                )
+
+            if snapshot_timestamp is None:
                 return None
-            msg = self._collection_latest_msg(deque, frame_time)
-            if msg is None:
-                return None
-            image_msgs[camera.observation_key] = (camera.name, msg)
+            assert first_fresh_timestamp is not None
 
-        self._last_acquire_stamp = frame_time
+            for key, deque in self._collection_raw_context_streams():
+                pinned_streams[key] = self._collection_context_messages(
+                    deque,
+                    first_fresh_timestamp,
+                    snapshot_timestamp,
+                )
 
-        def decode() -> Observation:
-            """Decode the pinned image msgs and assemble the full Observation."""
-            images: dict[str, np.ndarray] = {}
-            for obs_key, (camera_name, msg) in image_msgs.items():
-                image = self._decode_image_msg(camera_name, msg)
-                if image is None:
-                    raise ValueError(f"image decode failed for {camera_name}")
-                images[obs_key] = np.ascontiguousarray(image).copy()
-            return Observation(
-                images=images,
-                state_qpos=cast(np.ndarray, state_qpos),
-                state_eef=state_eef,
-                action_qpos=action_qpos,
-                action_eef=action_eef,
-                timestamp=frame_time,
-            )
+        def decode_raw() -> CollectionRawBatch:
+            return self._collection_raw_batch_from_msgs(new_messages, pinned_streams)
 
-        return RawCollectionSnapshot(timestamp=frame_time, decode=decode)
+        return RawCollectionSnapshot(
+            timestamp=snapshot_timestamp,
+            decode_raw=decode_raw,
+        )

--- a/src/transport/dataset.py
+++ b/src/transport/dataset.py
@@ -447,6 +447,11 @@ class DatasetTransport(TransportBridge):
         """
         return self._expand_robot_qpos(self.get_obs_state(index))
 
+    def _frame_timestamp(self, index: int) -> float:
+        if self._timestamps is not None:
+            return float(self._timestamps[index])
+        return float(index) / float(max(1, self._fps))
+
     def get_frame(self) -> Observation | None:
         """Decode the observation at the current frame index.
 
@@ -470,6 +475,7 @@ class DatasetTransport(TransportBridge):
                 return Observation(
                     images={k: self._frame_cache[k].copy() for k in self._camera_keys},
                     state_qpos=state,
+                    timestamp=self._frame_timestamp(idx),
                 )
 
             h = self._config.transport.image_height
@@ -485,7 +491,7 @@ class DatasetTransport(TransportBridge):
 
             self._frame_cache_idx = idx
             self._frame_cache = {k: v.copy() for k, v in images.items()}
-        return Observation(images=images, state_qpos=state)
+        return Observation(images=images, state_qpos=state, timestamp=self._frame_timestamp(idx))
 
     def get_camera_frame(self, key: str) -> np.ndarray | None:
         """Decode a single camera at the current frame index for the live MJPEG feed.

--- a/src/transport/ros1.py
+++ b/src/transport/ros1.py
@@ -9,6 +9,7 @@ import collections
 import importlib.util
 import logging
 import os
+import threading
 from typing import Any
 from urllib import parse
 
@@ -23,7 +24,7 @@ from transport.base import (
     _RosTransportBase,
     resolve_topics,
 )
-from transport.utils import StreamFreshness
+from transport.utils import ImageRateTracker, StreamFreshness
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +181,8 @@ class Ros1Transport(_RosTransportBase):
         self._robot = robot
         self._camera_topics, self._group_topics = resolve_topics(config.transport.topics)
         self._freshness = StreamFreshness()
+        self._image_rate = ImageRateTracker()
+        self._deque_lock = threading.RLock()
 
         runtime = get_ros_runtime(config.transport.node_name)
         self._rospy = runtime.rospy
@@ -246,7 +249,7 @@ class Ros1Transport(_RosTransportBase):
             self._register_subscriber(
                 topic,
                 self._Image,
-                lambda msg, d=deque: self._append_msg(d, msg),
+                lambda msg, c=camera.name, d=deque: self._append_camera_msg(c, d, msg),
             )
 
         # Subscribe to actuator group state topics
@@ -398,7 +401,7 @@ class Ros1Transport(_RosTransportBase):
 
         state = np.concatenate(state_parts, axis=0)
 
-        return Observation(images=images, state_qpos=state)
+        return Observation(images=images, state_qpos=state, timestamp=frame_time)
 
     def _pop_synced_msg(self, deque: collections.deque, frame_time: float) -> Any:
         while deque[0].header.stamp.to_sec() < frame_time:

--- a/src/transport/ros2.py
+++ b/src/transport/ros2.py
@@ -26,11 +26,13 @@ from transport.base import (
     _RosTransportBase,
     resolve_topics,
 )
-from transport.utils import StreamFreshness
+from transport.utils import ImageRateTracker, StreamFreshness
 
 logger = logging.getLogger(__name__)
 
 _ROS2_RUNTIME: _Ros2Runtime | None = None
+_HIL_CONTROL_MODES = frozenset({"absolute", "relative"})
+_CAMERA_QOS_DEPTH = 120
 
 
 class _Ros2Runtime:
@@ -134,6 +136,8 @@ class Ros2Transport(_RosTransportBase):
         self._robot = robot
         self._camera_topics, self._group_topics = resolve_topics(config.transport.topics)
         self._freshness = StreamFreshness()
+        self._image_rate = ImageRateTracker()
+        self._deque_lock = threading.RLock()
 
         runtime = get_ros2_runtime(config.transport.node_name)
         self._runtime = runtime
@@ -150,21 +154,56 @@ class Ros2Transport(_RosTransportBase):
         self._group_eef_deques: dict[str, collections.deque] = {}
         self._group_gripper_deques: dict[str, collections.deque] = {}
         self._collection_qpos_deques: dict[str, collections.deque] = {}
+        self._collection_qpos_gripper_deques: dict[str, collections.deque] = {}
         self._collection_eef_deques: dict[str, collections.deque] = {}
         self._collection_action_qpos_deques: dict[str, collections.deque] = {}
+        self._collection_action_qpos_gripper_deques: dict[str, collections.deque] = {}
         self._collection_action_eef_deques: dict[str, collections.deque] = {}
         self._group_cmd_publishers: dict[str, Any] = {}
         self._group_gripper_publishers: dict[str, Any] = {}
+        self._hil_control_mode = "absolute"
+        self._hil_cat_anchors: dict[str, np.ndarray] = {}
+        self._hil_robot_anchors: dict[str, np.ndarray] = {}
+        self._last_group_joint_commands: dict[str, np.ndarray] = {}
+        self._last_group_gripper_commands: dict[str, float] = {}
         self._group_joint_names: dict[str, list[str]] = {
             g.name: list(g.joint_names) for g in self._robot.actuator_groups
         }
         self._last_acquire_stamp: float | None = None
 
+        self.set_hil_control_mode(self._configured_hil_control_mode())
         self._init_ros()
+
+    def _configured_hil_control_mode(self) -> str:
+        rollout = self._config.get("rollout") or {}
+        intervention = rollout.get("intervention") or {}
+        return str(intervention.get("control_mode", "absolute"))
+
+    def _hil_intervention_enabled(self) -> bool:
+        rollout = self._config.get("rollout") or {}
+        intervention = rollout.get("intervention") or {}
+        return bool(intervention.get("enabled", False))
+
+    @property
+    def hil_control_mode(self) -> str:
+        return self._hil_control_mode
+
+    def set_hil_control_mode(self, mode: str) -> None:
+        if mode not in _HIL_CONTROL_MODES:
+            allowed = ", ".join(sorted(_HIL_CONTROL_MODES))
+            raise ValueError(f"Unsupported HIL control mode {mode!r}; expected: {allowed}")
+        self._hil_control_mode = mode
+        self.reset_hil_control()
+
+    def reset_hil_control(self) -> None:
+        self._hil_cat_anchors.clear()
+        self._hil_robot_anchors.clear()
 
     def _init_ros(self) -> None:
         schema = self._robot.observation_schema
         live_qos = _make_live_qos()
+        camera_qos = _make_live_qos(depth=_CAMERA_QOS_DEPTH)
+        hil_qos = _make_live_qos(depth=1)
 
         for camera in schema.cameras:
             topic = self._camera_topics.get(camera.name)
@@ -176,7 +215,10 @@ class Ros2Transport(_RosTransportBase):
             self._camera_is_compressed[camera.name] = is_compressed
             msg_type = self._CompressedImage if is_compressed else self._Image
             self._node.create_subscription(
-                msg_type, topic, lambda msg, d=deque: self._append_msg(d, msg), live_qos
+                msg_type,
+                topic,
+                lambda msg, c=camera.name, d=deque: self._append_camera_msg(c, d, msg),
+                camera_qos,
             )
 
         for group in self._robot.actuator_groups:
@@ -223,7 +265,7 @@ class Ros2Transport(_RosTransportBase):
                 topics = ros2_cfg.groups.get(group.name)
                 if topics is None:
                     continue
-                if topics.qpos_topic:
+                if topics.get("qpos_topic"):
                     self._subscribe_into(
                         self._collection_qpos_deques,
                         group.name,
@@ -231,7 +273,15 @@ class Ros2Transport(_RosTransportBase):
                         topics.qpos_topic,
                         live_qos,
                     )
-                if topics.eef_topic:
+                if topics.get("qpos_gripper_topic"):
+                    self._subscribe_into(
+                        self._collection_qpos_gripper_deques,
+                        group.name,
+                        self._JointState,
+                        topics.qpos_gripper_topic,
+                        live_qos,
+                    )
+                if topics.get("eef_topic"):
                     self._subscribe_into(
                         self._collection_eef_deques,
                         group.name,
@@ -239,7 +289,7 @@ class Ros2Transport(_RosTransportBase):
                         topics.eef_topic,
                         live_qos,
                     )
-                if topics.action_qpos_topic:
+                if topics.get("action_qpos_topic"):
                     self._subscribe_into(
                         self._collection_action_qpos_deques,
                         group.name,
@@ -247,13 +297,36 @@ class Ros2Transport(_RosTransportBase):
                         topics.action_qpos_topic,
                         live_qos,
                     )
-                if topics.action_eef_topic:
+                action_qpos_gripper_source = topics.get("action_qpos_gripper_source", "topic")
+                if action_qpos_gripper_source not in {"topic", "operator"}:
+                    raise ValueError(
+                        f"Unsupported action_qpos_gripper_source "
+                        f"{action_qpos_gripper_source!r} for {group.name}"
+                    )
+                if action_qpos_gripper_source == "operator":
+                    self._collection_action_qpos_gripper_deques[group.name] = collections.deque()
+                elif topics.get("action_qpos_gripper_topic"):
+                    self._subscribe_into(
+                        self._collection_action_qpos_gripper_deques,
+                        group.name,
+                        self._JointState,
+                        topics.action_qpos_gripper_topic,
+                        live_qos,
+                    )
+                if topics.get("action_eef_topic"):
                     self._subscribe_into(
                         self._collection_action_eef_deques,
                         group.name,
                         self._PoseStamped,
                         topics.action_eef_topic,
                         live_qos,
+                    )
+                if self._hil_intervention_enabled() and topics.get("hil_qpos_topic"):
+                    self._node.create_subscription(
+                        self._JointState,
+                        topics.hil_qpos_topic,
+                        lambda msg, g=group: self._handle_hil_joint_msg(g, msg),
+                        hil_qos,
                     )
 
     def _subscribe_into(
@@ -273,6 +346,50 @@ class Ros2Transport(_RosTransportBase):
             lambda msg, d=deque: self._append_msg(d, msg),
             qos,
         )
+
+    def start_collection(self) -> None:
+        """Seed collection-only gripper action from the current target/feedback."""
+        for group in self._robot.actuator_groups:
+            if not self._uses_operator_action_gripper(group):
+                continue
+            value = self._last_group_gripper_commands.get(group.name)
+            if value is None:
+                value = self._latest_group_gripper_feedback(group)
+            if value is not None:
+                self.record_collection_gripper_action(group.name, value)
+
+    def clear_collection_backlog(self) -> float | None:
+        """Advance raw cursors after seeding operator-sourced gripper action."""
+        self.start_collection()
+        return super().clear_collection_backlog()
+
+    def record_collection_gripper_action(
+        self, group_name: str, value: float, stamp: Any | None = None
+    ) -> None:
+        """Record a collection-only gripper action target for operator-sourced configs."""
+        group = self._group_by_name(group_name)
+        if group is None or not self._uses_operator_action_gripper(group):
+            return
+        deque = self._collection_action_qpos_gripper_deques.get(group_name)
+        if deque is None:
+            return
+        if stamp is None:
+            stamp = self._node.get_clock().now().to_msg()
+        position = np.asarray([value], dtype=np.float32)
+        self._append_msg(
+            deque,
+            self._make_joint_state(group_name, position, stamp, gripper_only=True),
+        )
+
+    def _group_by_name(self, group_name: str) -> Any | None:
+        for group in self._robot.actuator_groups:
+            if group.name == group_name:
+                return group
+        return None
+
+    def _uses_operator_action_gripper(self, group: Any) -> bool:
+        topics = self._config.collection.transport.ros2.groups.get(group.name)
+        return topics is not None and topics.get("action_qpos_gripper_source") == "operator"
 
     def get_frame(self) -> Observation | None:
         """Build a time-synchronized observation from the per-topic message deques.
@@ -305,6 +422,8 @@ class Ros2Transport(_RosTransportBase):
         for camera in schema.cameras:
             deque = self._camera_deques[camera.name]
             msg = self._pop_synced_msg(deque, frame_time)
+            if msg is None:
+                return None
             image = self._decode_image_msg(camera.name, msg)
             if image is None:
                 return None
@@ -317,26 +436,337 @@ class Ros2Transport(_RosTransportBase):
                 if eef_deque is None:
                     return None
                 eef_msg = self._pop_synced_msg(eef_deque, frame_time)
+                if eef_msg is None:
+                    return None
                 state_parts.append(self._eef_msg_to_state(group.name, eef_msg, frame_time))
         else:
             for group_name in schema.state_composition:
                 deque = self._group_state_deques[group_name]
                 joint_msg = self._pop_synced_msg(deque, frame_time)
+                if joint_msg is None:
+                    return None
                 group = next(g for g in self._robot.actuator_groups if g.name == group_name)
                 state_parts.append(self._joint_msg_to_state(group, joint_msg, frame_time))
         state = np.concatenate(state_parts, axis=0)
 
-        return Observation(images=images, state_qpos=state)
+        return Observation(images=images, state_qpos=state, timestamp=frame_time)
 
     @property
     def _collection_cfg(self) -> Any:
         return self._config.collection.transport.ros2
+
+    def get_camera_frame(self, key: str) -> np.ndarray | None:
+        """Return the latest decoded image for one camera without consuming queues.
+
+        Args:
+            key: Camera observation key or ROS2 camera name.
+
+        Returns:
+            Image [H, W, 3] uint8, or None if no message is available.
+        """
+        for camera in self._robot.observation_schema.cameras:
+            if key not in (camera.observation_key, camera.name):
+                continue
+            deque = self._camera_deques.get(camera.name)
+            if deque is None:
+                return None
+            try:
+                msg = deque[-1]
+            except IndexError:
+                return None
+            return self._decode_image_msg(camera.name, msg)
+        return None
+
+    def get_camera_jpeg(self, key: str) -> bytes | None:
+        """Return the latest compressed JPEG payload for one camera without consuming queues.
+
+        Args:
+            key: Camera observation key or ROS2 camera name.
+
+        Returns:
+            JPEG bytes, or None if the camera is unavailable or not compressed.
+        """
+        for camera in self._robot.observation_schema.cameras:
+            if key not in (camera.observation_key, camera.name):
+                continue
+            if not self._camera_is_compressed.get(camera.name, False):
+                return None
+            deque = self._camera_deques.get(camera.name)
+            if deque is None:
+                return None
+            try:
+                msg = deque[-1]
+            except IndexError:
+                return None
+            return bytes(msg.data)
+        return None
 
     def _stamp_to_sec(self, msg: Any) -> float:
         return _stamp_to_sec(msg)
 
     def _eef_from_msg(self, group: Any, msg: Any, frame_time: float) -> np.ndarray:
         return self._eef_msg_to_state(group.name, msg, frame_time)
+
+    def _collection_joint_vector(
+        self,
+        deques_by_group: dict[str, collections.deque],
+        frame_time: float,
+        value_attr: str = "position",
+        gripper_deques_by_group: dict[str, collections.deque] | None = None,
+        action_gripper: bool = False,
+    ) -> np.ndarray | None:
+        if gripper_deques_by_group is None:
+            if deques_by_group is self._collection_qpos_deques:
+                gripper_deques_by_group = self._collection_qpos_gripper_deques
+            elif deques_by_group is self._collection_action_qpos_deques:
+                gripper_deques_by_group = self._collection_action_qpos_gripper_deques
+                action_gripper = True
+        if not deques_by_group:
+            return None
+        parts: list[np.ndarray] = []
+        for group in self._robot.actuator_groups:
+            deque = deques_by_group.get(group.name)
+            if deque is None:
+                return None
+            msg = self._collection_latest_msg(deque, frame_time)
+            if msg is None:
+                return None
+            part = np.asarray(getattr(msg, value_attr), dtype=np.float32)
+            if (
+                group.gripper_index is not None
+                and part.shape == (group.dof - 1,)
+                and gripper_deques_by_group is not None
+                and group.name in gripper_deques_by_group
+            ):
+                gripper = self._collection_gripper_value(
+                    group,
+                    gripper_deques_by_group[group.name],
+                    frame_time,
+                    action_gripper=action_gripper,
+                )
+                if gripper is None:
+                    return None
+                part = np.insert(part, group.gripper_index, gripper).astype(np.float32)
+            parts.append(part)
+        return np.concatenate(parts, axis=0)
+
+    def _collection_raw_context_streams(self) -> list[tuple[str, collections.deque]]:
+        streams: list[tuple[str, collections.deque]] = []
+        for group_name, deque in self._collection_qpos_gripper_deques.items():
+            streams.append((f"gripper:state_qpos:{group_name}", deque))
+        for group_name, deque in self._collection_action_qpos_gripper_deques.items():
+            streams.append((f"gripper:action_qpos:{group_name}", deque))
+        for group_name, deque in self._group_gripper_deques.items():
+            streams.append((f"gripper:state_eef:{group_name}", deque))
+            streams.append((f"gripper:action_eef:{group_name}", deque))
+        return streams
+
+    def _collection_raw_joint_value(
+        self,
+        field: str,
+        group: Any,
+        msg: Any,
+        timestamp: float,
+        pinned_streams: dict[str, list[Any]],
+    ) -> np.ndarray:
+        part = np.asarray(msg.position, dtype=np.float32)
+        if group.gripper_index is None or part.shape != (group.dof - 1,):
+            return part
+        gripper = self._raw_gripper_value(
+            f"gripper:{field}:{group.name}",
+            timestamp,
+            pinned_streams,
+            action_gripper=(field == "action_qpos"),
+        )
+        if gripper is None:
+            return part
+        return np.insert(part, group.gripper_index, gripper).astype(np.float32)
+
+    def _raw_gripper_value(
+        self,
+        key: str,
+        timestamp: float,
+        pinned_streams: dict[str, list[Any]],
+        *,
+        action_gripper: bool,
+    ) -> float | None:
+        msg = self._latest_pinned_before_or_at(pinned_streams.get(key, []), timestamp)
+        if msg is None:
+            return None
+        position = getattr(msg, "position", ())
+        if len(position) == 0:
+            return None
+        value = float(position[0])
+        group_name = key.rsplit(":", 1)[-1]
+        topics = self._config.collection.transport.ros2.groups.get(group_name)
+        binary = False
+        if topics is not None:
+            config_key = "action_qpos_gripper_binary" if action_gripper else "qpos_gripper_binary"
+            binary = bool(topics.get(config_key, False))
+        if not binary:
+            return value
+        return self._binary_gripper_value(value)
+
+    def _latest_pinned_before_or_at(self, messages: list[Any], timestamp: float) -> Any | None:
+        latest = None
+        for msg in messages:
+            if self._stamp_to_sec(msg) <= timestamp:
+                latest = msg
+            else:
+                break
+        return latest
+
+    def collection_diagnostics(self) -> str:
+        """Describe which configured collection streams are missing or stale."""
+        if not self._config.collection.schema.columns:
+            return "collection schema has no columns"
+        frame_time = self._collection_frame_time()
+        max_skew = float(self._collection_cfg.max_frame_skew_sec)
+        problems: list[str] = []
+
+        def check_stream(
+            label: str,
+            topic: str | None,
+            deque: collections.deque | None,
+            *,
+            descriptor: str | None = None,
+            latched: bool = False,
+        ) -> None:
+            if descriptor is None:
+                if not topic:
+                    problems.append(f"{label} topic not configured")
+                    return
+                descriptor = f"topic={topic}"
+            if deque is None:
+                problems.append(f"{label} {descriptor} not subscribed")
+                return
+            if len(deque) == 0:
+                problems.append(f"{label} {descriptor} no messages")
+                return
+            if frame_time is None:
+                return
+            earliest = self._stamp_to_sec(deque[0])
+            latest = self._stamp_to_sec(deque[-1])
+            if earliest > frame_time:
+                problems.append(
+                    f"{label} {descriptor} starts after frame_time "
+                    f"{frame_time:.3f}s (earliest {earliest:.3f}s)"
+                )
+            elif not latched and max_skew > 0.0 and latest < frame_time - max_skew:
+                problems.append(
+                    f"{label} {descriptor} stale at frame_time {frame_time:.3f}s "
+                    f"(latest {latest:.3f}s, max_skew {max_skew:.3f}s)"
+                )
+
+        for camera in self._collection_camera_specs():
+            check_stream(
+                f"camera:{camera.observation_key}",
+                self._camera_topics.get(camera.name),
+                self._camera_deques.get(camera.name),
+            )
+
+        columns = self._config.collection.schema.columns
+        for group in self._robot.actuator_groups:
+            topics = self._config.collection.transport.ros2.groups.get(group.name)
+            if topics is None:
+                problems.append(f"group:{group.name} collection topics not configured")
+                continue
+            if "qpos" in columns:
+                check_stream(
+                    f"qpos:{group.name}",
+                    topics.get("qpos_topic"),
+                    self._collection_qpos_deques.get(group.name),
+                )
+                if topics.get("qpos_gripper_topic"):
+                    check_stream(
+                        f"qpos_gripper:{group.name}",
+                        topics.get("qpos_gripper_topic"),
+                        self._collection_qpos_gripper_deques.get(group.name),
+                    )
+            if "eef" in columns:
+                check_stream(
+                    f"eef:{group.name}",
+                    topics.get("eef_topic"),
+                    self._collection_eef_deques.get(group.name),
+                )
+            if "action_qpos" in columns:
+                check_stream(
+                    f"action_qpos:{group.name}",
+                    topics.get("action_qpos_topic"),
+                    self._collection_action_qpos_deques.get(group.name),
+                )
+                action_gripper_source = topics.get("action_qpos_gripper_source", "topic")
+                if action_gripper_source == "operator":
+                    check_stream(
+                        f"action_qpos_gripper:{group.name}",
+                        None,
+                        self._collection_action_qpos_gripper_deques.get(group.name),
+                        descriptor="source=operator",
+                        latched=True,
+                    )
+                elif topics.get("action_qpos_gripper_topic"):
+                    check_stream(
+                        f"action_qpos_gripper:{group.name}",
+                        topics.get("action_qpos_gripper_topic"),
+                        self._collection_action_qpos_gripper_deques.get(group.name),
+                    )
+            if "action_eef" in columns:
+                check_stream(
+                    f"action_eef:{group.name}",
+                    topics.get("action_eef_topic"),
+                    self._collection_action_eef_deques.get(group.name),
+                )
+
+        if problems:
+            return "missing collection streams: " + "; ".join(problems)
+        if frame_time is None:
+            return "collection streams have messages, but no frame_time is available"
+        return (
+            f"collection streams have messages, but no synchronized frame at "
+            f"{frame_time:.3f}s (max_skew {max_skew:.3f}s)"
+        )
+
+    def _collection_gripper_value(
+        self,
+        group: Any,
+        deque: collections.deque,
+        frame_time: float,
+        action_gripper: bool,
+    ) -> float | None:
+        if action_gripper and self._uses_operator_action_gripper(group):
+            msg = self._latest_before_or_at(deque, frame_time)
+        else:
+            msg = self._collection_latest_msg(deque, frame_time)
+        if msg is None:
+            return None
+        topics = self._config.collection.transport.ros2.groups.get(group.name)
+        position = getattr(msg, "position", ())
+        if len(position) == 0:
+            return None
+        value = float(position[0])
+        binary = False
+        if topics is not None:
+            key = "action_qpos_gripper_binary" if action_gripper else "qpos_gripper_binary"
+            binary = bool(topics.get(key, False))
+        if not binary:
+            return value
+        return self._binary_gripper_value(value)
+
+    def _binary_gripper_value(self, value: float) -> float:
+        threshold = self._config.robot.gripper_threshold
+        if threshold is None:
+            threshold = (self._config.robot.gripper_open + self._config.robot.gripper_close) * 0.5
+        if self._config.robot.gripper_open >= self._config.robot.gripper_close:
+            return (
+                self._config.robot.gripper_open
+                if value >= threshold
+                else self._config.robot.gripper_close
+            )
+        return (
+            self._config.robot.gripper_open
+            if value <= threshold
+            else self._config.robot.gripper_close
+        )
 
     def _decode_image_msg(self, camera_name: str, msg: Any) -> np.ndarray | None:
         if not self._camera_is_compressed.get(camera_name, False):
@@ -374,6 +804,109 @@ class Ros2Transport(_RosTransportBase):
             axis=0,
         )
 
+    def _latest_group_qpos(self, group: Any) -> np.ndarray | None:
+        msg = self._latest_group_qpos_msg(group)
+        if msg is None:
+            return None
+        return self._joint_msg_to_state(group, msg, _stamp_to_sec(msg))
+
+    def _latest_group_qpos_msg(self, group: Any) -> Any | None:
+        deque = self._group_state_deques.get(group.name)
+        if deque is None or len(deque) == 0:
+            return None
+        return deque[-1]
+
+    def _latest_group_gripper_feedback(self, group: Any) -> float | None:
+        deque = self._group_gripper_deques.get(group.name)
+        if deque is None or len(deque) == 0:
+            return None
+        position = getattr(deque[-1], "position", ())
+        if len(position) == 0:
+            return None
+        return float(position[0])
+
+    def _hil_robot_state_for_message(
+        self,
+        group: Any,
+        cat_position: np.ndarray,
+        robot_qpos: np.ndarray,
+    ) -> np.ndarray:
+        if robot_qpos.shape[0] == cat_position.shape[0]:
+            return robot_qpos.astype(np.float32, copy=True)
+        if (
+            group.gripper_index is not None
+            and robot_qpos.shape[0] == group.dof
+            and cat_position.shape[0] == group.dof - 1
+        ):
+            return np.delete(robot_qpos, group.gripper_index).astype(np.float32)
+        raise ValueError(
+            f"HIL relay shape mismatch for {group.name}: "
+            f"cat={cat_position.shape[0]} robot={robot_qpos.shape[0]}"
+        )
+
+    def _hil_anchor_state_for_message(
+        self,
+        group: Any,
+        cat_position: np.ndarray,
+        robot_qpos: np.ndarray,
+    ) -> np.ndarray:
+        last_command = self._last_group_joint_commands.get(group.name)
+        if last_command is None:
+            return self._hil_robot_state_for_message(group, cat_position, robot_qpos)
+        command = np.asarray(last_command, dtype=np.float32)
+        if command.shape[0] == cat_position.shape[0]:
+            return command.copy()
+        if group.gripper_index is None:
+            return self._hil_robot_state_for_message(group, cat_position, robot_qpos)
+        if command.shape[0] == group.dof and cat_position.shape[0] == group.dof - 1:
+            return np.delete(command, group.gripper_index).astype(np.float32)
+        if command.shape[0] == group.dof - 1 and cat_position.shape[0] == group.dof:
+            anchor = self._hil_robot_state_for_message(group, cat_position, robot_qpos)
+            anchor[: group.gripper_index] = command[: group.gripper_index]
+            anchor[group.gripper_index + 1 :] = command[group.gripper_index :]
+            return anchor.astype(np.float32)
+        return self._hil_robot_state_for_message(group, cat_position, robot_qpos)
+
+    def _resolve_hil_joint_command(
+        self,
+        group: Any,
+        cat_position: np.ndarray,
+        robot_qpos: np.ndarray,
+    ) -> np.ndarray:
+        cat = np.asarray(cat_position, dtype=np.float32)
+        if self._hil_control_mode == "absolute":
+            return cat.copy()
+        robot = self._hil_anchor_state_for_message(group, cat, robot_qpos)
+        if group.name not in self._hil_cat_anchors:
+            self._hil_cat_anchors[group.name] = cat.copy()
+            self._hil_robot_anchors[group.name] = robot.copy()
+        command = self._hil_robot_anchors[group.name] + (cat - self._hil_cat_anchors[group.name])
+        if group.gripper_index is not None and cat.shape[0] == group.dof:
+            command[group.gripper_index] = cat[group.gripper_index]
+        return command.astype(np.float32)
+
+    def _handle_hil_joint_msg(self, group: Any, msg: Any) -> None:
+        robot_qpos = self._latest_group_qpos(group)
+        if robot_qpos is None:
+            logger.error("HIL relay cannot publish %s without joint feedback", group.name)
+            return
+        try:
+            command = self._resolve_hil_joint_command(
+                group,
+                np.asarray(msg.position, dtype=np.float32),
+                robot_qpos,
+            )
+        except ValueError as exc:
+            logger.error("%s", exc)
+            return
+        publisher = self._group_cmd_publishers.get(group.name)
+        if publisher is None:
+            logger.error("HIL relay has no command publisher for %s", group.name)
+            return
+        stamp = self._node.get_clock().now().to_msg()
+        publisher.publish(self._make_joint_state(group.name, command, stamp))
+        self._last_group_joint_commands[group.name] = command.copy()
+
     def _eef_msg_to_state(self, group_name: str, msg: Any, frame_time: float) -> np.ndarray:
         pose = msg.pose
         eef_pose = np.asarray(
@@ -391,9 +924,11 @@ class Ros2Transport(_RosTransportBase):
         )
         return eef_pose
 
-    def _pop_synced_msg(self, deque: collections.deque, frame_time: float) -> Any:
-        while _stamp_to_sec(deque[0]) < frame_time:
+    def _pop_synced_msg(self, deque: collections.deque, frame_time: float) -> Any | None:
+        while deque and _stamp_to_sec(deque[0]) < frame_time:
             deque.popleft()
+        if not deque:
+            return None
         return deque.popleft()
 
     def publish_action(self, action: np.ndarray, target: str = "real") -> None:
@@ -418,12 +953,17 @@ class Ros2Transport(_RosTransportBase):
                 if group.gripper_index is not None and group.name in self._group_gripper_publishers:
                     joints = part[: group.gripper_index]
                 publisher.publish(self._make_joint_state(group.name, joints, stamp))
+                self._last_group_joint_commands[group.name] = np.asarray(
+                    joints,
+                    dtype=np.float32,
+                ).copy()
             gripper_publisher = self._group_gripper_publishers.get(group.name)
             if gripper_publisher is not None and group.gripper_index is not None:
                 gripper_position = np.asarray([part[group.gripper_index]], dtype=np.float32)
                 gripper_publisher.publish(
                     self._make_joint_state(group.name, gripper_position, stamp, gripper_only=True)
                 )
+                self._last_group_gripper_commands[group.name] = float(gripper_position[0])
 
     def _make_joint_state(
         self,

--- a/src/transport/utils.py
+++ b/src/transport/utils.py
@@ -8,8 +8,10 @@ rate limiter for non-ROS loops).
 
 from __future__ import annotations
 
+import collections
 import threading
 import time
+from collections.abc import Iterable
 
 
 class StreamFreshness:
@@ -35,6 +37,46 @@ class StreamFreshness:
             if self._last_monotonic == 0.0:
                 return None
             return time.monotonic() - self._last_monotonic
+
+
+class ImageRateTracker:
+    """Track per-camera image receive rates and report the minimum Hz."""
+
+    def __init__(self, sample_limit: int = 20) -> None:
+        self._sample_limit = max(2, sample_limit)
+        self._stamps: dict[str, collections.deque[float]] = {}
+        self._lock = threading.Lock()
+
+    def mark(self, key: str, timestamp: float | None = None) -> None:
+        stamp = time.monotonic() if timestamp is None else float(timestamp)
+        with self._lock:
+            stamps = self._stamps.setdefault(
+                key, collections.deque(maxlen=self._sample_limit)
+            )
+            if stamps and stamp <= stamps[-1]:
+                return
+            stamps.append(stamp)
+
+    def mark_many(self, keys: Iterable[str], timestamp: float | None = None) -> None:
+        stamp = time.monotonic() if timestamp is None else float(timestamp)
+        for key in keys:
+            self.mark(str(key), stamp)
+
+    def min_hz(self, keys: Iterable[str] | None = None) -> float | None:
+        with self._lock:
+            selected = tuple(keys) if keys is not None else tuple(self._stamps)
+            if not selected:
+                return None
+            rates: list[float] = []
+            for key in selected:
+                stamps = self._stamps.get(str(key))
+                if stamps is None or len(stamps) < 2:
+                    return None
+                duration = stamps[-1] - stamps[0]
+                if duration <= 0:
+                    return None
+                rates.append((len(stamps) - 1) / duration)
+        return min(rates) if rates else None
 
 
 class _SimpleRate:

--- a/src/transport/zmq.py
+++ b/src/transport/zmq.py
@@ -28,10 +28,10 @@ from openpi_client import msgpack_numpy
 
 from core.config import ConfigDict
 from core.registry import TRANSPORT_REGISTRY
-from core.types import Observation, RawCollectionSnapshot
+from core.types import CollectionRawBatch, CollectionRawSample, Observation, RawCollectionSnapshot
 from robots.base import Robot
 from transport.base import TransportBridge
-from transport.utils import StreamFreshness
+from transport.utils import ImageRateTracker, StreamFreshness
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +184,7 @@ class _ObservationReader:
         self._collection_queue: collections.deque[WireObservation] = collections.deque()
         self._raw_collection_queue: collections.deque[bytes] = collections.deque()
         self._freshness = StreamFreshness()
+        self._image_rate = ImageRateTracker()
         self._lock = threading.Lock()
         self._closed = False
 
@@ -217,6 +218,7 @@ class _ObservationReader:
                     break
                 got_message = True
                 obs = unpack_observation(payload)
+                self._image_rate.mark_many(obs.images.keys(), obs.t)
                 self._cache_images_locked(obs)
                 if newest is None or obs.t >= newest.t:
                     newest = obs
@@ -235,6 +237,7 @@ class _ObservationReader:
                     break
                 got_message = True
                 obs = unpack_observation(payload)
+                self._image_rate.mark_many(obs.images.keys(), obs.t)
                 self._cache_images_locked(obs)
                 self._collection_queue.append(obs)
                 if self._latest is None or obs.t >= self._latest.t:
@@ -248,6 +251,15 @@ class _ObservationReader:
     def seconds_since_last_recv(self) -> float | None:
         """Seconds since this reader's socket last received a message, or None."""
         return self._freshness.seconds_since()
+
+    def image_min_hz(self) -> float | None:
+        """Minimum image receive rate across enabled cameras."""
+        keys = (
+            camera.observation_key
+            for camera in self._robot.observation_schema.cameras
+            if camera.observation_key not in self._disabled_cameras
+        )
+        return self._image_rate.min_hz(keys)
 
     def clear_collection_backlog(self) -> float | None:
         """Drain the socket and drop queued collection frames captured pre-recording."""
@@ -318,8 +330,9 @@ class _ObservationReader:
                 images=images,
                 state_qpos=state,
                 action_qpos=np.asarray(wire_obs.action, dtype=np.float32),
+                timestamp=wire_obs.t,
             )
-        return Observation(images=images, state_qpos=state)
+        return Observation(images=images, state_qpos=state, timestamp=wire_obs.t)
 
     def get_camera_frame(self, key: str) -> np.ndarray | None:
         """Single camera's image [H, W, 3] uint8 from the freshest snapshot, or None.
@@ -429,7 +442,7 @@ class _ObservationReader:
 
         The main thread does zero msgpack work here: it only moves bytes off the
         socket into a backlog and hands back one payload. Decoding happens later
-        in the snapshot's decode() closure on the ingest thread.
+        through the snapshot's raw-batch closure on the ingest thread.
         """
         with self._lock:
             got_message = False
@@ -447,24 +460,53 @@ class _ObservationReader:
             return self._raw_collection_queue.popleft()
 
     def acquire_collection_raw(self) -> RawCollectionSnapshot | None:
-        """O(1) capture: pop one raw payload off the backlog, defer unpack to decode().
+        """Capture one raw collection payload and expose it as timestamped streams.
 
-        The main thread does no msgpack work — it only moves bytes off the socket
-        and returns a snapshot whose decode() closure unpacks into an Observation
-        on the ingest thread. Returns None when the backlog is empty.
+        Returns None when the backlog is empty.
         """
         payload = self._drain_raw_collection()
         if payload is None:
             return None
+        wire_obs = unpack_observation(payload)
 
-        def decode(payload: bytes = payload) -> Observation:
-            """Unpack the pinned payload into an Observation (ingest-thread work)."""
-            return self._wire_to_observation(unpack_observation(payload))
+        def decode_raw(wire_obs: WireObservation = wire_obs) -> CollectionRawBatch:
+            batch = CollectionRawBatch()
+            for key, image in wire_obs.images.items():
+                batch.images.setdefault(key, []).append(
+                    CollectionRawSample(timestamp=wire_obs.t, value=np.asarray(image))
+                )
+            for group_name, state in wire_obs.state.items():
+                batch.vectors.setdefault(f"state_qpos:{group_name}", []).append(
+                    CollectionRawSample(
+                        timestamp=wire_obs.t,
+                        value=np.asarray(state, dtype=np.float32),
+                    )
+                )
+            if wire_obs.action is not None:
+                batch.vectors.setdefault("action_qpos", []).append(
+                    CollectionRawSample(
+                        timestamp=wire_obs.t,
+                        value=np.asarray(wire_obs.action, dtype=np.float32),
+                    )
+                )
+            if wire_obs.eef is not None:
+                for group_name, eef in wire_obs.eef.items():
+                    batch.vectors.setdefault(f"state_eef:{group_name}", []).append(
+                        CollectionRawSample(
+                            timestamp=wire_obs.t,
+                            value=np.asarray(eef, dtype=np.float32),
+                        )
+                    )
+            if wire_obs.action_eef is not None:
+                batch.vectors.setdefault("action_eef", []).append(
+                    CollectionRawSample(
+                        timestamp=wire_obs.t,
+                        value=np.asarray(wire_obs.action_eef, dtype=np.float32),
+                    )
+                )
+            return batch
 
-        # The wire timestamp lives inside the still-packed payload; the backlog
-        # only ever holds genuinely published frames, so a non-empty pop is the
-        # dedup signal. decode() fills the real capture time into the frame.
-        return RawCollectionSnapshot(timestamp=0.0, decode=decode)
+        return RawCollectionSnapshot(timestamp=wire_obs.t, decode_raw=decode_raw)
 
     def close(self) -> None:
         """Close this reader's SUB socket (idempotent)."""
@@ -545,6 +587,20 @@ class ZmqTransport(TransportBridge):
             )
         ]
         known = [age for age in ages if age is not None]
+        return min(known) if known else None
+
+    def image_min_hz(self) -> float | None:
+        """Minimum known image receive rate across all active readers."""
+        rates = [
+            reader.image_min_hz()
+            for reader in (
+                self._reader,
+                self._collection_reader,
+                self._qpos_reader,
+                *self._extra_readers,
+            )
+        ]
+        known = [rate for rate in rates if rate is not None]
         return min(known) if known else None
 
     def publish_action(self, action: np.ndarray, target: str = "real") -> None:

--- a/tests/comms/test_wire.py
+++ b/tests/comms/test_wire.py
@@ -26,6 +26,7 @@ from transport.zmq import (
     unpack_action,
     unpack_observation,
 )
+from transport.utils import ImageRateTracker
 
 
 def _build_zmq_transport_with_fake_readers(monkeypatch):
@@ -213,6 +214,7 @@ def test_zmq_collection_reader_preserves_backlog_order():
     reader._latest = None
     reader._disabled_cameras = set()
     reader._latest_images = {}
+    reader._image_rate = ImageRateTracker()
     reader._preserve_collection_backlog = True
     reader._collection_queue = collections.deque()
     reader._freshness = types.SimpleNamespace(mark=lambda: None)  # type: ignore[reportAttributeAccessIssue]
@@ -260,6 +262,7 @@ def test_zmq_collection_reader_defaults_to_latest_frame():
     reader._latest = None
     reader._disabled_cameras = set()
     reader._latest_images = {}
+    reader._image_rate = ImageRateTracker()
     reader._preserve_collection_backlog = False
     reader._collection_queue = collections.deque()
     reader._freshness = types.SimpleNamespace(mark=lambda: None)  # type: ignore[reportAttributeAccessIssue]
@@ -436,6 +439,7 @@ def test_zmq_reader_keeps_multi_camera_visualization_cache():
     reader._sub = _Sub()
     reader._latest = None
     reader._latest_images = {}
+    reader._image_rate = ImageRateTracker()
     reader._disabled_cameras = set()
     reader._disabled_groups = set()
     reader._freshness = types.SimpleNamespace(mark=lambda: None)  # type: ignore[reportAttributeAccessIssue]

--- a/tests/config/test_console_strategy_selection.py
+++ b/tests/config/test_console_strategy_selection.py
@@ -102,8 +102,9 @@ def test_eval_bootstrap_uses_default_ckpt_slot(monkeypatch):
         inference_strategy="sync",
         cli_mode="real",
     )
-    config = ConfigDict(eval=eval_cfg)
+    config = ConfigDict(eval=eval_cfg, eval_cfg=eval_cfg)
     runtime, session = _runtime_and_session()
+    runtime.ckpt_order = [0]
     connected_ports = []
 
     def fake_connect_policy(config, runtime, session, **kwargs):

--- a/tests/config/test_control_state.py
+++ b/tests/config/test_control_state.py
@@ -1,15 +1,26 @@
-"""Tests for CLI state data helpers (core.app.state)."""
+"""Tests for CLI state helpers and rollout intervention state."""
 
 from __future__ import annotations
 
+import logging
+import queue
+
+import numpy as np
+
+from core.app import run as app
+from core.app.handlers import control, recording
 from core.app.state import (
+    RuntimeState,
+    SessionMode,
+    SessionState,
+    SessionStatus,
     default_inference_strategy_key,
     format_task_label,
     resolve_inference_strategy_label,
 )
 from core.config import ConfigDict
-
-# --- format_task_label ---
+from core.types import Observation, RolloutInterventionSegment
+from robots.base import ActuatorGroup, CameraSpec, ObservationSchema, Robot
 
 
 def test_format_task_label_none():
@@ -24,7 +35,29 @@ def test_format_task_label_normal():
     assert format_task_label("pick up cup") == "pick up cup"
 
 
-# --- inference strategy key helpers ---
+def test_gripper_command_records_collection_action_target():
+    transport = _CollectionTransport()
+    transport.latest_qpos = np.array([1.0, 100.0, 2.0, 0.0], dtype=np.float32)
+    transport.recorded_gripper_actions = []
+
+    def record_collection_gripper_action(group_name, value):
+        transport.recorded_gripper_actions.append((group_name, value))
+
+    transport.record_collection_gripper_action = record_collection_gripper_action
+    runtime = RuntimeState(robot=_gripper_robot(), transport=transport)
+    session = SessionState()
+
+    ok = control.set_gripper_immediate(
+        _gripper_config(),
+        runtime,
+        session,
+        open_gripper=False,
+        side="l",
+        lock=False,
+    )
+
+    assert ok is True
+    assert transport.recorded_gripper_actions == [("left_arm", 0.0)]
 
 
 def _config_with_strategies(strategies):
@@ -48,3 +81,432 @@ def test_resolve_label_explicit_key_passthrough():
         {"sync": {"type": "sync", "args": {}}, "rtc": {"type": "rtc", "args": {}}}
     )
     assert resolve_inference_strategy_label(cfg, "rtc") == "rtc"
+
+
+class _CollectionTransport:
+    def __init__(self) -> None:
+        self.started = 0
+        self.stopped = 0
+        self.cleared = 0
+        self.latest_qpos = np.array([0.1, 0.2], dtype=np.float32)
+        self.collection_frames: list[Observation] = []
+        self.diagnostics = ""
+        self.hil_resets = 0
+        self.hil_modes: list[str] = []
+        self.published: list[tuple[str, np.ndarray]] = []
+        self.sleep_count = 0
+
+    def supports_collection(self) -> bool:
+        return True
+
+    def start_collection(self) -> None:
+        self.started += 1
+
+    def stop_collection(self) -> None:
+        self.stopped += 1
+
+    def clear_collection_backlog(self) -> None:
+        self.cleared += 1
+
+    def get_latest_qpos(self) -> np.ndarray | None:
+        return self.latest_qpos.copy()
+
+    def get_collection_frame(self) -> Observation | None:
+        if not self.collection_frames:
+            return None
+        return self.collection_frames.pop(0)
+
+    def acquire_collection_raw(self):
+        return None
+
+    def collection_diagnostics(self) -> str:
+        return self.diagnostics
+
+    def reset_hil_control(self) -> None:
+        self.hil_resets += 1
+
+    def set_hil_control_mode(self, mode: str) -> None:
+        self.hil_modes.append(mode)
+
+    def has_sim_publishers(self) -> bool:
+        return False
+
+    def publish_action(self, action: np.ndarray, target: str = "real") -> None:
+        self.published.append((target, np.asarray(action, dtype=np.float32).copy()))
+
+    def create_rate(self, _hz: float):
+        transport = self
+
+        class _Rate:
+            def sleep(self) -> None:
+                transport.sleep_count += 1
+
+        return _Rate()
+
+
+class _EmptyCollectionLogger:
+    is_collection_enabled = True
+
+    def end_episode(self) -> bool:
+        return False
+
+
+class _ActiveRolloutLogger:
+    has_active_episode = True
+    active_frame_count = 1
+
+    def cancel_episode(self, _reason: str) -> None:
+        raise AssertionError("active rollout should not be cancelled")
+
+
+class _ResettableStrategy:
+    def __init__(self) -> None:
+        self.resets = 0
+
+    def reset(self) -> None:
+        self.resets += 1
+
+
+def _robot() -> Robot:
+    return Robot(
+        name="fake_arm",
+        actuator_groups=(ActuatorGroup("arm", 2, ("j0", "j1")),),
+        initial_qpos=np.zeros(2, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam"),),
+            state_composition=("arm",),
+        ),
+    )
+
+
+def _runtime_and_session() -> tuple[RuntimeState, SessionState]:
+    return RuntimeState(robot=_robot(), transport=_CollectionTransport()), SessionState()
+
+
+def _gripper_robot() -> Robot:
+    return Robot(
+        name="fake_gripper_robot",
+        actuator_groups=(
+            ActuatorGroup("left_arm", 2, ("left_j0", "left_gripper"), gripper_index=1),
+            ActuatorGroup("right_arm", 2, ("right_j0", "right_gripper"), gripper_index=1),
+        ),
+        initial_qpos=np.zeros(4, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam"),),
+            state_composition=("left_arm", "right_arm"),
+        ),
+    )
+
+
+def _gripper_config() -> ConfigDict:
+    return ConfigDict(
+        robot=ConfigDict(gripper_open=100.0, gripper_close=0.0, gripper_threshold=None),
+        inference_cfg=ConfigDict(publish_rate=15),
+    )
+
+
+def _config(*, intervention_enabled: bool = False) -> ConfigDict:
+    return ConfigDict(
+        collection=ConfigDict(
+            schema=ConfigDict(columns={"qpos": "state", "action_qpos": "action"}),
+        ),
+        rollout=ConfigDict(
+            intervention=ConfigDict(enabled=intervention_enabled),
+        ),
+        inference_cfg=ConfigDict(publish_rate=1000),
+    )
+
+
+def _observation(timestamp: float = 1.0) -> Observation:
+    return Observation(
+        timestamp=timestamp,
+        images={"cam": np.zeros((2, 2, 3), dtype=np.uint8)},
+        state_qpos=np.array([0.3, 0.4], dtype=np.float32),
+        action_qpos=np.array([0.5, 0.6], dtype=np.float32),
+    )
+
+
+def test_rollout_intervention_segment_tracks_observations():
+    segment = RolloutInterventionSegment(
+        segment_index=2,
+        start_policy_frame_index=5,
+        pre_intervention_qpos=np.array([0.1, 0.2], dtype=np.float32),
+    )
+
+    segment.frames.append(_observation(1.5))
+    segment.resume_policy_frame_index = 8
+
+    assert segment.segment_index == 2
+    assert segment.start_policy_frame_index == 5
+    assert segment.resume_policy_frame_index == 8
+    assert len(segment.frames) == 1
+
+
+def test_runtime_intervention_buffers_start_empty():
+    runtime, _session = _runtime_and_session()
+
+    assert runtime.rollout_intervention_pre_qpos is None
+    assert runtime.rollout_intervention_active_segment is None
+    assert runtime.rollout_intervention_segments == []
+    assert runtime.rollout_intervention_next_segment_index == 0
+
+
+def test_collect_start_teleop_starts_transport_collection():
+    runtime, session = _runtime_and_session()
+    runtime.collection_teleop_armed = True
+
+    ok = recording.collect_start_teleop(_config(), runtime, session)
+
+    assert ok is True
+    assert runtime.collection_teleop_active is True
+    assert runtime.transport.started == 1
+    assert session.mode is SessionMode.COLLECT
+    assert runtime.transport.hil_resets == 1
+
+
+def test_collect_start_teleop_refuses_when_not_armed():
+    runtime, session = _runtime_and_session()
+
+    ok = recording.collect_start_teleop(_config(), runtime, session)
+
+    assert ok is False
+    assert runtime.collection_teleop_active is False
+    assert runtime.transport.started == 0
+    assert session.last_error == "Collection teleop requires COLLECT activation"
+
+
+def test_collect_stop_teleop_stops_transport_collection():
+    runtime, session = _runtime_and_session()
+    runtime.collection_teleop_active = True
+    session.mode = SessionMode.COLLECT
+
+    recording.collect_stop_teleop(_config(), runtime, session)
+
+    assert runtime.collection_teleop_active is False
+    assert runtime.transport.stopped == 1
+
+
+def test_collect_stop_reports_collection_diagnostics(caplog):
+    runtime, session = _runtime_and_session()
+    runtime.episode_logger = _EmptyCollectionLogger()
+    runtime.transport.diagnostics = (
+        "missing collection streams: action_qpos_gripper:left_arm "
+        "topic=/motion_target/target_position_gripper_left no messages"
+    )
+
+    with caplog.at_level(logging.WARNING):
+        recording.collect_stop(_config(), runtime, session)
+
+    assert session.status is SessionStatus.READY
+    assert session.last_error == (
+        "Episode saved 0 frames; missing collection streams: "
+        "action_qpos_gripper:left_arm "
+        "topic=/motion_target/target_position_gripper_left no messages"
+    )
+    assert session.last_error in caplog.text
+
+
+def test_start_rollout_intervention_starts_transport_collection():
+    runtime, session = _runtime_and_session()
+
+    assert recording.start_rollout_intervention(
+        _config(intervention_enabled=True), runtime, session
+    ) is True
+    assert runtime.rollout_intervention_active is True
+    assert runtime.transport.started == 1
+    assert runtime.transport.cleared == 1
+    assert runtime.transport.hil_resets == 1
+    np.testing.assert_allclose(runtime.rollout_intervention_pre_qpos, [0.1, 0.2])
+    assert runtime.rollout_intervention_active_segment is not None
+
+
+def test_start_rollout_intervention_resets_policy_strategy():
+    runtime, session = _runtime_and_session()
+    strategy = _ResettableStrategy()
+    runtime.infer_strategy = strategy
+
+    assert recording.start_rollout_intervention(
+        _config(intervention_enabled=True), runtime, session
+    ) is True
+    assert strategy.resets == 1
+
+
+def test_start_rollout_intervention_clears_collection_backlog():
+    runtime, session = _runtime_and_session()
+
+    assert recording.start_rollout_intervention(
+        _config(intervention_enabled=True), runtime, session
+    ) is True
+    assert runtime.rollout_intervention_active is True
+    assert runtime.transport.started == 1
+    assert runtime.transport.cleared == 1
+    assert runtime.transport.hil_resets == 1
+    assert runtime.rollout_intervention_active_segment is not None
+
+
+def test_record_rollout_intervention_step_appends_observation():
+    runtime, session = _runtime_and_session()
+    runtime.rollout_intervention_active = True
+    runtime.rollout_intervention_active_segment = RolloutInterventionSegment(
+        segment_index=0,
+        start_policy_frame_index=3,
+        pre_intervention_qpos=np.array([0.1, 0.2], dtype=np.float32),
+    )
+    runtime.transport.collection_frames.append(_observation(2.0))
+
+    assert recording.record_rollout_intervention_step(runtime, session) is True
+
+    assert len(runtime.rollout_intervention_active_segment.frames) == 1
+    assert runtime.rollout_intervention_active_segment.frames[0].timestamp == 2.0
+
+
+def test_accept_rollout_intervention_segment_moves_active_to_accepted():
+    runtime, session = _runtime_and_session()
+    session.step_index = 9
+    runtime.rollout_intervention_active_segment = RolloutInterventionSegment(
+        segment_index=0,
+        start_policy_frame_index=3,
+        pre_intervention_qpos=np.array([0.1, 0.2], dtype=np.float32),
+        frames=[_observation(2.0)],
+    )
+
+    assert recording.accept_rollout_intervention_segment(runtime, session) is True
+
+    assert runtime.rollout_intervention_active_segment is None
+    assert len(runtime.rollout_intervention_segments) == 1
+    assert runtime.rollout_intervention_segments[0].resume_policy_frame_index == 9
+
+
+def test_rollback_rollout_intervention_scales_steps_with_joint_distance(monkeypatch):
+    from core.app.handlers import imaging
+
+    runtime, session = _runtime_and_session()
+    runtime.transport.latest_qpos = np.array([0.1, 0.2], dtype=np.float32)
+    runtime.rollout_intervention_pre_qpos = np.array([0.11, 0.2], dtype=np.float32)
+    observed_steps = []
+
+    def fake_build_linear_trajectory(current, target, steps):
+        observed_steps.append(steps)
+        return np.asarray([current, target], dtype=np.float32)
+
+    monkeypatch.setattr(imaging, "build_linear_trajectory", fake_build_linear_trajectory)
+
+    assert recording.rollback_rollout_intervention(_config(), runtime, session) is True
+
+    assert observed_steps == [2]
+    assert len(runtime.transport.published) == 1
+    np.testing.assert_allclose(runtime.transport.published[0][1], [0.11, 0.2])
+
+
+def test_console_halt_starts_intervention_without_ending_rollout(monkeypatch):
+    calls = []
+    runtime, session = _runtime_and_session()
+    session.mode = SessionMode.REAL
+    session.status = SessionStatus.RUNNING
+    runtime.rollout_save_ready = False
+
+    monkeypatch.setattr(app, "is_replay", lambda runtime: False)
+    monkeypatch.setattr(
+        app,
+        "mark_rollout_save_ready",
+        lambda runtime, reason: calls.append(("save_ready", reason)),
+    )
+    monkeypatch.setattr(
+        app,
+        "start_rollout_intervention",
+        lambda config, runtime, session: calls.append(("intervention", True)) or True,
+    )
+
+    app.handle_command("web:halt", _config(intervention_enabled=True), runtime, session)
+
+    assert session.status is SessionStatus.READY
+    assert calls == [("save_ready", "stop"), ("intervention", True)]
+
+
+def test_operator_button_interrupts_sync_motion_and_starts_intervention():
+    runtime, session = _runtime_and_session()
+    session.mode = SessionMode.REAL
+    session.status = SessionStatus.RUNNING
+    runtime.rollout_episode_logger = _ActiveRolloutLogger()
+    runtime.command_queue = queue.Queue()
+    runtime.command_queue.put("web:operator_button:x:cat")
+
+    interrupted = control.poll_motion_commands(
+        _config(intervention_enabled=True),
+        runtime,
+        session,
+    )
+
+    assert interrupted is True
+    assert session.interrupt_requested is True
+    assert runtime.rollout_intervention_active is True
+    assert runtime.rollout_save_ready is True
+    assert runtime.transport.started == 1
+    assert runtime.transport.cleared == 1
+
+
+def test_rollout_stop_stops_without_starting_new_intervention():
+    runtime, session = _runtime_and_session()
+    session.mode = SessionMode.REAL
+    session.status = SessionStatus.RUNNING
+    runtime.rollout_episode_logger = _ActiveRolloutLogger()
+
+    app.handle_command("web:rollout_stop", _config(intervention_enabled=True), runtime, session)
+
+    assert session.status is SessionStatus.READY
+    assert runtime.rollout_save_ready is True
+    assert runtime.rollout_intervention_active is False
+    assert runtime.transport.started == 0
+
+
+def test_rollout_stop_interrupts_sync_motion_and_marks_save_ready():
+    runtime, session = _runtime_and_session()
+    session.mode = SessionMode.REAL
+    session.status = SessionStatus.RUNNING
+    runtime.rollout_episode_logger = _ActiveRolloutLogger()
+    runtime.command_queue = queue.Queue()
+    runtime.command_queue.put("web:rollout_stop")
+
+    interrupted = control.poll_motion_commands(
+        _config(intervention_enabled=True),
+        runtime,
+        session,
+    )
+
+    assert interrupted is True
+    assert session.interrupt_requested is True
+    assert runtime.rollout_save_ready is True
+    assert runtime.rollout_intervention_active is False
+    assert runtime.transport.started == 0
+
+
+def test_console_rollout_intervention_mode_sets_transport():
+    runtime, session = _runtime_and_session()
+
+    app.handle_command(
+        "web:rollout_intervention_mode:relative",
+        _config(intervention_enabled=True),
+        runtime,
+        session,
+    )
+
+    assert runtime.hil_control_mode == "relative"
+    assert runtime.transport.hil_modes == ["relative"]
+    assert session.last_error == ""
+
+
+def test_rollout_save_rejects_active_intervention(monkeypatch):
+    calls = []
+    runtime, session = _runtime_and_session()
+    runtime.rollout_intervention_active = True
+
+    monkeypatch.setattr(
+        app,
+        "save_rollout_episode",
+        lambda runtime, session: calls.append(("save", True)),
+    )
+
+    app.handle_command("web:rollout_save", _config(intervention_enabled=True), runtime, session)
+
+    assert calls == []
+    assert session.last_error == "Continue or abandon the active intervention before saving"

--- a/tests/config/test_operator_control.py
+++ b/tests/config/test_operator_control.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import queue
+
+import numpy as np
+
+from core.app.operator_control import resolve_operator_event
+from core.app.state import RuntimeState, SessionMode, SessionState, SessionStatus
+from core.config import ConfigDict
+from robots.base import ActuatorGroup, CameraSpec, ObservationSchema, Robot
+
+
+class _Transport:
+    def supports_collection(self) -> bool:
+        return True
+
+
+class _Logger:
+    def __init__(self, *, collecting: bool = False, active_frames: int = 0) -> None:
+        self._collecting = collecting
+        self.active_frame_count = active_frames
+
+    @property
+    def has_active_episode(self) -> bool:
+        return self._collecting
+
+    @property
+    def is_collection_enabled(self) -> bool:
+        return True
+
+    def is_queue_full(self) -> bool:
+        return False
+
+
+def _robot() -> Robot:
+    return Robot(
+        name="fake",
+        actuator_groups=(ActuatorGroup("arm", 2, ("j0", "j1")),),
+        initial_qpos=np.zeros(2, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam"),),
+            state_composition=("arm",),
+        ),
+    )
+
+
+def _runtime() -> RuntimeState:
+    runtime = RuntimeState(robot=_robot(), transport=_Transport())
+    runtime.command_queue = queue.Queue()
+    return runtime
+
+
+def _config() -> ConfigDict:
+    return ConfigDict(
+        operator_control=ConfigDict(enabled=True, button_topic="/eva/operator_button"),
+        collection=ConfigDict(schema=ConfigDict(columns={"qpos": "state"})),
+        rollout=ConfigDict(intervention=ConfigDict(enabled=True)),
+    )
+
+
+def test_operator_start_in_collect_ready_starts_collection():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.COLLECT, status=SessionStatus.READY)
+    runtime.episode_logger = _Logger(collecting=False)
+
+    command = resolve_operator_event(_config(), runtime, session, intent="start", source="ui")
+
+    assert command == "web:collect_start"
+    assert session.last_error == ""
+
+
+def test_operator_accept_in_collect_recording_stops_and_saves_collection():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.COLLECT, status=SessionStatus.RUNNING)
+    runtime.episode_logger = _Logger(collecting=True)
+
+    command = resolve_operator_event(_config(), runtime, session, intent="accept", source="ui")
+
+    assert command == "web:collect_stop"
+    assert session.last_error == ""
+
+
+def test_operator_cancel_in_collect_recording_cancels_collection():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.COLLECT, status=SessionStatus.RUNNING)
+    runtime.episode_logger = _Logger(collecting=True)
+
+    command = resolve_operator_event(_config(), runtime, session, intent="cancel", source="cat")
+
+    assert command == "web:collect_cancel"
+    assert session.last_error == ""
+
+
+def test_operator_start_while_policy_running_enters_intervention():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.RUNNING)
+
+    command = resolve_operator_event(_config(), runtime, session, intent="start", source="cat")
+
+    assert command == "web:halt"
+
+
+def test_operator_accept_in_intervention_resumes_policy():
+    runtime = _runtime()
+    runtime.rollout_intervention_active = True
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(_config(), runtime, session, intent="accept", source="cat")
+
+    assert command == "web:run"
+
+
+def test_operator_cancel_in_intervention_abandons_segment():
+    runtime = _runtime()
+    runtime.rollout_intervention_active = True
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(_config(), runtime, session, intent="cancel", source="cat")
+
+    assert command == "web:rollout_intervention_abandon"
+
+
+def test_operator_accept_when_rollout_ready_saves_rollout():
+    runtime = _runtime()
+    runtime.rollout_save_ready = True
+    runtime.rollout_episode_logger = _Logger(active_frames=3)
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(_config(), runtime, session, intent="accept", source="ui")
+
+    assert command == "web:rollout_save"
+
+
+def test_x_button_maps_to_cancel_when_collect_recording():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.COLLECT, status=SessionStatus.RUNNING)
+    runtime.episode_logger = _Logger(collecting=True)
+
+    command = resolve_operator_event(_config(), runtime, session, button="x", source="cat")
+
+    assert command == "web:collect_cancel"
+
+
+def test_operator_gripper_button_uses_standard_semantic_event():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(
+        _config(), runtime, session, button="right_gripper_close", source="hardware"
+    )
+
+    assert command == "web:gripper:r:close:0"
+    assert session.last_error == ""
+
+
+def test_x_button_maps_to_start_when_collect_ready():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.COLLECT, status=SessionStatus.READY)
+    runtime.episode_logger = _Logger(collecting=False)
+
+    command = resolve_operator_event(_config(), runtime, session, button="x", source="cat")
+
+    assert command == "web:collect_start"
+
+
+def test_y_button_maps_to_accept():
+    runtime = _runtime()
+    runtime.rollout_intervention_active = True
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(_config(), runtime, session, button="y", source="cat")
+
+    assert command == "web:run"
+
+
+def test_x_button_maps_to_halt_while_policy_running():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.RUNNING)
+
+    command = resolve_operator_event(_config(), runtime, session, button="x", source="cat")
+
+    assert command == "web:halt"
+    assert session.last_error == ""
+
+
+def test_x_button_maps_to_abandon_when_intervention_active():
+    runtime = _runtime()
+    runtime.rollout_intervention_active = True
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(_config(), runtime, session, button="x", source="cat")
+
+    assert command == "web:rollout_intervention_abandon"
+    assert session.last_error == ""
+
+
+def test_y_button_maps_to_rollout_save_when_save_ready():
+    runtime = _runtime()
+    runtime.rollout_save_ready = True
+    runtime.rollout_episode_logger = _Logger(active_frames=3)
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(_config(), runtime, session, button="y", source="cat")
+
+    assert command == "web:rollout_save"
+    assert session.last_error == ""
+
+
+def test_gripper_buttons_map_to_immediate_unlocked_gripper_commands():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(
+        _config(), runtime, session, button="left_gripper_open", source="cat"
+    )
+
+    assert command == "web:gripper:l:open:0"
+    assert session.last_error == ""
+
+
+def test_right_gripper_close_button_maps_to_right_close_command():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.REAL, status=SessionStatus.READY)
+
+    command = resolve_operator_event(
+        _config(), runtime, session, button="right_gripper_close", source="cat"
+    )
+
+    assert command == "web:gripper:r:close:0"
+    assert session.last_error == ""
+
+
+def test_invalid_operator_event_sets_explicit_error():
+    runtime = _runtime()
+    session = SessionState(mode=SessionMode.SELECT, status=SessionStatus.UNSET)
+
+    command = resolve_operator_event(_config(), runtime, session, intent="accept", source="ui")
+
+    assert command is None
+    assert session.last_error == "Operator action 'accept' is not valid in mode=select status=unset"

--- a/tests/integration/web/test_console_camera_api.py
+++ b/tests/integration/web/test_console_camera_api.py
@@ -23,7 +23,13 @@ import numpy as np
 import pytest
 from _harness import WebHarness, build_runtime, console_config
 
-from core.app.console.server import ConsoleContext, ConsoleRequestHandler, _serialize_frame
+from core.app.console.server import (
+    ConsoleContext,
+    ConsoleRequestHandler,
+    _camera_jpeg_payload,
+    _serialize_frame,
+    _serialize_status,
+)
 
 
 def test_frame_carries_telemetry_not_image_bytes(console: WebHarness):
@@ -35,6 +41,32 @@ def test_frame_carries_telemetry_not_image_bytes(console: WebHarness):
     assert frame["cameras"] == ["cam_high", "cam_left_wrist", "cam_right_wrist"]
     for key in frame["cameras"]:
         assert isinstance(key, str)
+
+
+def test_status_reports_image_min_hz_from_observation_reader():
+    config = console_config()
+    runtime, session = build_runtime(config)
+
+    class _Reader:
+        def seconds_since_last_recv(self):
+            return 0.0
+
+        def image_min_hz(self):
+            return 14.25
+
+    try:
+        status = _serialize_status(
+            ConsoleContext(
+                config=config,
+                runtime=runtime,
+                session=session,
+                obs_reader=_Reader(),  # type: ignore[reportArgumentType]
+            )
+        )
+    finally:
+        runtime.transport.close()
+
+    assert status["image_min_hz"] == 14.25
 
 
 def test_frame_uses_live_camera_keys_when_reader_reports_them():
@@ -172,3 +204,25 @@ def test_camera_stream_is_multipart_mjpeg(console: WebHarness):
     # At least one part boundary + a JPEG content-type arrives in the first read window.
     assert b"--evaframe" in buf
     assert b"image/jpeg" in buf
+
+
+def test_camera_jpeg_payload_prefers_reader_jpeg(monkeypatch):
+    payload = b"\xff\xd8raw-jpeg\xff\xd9"
+
+    class _Reader:
+        def get_camera_jpeg(self, key: str):
+            assert key == "cam_high"
+            return payload
+
+        def get_camera_frame(self, _key: str):
+            raise AssertionError("raw JPEG path should not decode frames")
+
+    def fail_encode(_image, _convert_bgr_to_rgb):
+        raise AssertionError("raw JPEG path should not encode frames")
+
+    monkeypatch.setattr("core.app.console.server._encode_jpeg", fail_encode)
+
+    jpeg, sig = _camera_jpeg_payload(_Reader(), "cam_high", convert_bgr_to_rgb=True)
+
+    assert jpeg == payload
+    assert sig is not None

--- a/tests/integration/web/test_console_state_machine.py
+++ b/tests/integration/web/test_console_state_machine.py
@@ -63,6 +63,24 @@ def test_single_gripper_config_exposes_one_gripper_control(console):
     assert controls == [{"side": "l", "label": "GRIPPER", "group": "arm"}]
 
 
+@pytest.mark.parametrize(
+    "console",
+    [
+        console_config(
+            robot=dict(type="r1_lite", gripper_open=100.0, gripper_close=0.0)
+        )
+    ],
+    indirect=True,
+)
+def test_r1lite_manual_qpos_limits_expose_full_gripper_range(console):
+    limits = console.get("/api/config").json["manual_qpos_limits"]
+
+    assert len(limits) == 14
+    assert limits[0] == {"min": -3.2, "max": 3.2, "step": 0.005}
+    assert limits[6] == {"min": 0.0, "max": 100.0, "step": 0.1}
+    assert limits[13] == {"min": 0.0, "max": 100.0, "step": 0.1}
+
+
 def test_reselecting_mode_clears_completed_setup(console):
     console.do("/api/connect")
     console.do("/api/select_mode", {"mode": "sim"})
@@ -145,10 +163,12 @@ def test_tab_switch_away_from_collect_stops_armed_teleop():
         policy=None,
         ik_solver=None,
         web_phase="idle",
+        rollout_intervention_active=False,
     )
     session = SessionState(mode=SessionMode.COLLECT, status=SessionStatus.READY)
+    config = ConfigDict(collection=ConfigDict(gate=ConfigDict(enabled=False)))
 
-    app.handle_command("web:tab_switch:manual", ConfigDict(), cast(RuntimeState, runtime), session)
+    app.handle_command("web:tab_switch:manual", config, cast(RuntimeState, runtime), session)
 
     assert calls == ["stop_collection"]
     assert runtime.collection_teleop_active is False
@@ -167,6 +187,57 @@ def test_tab_switch_to_eval_restores_config_mode(console):
     console.post("/api/tab_switch", {"tab": "eval"})
     console.pump()
     assert console.session.mode is SessionMode.REAL
+
+
+@pytest.mark.parametrize(
+    "console",
+    [
+        console_config(
+            eval=ConfigDict(
+                cli_mode="sim",
+                inference_strategy="sync",
+                reset_after_each_trial=False,
+                skip_warmup_after_first=False,
+                checkpoints=(),
+                tasks=(
+                    ConfigDict(prompt_en="pick up the cup"),
+                    ConfigDict(prompt_en="pour soybean"),
+                ),
+            )
+        )
+    ],
+    indirect=True,
+)
+def test_eval_stop_can_switch_prompt_and_start_next_rollout(console):
+    first_prompt = "pick up the cup"
+    second_prompt = "pour soybean"
+    console.do("/api/connect")
+    console.do("/api/select_mode", {"mode": "sim"})
+    console.do("/api/select_task", {"task": first_prompt})
+    console.do("/api/setup")
+    console.runtime.web_phase = "ready"
+
+    console.do(
+        "/api/eval_start",
+        {"clip_id": "clip-1", "prompt": first_prompt, "trial": 1},
+    )
+    for _ in range(5):
+        handlers.publish_next_action(console.config, console.runtime, console.session)
+    console.do("/api/eval_stop")
+    assert console.session.status is SessionStatus.READY
+    assert console.session.step_index == 5
+    assert console.runtime.needs_pre_start_reset is True
+
+    console.do("/api/select_task", {"task": second_prompt})
+    console.do(
+        "/api/eval_start",
+        {"clip_id": "clip-2", "prompt": second_prompt, "trial": 1},
+    )
+
+    assert console.status()["session_status"] == "running"
+    assert console.session.selected_task == second_prompt
+    assert console.session.step_index == 0
+    assert console.runtime.needs_pre_start_reset is False
 
 
 def test_collect_loop_uses_publish_rate_without_dataset_fps():
@@ -436,12 +507,45 @@ def test_collection_replay_status_stops_playing_at_last_frame():
         assert replay["frame_index"] == 1
 
 
-def test_collect_step_yields_after_budgeted_collection_snapshots():
-    budget = 16
-    snapshots = [object() for _ in range(budget + 3)]
+def test_collect_step_collection_capture_is_background_only():
+    class _Transport:
+        def __init__(self):
+            self.acquired = 0
+
+        def acquire_collection_raw(self):
+            self.acquired += 1
+            return object()
+
+    class _Logger:
+        is_collection_enabled = True
+
+        def ingest_collection_snapshot(self, snapshot):
+            raise AssertionError("collection-enabled collect_step must not ingest")
+
+    transport = _Transport()
+    runtime = SimpleNamespace(episode_logger=_Logger(), transport=transport)
+
+    assert not handlers.collect_step(console_config(), cast(RuntimeState, runtime))
+    assert transport.acquired == 0
+
+
+def test_collect_start_runs_collection_capture_in_background():
+    snapshots = [object(), object(), object()]
     ingested = []
 
     class _Transport:
+        def supports_collection(self):
+            return True
+
+        def start_collection(self):
+            return None
+
+        def reset_hil_control(self):
+            return None
+
+        def clear_collection_backlog(self):
+            return 42.0
+
         def acquire_collection_raw(self):
             if snapshots:
                 return snapshots.pop(0)
@@ -450,14 +554,37 @@ def test_collect_step_yields_after_budgeted_collection_snapshots():
     class _Logger:
         is_collection_enabled = True
 
+        def is_queue_full(self):
+            return False
+
+        def start_episode(self, *, task, collection_min_capture_time=None):
+            return None
+
         def ingest_collection_snapshot(self, snapshot):
             ingested.append(snapshot)
 
-    runtime = SimpleNamespace(episode_logger=_Logger(), transport=_Transport())
+        def end_episode(self):
+            return True
 
-    assert handlers.collect_step(console_config(), cast(RuntimeState, runtime))
-    assert len(ingested) == budget
-    assert len(snapshots) == 3
+    runtime = SimpleNamespace(
+        episode_logger=_Logger(),
+        transport=_Transport(),
+        collection_replay_qpos=None,
+        collection_replay_episode=None,
+        collection_teleop_armed=True,
+        collection_teleop_active=False,
+        last_collection_timestamp=None,
+    )
+    session = SessionState(selected_collect_task="pick")
+    config = console_config(inference_cfg=ConfigDict(publish_rate=200))
+
+    assert handlers.collect_start(config, cast(RuntimeState, runtime), session)
+    deadline = time.monotonic() + 1.0
+    while len(ingested) < 3 and time.monotonic() < deadline:
+        time.sleep(0.005)
+    handlers.collect_stop(config, cast(RuntimeState, runtime), session)
+
+    assert len(ingested) == 3
 
 
 def test_collect_start_clears_backlog_and_passes_cutoff_to_logger():
@@ -470,9 +597,15 @@ def test_collect_start_clears_backlog_and_passes_cutoff_to_logger():
         def start_collection(self):
             calls.append("start_collection")
 
+        def reset_hil_control(self):
+            calls.append("reset_hil_control")
+
         def clear_collection_backlog(self):
             calls.append("clear_collection_backlog")
             return 42.0
+
+        def acquire_collection_raw(self):
+            return None
 
     class _Logger:
         is_collection_enabled = True
@@ -493,16 +626,22 @@ def test_collect_start_clears_backlog_and_passes_cutoff_to_logger():
         last_collection_timestamp=None,
     )
     session = SessionState(selected_collect_task="pick")
+    config = console_config(inference_cfg=ConfigDict(publish_rate=200))
 
-    assert handlers.collect_start(cast(RuntimeState, runtime), session)
-    assert calls == [
-        "start_collection",
-        "clear_collection_backlog",
-        ("start_episode", "pick", 42.0),
-    ]
-    assert session.status is SessionStatus.RUNNING
-    assert runtime.collection_replay_qpos is None
-    assert runtime.collection_replay_episode is None
+    assert handlers.collect_start(config, cast(RuntimeState, runtime), session)
+    try:
+        assert calls == [
+            "reset_hil_control",
+            "start_collection",
+            "clear_collection_backlog",
+            ("start_episode", "pick", 42.0),
+        ]
+        assert session.status is SessionStatus.RUNNING
+        assert runtime.collection_replay_qpos is None
+        assert runtime.collection_replay_episode is None
+    finally:
+        runtime.collection_capture_runner.stop()
+        runtime.collection_capture_runner = None
 
 
 def test_collect_start_requires_activation_gate():
@@ -533,8 +672,9 @@ def test_collect_start_requires_activation_gate():
         collection_teleop_active=False,
     )
     session = SessionState(selected_collect_task="pick")
+    config = ConfigDict(collection=ConfigDict(gate=ConfigDict(enabled=False)))
 
-    assert not handlers.collect_start(cast(RuntimeState, runtime), session)
+    assert not handlers.collect_start(config, cast(RuntimeState, runtime), session)
     assert calls == []
     assert session.last_error == "Collection teleop requires COLLECT activation"
 
@@ -731,7 +871,9 @@ def test_manual_halt_aborts_staged_real_publish():
             return self.rate
 
     transport = _Transport()
+    robot = SimpleNamespace(gripper_mask=(False, False))
     runtime = SimpleNamespace(
+        robot=robot,
         transport=transport,
         command_queue=command_queue,
         prompt_ready=None,
@@ -755,25 +897,14 @@ def test_manual_halt_aborts_staged_real_publish():
     assert not np.allclose(session.manual_real_qpos, session.manual_qpos)
 
 
-def test_manual_tuning_updates_manual_publish_rate_only(console):
-    inference_publish_rate = console.config.inference_cfg.publish_rate
-
-    console.do("/api/update_manual_params", {"publish_rate": 17})
-
-    config = console.runtime.active_config
-    assert config.manual_cfg.publish_rate == 17
-    assert config.inference_cfg.publish_rate == inference_publish_rate
-
-
-def test_manual_send_uses_manual_publish_rate():
+def test_manual_send_publishes_gripper_target_without_joint_step_scaling():
     class _Rate:
         def sleep(self) -> None:
             pass
 
     class _Transport:
         def __init__(self) -> None:
-            self.qpos = np.zeros(2, dtype=np.float32)
-            self.rates: list[float] = []
+            self.qpos = np.zeros(14, dtype=np.float32)
             self.published: list[tuple[str, np.ndarray]] = []
 
         def get_latest_qpos(self) -> np.ndarray:
@@ -785,88 +916,36 @@ def test_manual_send_uses_manual_publish_rate():
             if target == "real":
                 self.qpos = sent
 
-        def create_rate(self, hz: float) -> _Rate:
-            self.rates.append(hz)
+        def create_rate(self, _hz: float) -> _Rate:
             return _Rate()
 
     transport = _Transport()
+    robot = SimpleNamespace(
+        gripper_mask=tuple(i in {6, 13} for i in range(14)),
+    )
     runtime = SimpleNamespace(
+        robot=robot,
         transport=transport,
         command_queue=queue.Queue(),
         prompt_ready=None,
         web_phase="idle",
     )
+    target = np.zeros(14, dtype=np.float32)
+    target[6] = 100.0
     session = SessionState(
         mode=SessionMode.MANUAL,
         status=SessionStatus.UNSET,
-        manual_qpos=np.asarray([handlers.MANUAL_MAX_QPOS_STEP * 2, 0.0], dtype=np.float32),
-        manual_real_qpos=np.zeros(2, dtype=np.float32),
+        manual_qpos=target,
+        manual_real_qpos=np.zeros(14, dtype=np.float32),
     )
-    config = ConfigDict(
-        inference_cfg=ConfigDict(publish_rate=100),
-        manual_cfg=ConfigDict(publish_rate=7),
-    )
+    config = ConfigDict(inference_cfg=ConfigDict(publish_rate=100))
 
     app.handle_command("web:manual_send", config, cast(RuntimeState, runtime), session)
 
-    assert transport.rates == [7]
-    assert transport.published
-
-
-def test_manual_reset_uses_manual_publish_rate():
-    class _Rate:
-        def sleep(self) -> None:
-            pass
-
-    class _Transport:
-        def __init__(self) -> None:
-            self.qpos = np.asarray([1.0, 0.0], dtype=np.float32)
-            self.rates: list[float] = []
-
-        def get_latest_qpos(self) -> np.ndarray:
-            return self.qpos.copy()
-
-        def publish_action(self, action: np.ndarray, target: str = "real") -> None:
-            if target == "real":
-                self.qpos = np.asarray(action, dtype=np.float32).copy()
-
-        def create_rate(self, hz: float) -> _Rate:
-            self.rates.append(hz)
-            return _Rate()
-
-        def has_sim_publishers(self) -> bool:
-            return False
-
-        def is_shutdown(self) -> bool:
-            return False
-
-    transport = _Transport()
-    runtime = SimpleNamespace(
-        transport=transport,
-        command_queue=queue.Queue(),
-        prompt_ready=None,
-        robot=SimpleNamespace(
-            initial_qpos=np.zeros(2, dtype=np.float32),
-            gripper_indices=[],
-        ),
-        init_qpos=None,
-    )
-    session = SessionState(mode=SessionMode.MANUAL)
-    config = ConfigDict(
-        inference_cfg=ConfigDict(publish_rate=100),
-        manual_cfg=ConfigDict(publish_rate=7),
-    )
-
-    ok = handlers.reset_with_setup(
-        config,
-        cast(RuntimeState, runtime),
-        session,
-        OutputTarget.REAL,
-    )
-
-    assert ok is True
-    assert transport.rates == [7]
-    np.testing.assert_allclose(transport.qpos, np.zeros(2, dtype=np.float32))
+    assert len(transport.published) == 1
+    assert transport.published[-1][0] == "real"
+    assert transport.published[-1][1][6] == pytest.approx(100.0)
+    np.testing.assert_allclose(session.manual_real_qpos, target)
 
 
 def test_manual_send_status_returns_to_idle_after_publish(console):
@@ -1014,6 +1093,9 @@ def test_eval_start_skips_setup_when_already_warmed(monkeypatch):
         current_cell={"prompt": "pick up the cup", "trial": 1},
         current_clip_id=None,
         needs_pre_start_reset=False,
+        infer_strategy=None,
+        policy=None,
+        ik_solver=None,
     )
     session = SessionState(
         mode=SessionMode.REAL,
@@ -1029,8 +1111,8 @@ def test_eval_start_skips_setup_when_already_warmed(monkeypatch):
 
 
 def test_eval_start_runs_setup_when_not_warmed(monkeypatch):
-    """The skip is gated: a RUN with no prior SETUP (or after a stop that left the arm
-    un-reset) must still run setup so the home trajectory is sent before publishing."""
+    """The skip is gated: a RUN with no prior SETUP or an explicit deferred reset
+    must still run setup so the home trajectory is sent before publishing."""
     setup_calls = {"n": 0}
 
     def _fake_setup(config, runtime, session, fail_fast=False):
@@ -1040,9 +1122,7 @@ def test_eval_start_runs_setup_when_not_warmed(monkeypatch):
         return True
 
     monkeypatch.setattr(app, "run_setup", _fake_setup)
-    monkeypatch.setattr(
-        app, "_dispatch_run", lambda *a: setattr(a[2], "status", SessionStatus.RUNNING)
-    )
+    monkeypatch.setattr(app, "_dispatch_run", lambda *a: setattr(a[2], "status", SessionStatus.RUNNING))
 
     runtime = SimpleNamespace(
         web_phase="ready",
@@ -1050,7 +1130,7 @@ def test_eval_start_runs_setup_when_not_warmed(monkeypatch):
         episode_logger=None,
         current_cell={"prompt": "pick up the cup", "trial": 1},
         current_clip_id=None,
-        needs_pre_start_reset=True,  # a prior stop left the arm un-reset
+        needs_pre_start_reset=True,
     )
     session = SessionState(
         mode=SessionMode.REAL,
@@ -1064,7 +1144,40 @@ def test_eval_start_runs_setup_when_not_warmed(monkeypatch):
     assert setup_calls["n"] == 1
 
 
-def test_eval_stop_during_running_motion_is_requeued_and_finalized():
+def test_eval_start_binds_cell_prompt_before_task_gate(monkeypatch):
+    def _fake_setup(config, runtime, session, fail_fast=False):
+        session.is_setup_done = True
+        session.status = SessionStatus.READY
+        return True
+
+    monkeypatch.setattr(app, "run_setup", _fake_setup)
+    monkeypatch.setattr(app, "_dispatch_run", lambda *a: setattr(a[2], "status", SessionStatus.RUNNING))
+
+    runtime = SimpleNamespace(
+        web_phase="ready",
+        replay_source=None,
+        episode_logger=None,
+        current_cell={"prompt": "pick up the cup", "trial": 1},
+        current_clip_id=None,
+        needs_pre_start_reset=False,
+        infer_strategy=None,
+        policy=None,
+        ik_solver=None,
+    )
+    session = SessionState(
+        mode=SessionMode.REAL,
+        status=SessionStatus.READY,
+        is_setup_done=True,
+        selected_task=None,
+    )
+
+    app.handle_command("web:start", ConfigDict(), cast(RuntimeState, runtime), session)
+
+    assert session.selected_task == "pick up the cup"
+    assert session.status is SessionStatus.RUNNING
+
+
+def test_eval_stop_during_running_motion_is_requeued_finalized_and_left_ready():
     command_queue: queue.Queue[str] = queue.Queue()
 
     class _Logger:

--- a/tests/integration/web/test_console_static.py
+++ b/tests/integration/web/test_console_static.py
@@ -52,6 +52,14 @@ def test_console_post_requests_are_serialized():
     assert "postQueue = result.then(() => undefined, () => undefined);" in html
 
 
+def test_telemetry_bar_renders_image_hz_metric():
+    html = console_source()
+
+    assert 'id="t-image-hz"' in html
+    assert "function formatImageHz(hz)" in html
+    assert '$("t-image-hz").textContent = formatImageHz(s.image_min_hz);' in html
+
+
 def test_manual_target_qpos_renders_from_status_without_frame_qpos():
     html = console_source()
 
@@ -63,6 +71,15 @@ def test_manual_target_qpos_renders_from_status_without_frame_qpos():
     )
 
 
+def test_manual_sliders_use_configured_qpos_limits():
+    html = console_source()
+
+    assert "manual_qpos_limits" in html
+    assert "const limits = S.CFG.manual_qpos_limits;" in html
+    assert 'min="${limit.min}" max="${limit.max}" step="${limit.step}"' in html
+    assert 'min="-3.2" max="3.2" step="0.005"' not in html
+
+
 def test_manual_scene_transforms_keep_per_mesh_easing():
     html = console_source()
 
@@ -71,6 +88,15 @@ def test_manual_scene_transforms_keep_per_mesh_easing():
     assert "applyLayer(meshes, command);" in html
     assert "applyLayer(ghostMeshes, payload.ghost);" in html
     assert "mesh.position.lerp(u.tPos, alpha);" in html
+
+
+def test_collect_scene_poll_uses_normal_cadence_during_recording():
+    html = console_source()
+
+    assert "const COLLECT_SCENE_POLL_MS = 80;" in html
+    assert "function scenePollMinIntervalMs()" in html
+    assert "S.STATUS.collect.collecting" in html
+    assert "now - lastScenePollAt < minInterval" in html
 
 
 def test_manual_dispatch_uses_single_send_stop_toggle():
@@ -93,17 +119,8 @@ def test_manual_tuning_exposes_publish_rate_only():
     assert 'id="b-manual-tune-apply"' in html
     assert 'id="manual-tune-status"' in html
     assert '$("b-manual-tune-apply").onclick = applyManualTune;' in html
-    assert 'apiPost("/api/update_manual_params", { publish_rate: publishRate })' in html
+    assert 'apiPost("/api/update_infer_params", { publish_rate: publishRate })' in html
     assert 'id="manual-tune-inference-rate"' not in html
-
-
-def test_manual_panel_order_is_connect_qpos_send_tune():
-    html = console_source()
-    manual = html[html.index('id="view-manual"') :]
-
-    assert manual.index("MANUAL · REAL ROBOT") < manual.index("TARGET QPOS")
-    assert manual.index("TARGET QPOS") < manual.index("DISPATCH")
-    assert manual.index("DISPATCH") < manual.index('id="manual-panel-tune"')
 
 
 def test_collect_qc_does_not_jump_to_replay_tab():
@@ -327,8 +344,12 @@ def test_saved_collect_episode_is_gray_until_manual_qc():
 
     assert 'if (item.qc_verdict === "pass") return "cq-ok";' in body
     assert 'if (item.qc_verdict === "fail") return "cq-fail";' in body
+    assert 'item.quality === "green"' not in body
+    assert 'if (item.quality === "red") return "cq-fail";' in body
     assert 'if (savedEpisodeId(item) != null' not in body
     assert body.rstrip().endswith('return "cq-queued";\n  }')
+    assert "Green means saved" not in html
+    assert "Pass green / fail red" in html
 
 
 def test_selected_batch_qc_episode_is_highlighted():
@@ -337,6 +358,26 @@ def test_selected_batch_qc_episode_is_highlighted():
     assert ".collect-tile.selected" in html
     assert 'if (episode === S.collectReplayEpisode) tile.classList.add("selected");' in html
     assert 'episode === S.collectReplayEpisode ? " selected" : ""' in html
+
+
+def test_collect_queue_click_switches_active_review_episode():
+    html = console_source()
+    start = html.index("function selectCollectEpisode(item)")
+    body = html[start:html.index("function selectRolloutSaveEpisode", start)]
+
+    assert "const replay = S.STATUS.collection_replay || {};" in body
+    assert 'S.reviewKind === "collect" && replay.active' in body
+    assert 'reviewEpisode("collect", item);' in body
+
+
+def test_collect_review_ignores_stale_async_switches():
+    html = console_source()
+    start = html.index("async function reviewEpisode(kind, item)")
+    body = html[start:html.index("async function submitEpisodeQc", start)]
+
+    assert "let reviewRequestId = 0;" in html
+    assert "const requestId = ++reviewRequestId;" in body
+    assert "requestId !== reviewRequestId" in body
 
 
 def test_collect_replay_toggle_starts_and_stops_selected_episode():
@@ -374,8 +415,67 @@ def test_collect_fourth_stage_is_quality_check():
 def test_stopped_run_button_switches_to_continue_icon():
     html = console_source()
 
-    assert "const continueRun = !running && (s.step_index || 0) > 0;" in html
-    assert '$(ids.run).textContent = continueRun ? "CONTINUE ▶▶" : "RUN ▶";' in html
+    assert "const intervention = !!s.rollout_intervention_active;" in html
+    assert "const continueRun = !running && ((s.step_index || 0) > 0 || intervention);" in html
+    assert 'run.querySelector(".rec-label").textContent = running' in html
+    assert '? "STOP ■"' in html
+    assert ': (intervention ? "RESUME ▶" : (continueRun ? "CONTINUE ▶▶" : "RUN ▶"));' in html
+
+
+def test_rollout_intervention_abandon_controls_are_wired():
+    html = console_source()
+    server_source = (
+        Path(__file__).resolve().parents[3] / "src" / "core" / "app" / "console" / "server.py"
+    ).read_text()
+
+    assert 'id="b-rollout-intervention-abandon"' in html
+    assert 'apiPost("/api/operator_action", { intent: "cancel" })' in html
+    assert (
+        '"/api/rollout_intervention_abandon": "web:rollout_intervention_abandon"'
+        in server_source
+    )
+    assert '"/api/rollout_stop": "web:rollout_stop"' in server_source
+    assert "save_blocked_by_intervention" in html
+    assert "accepted_intervention_segments" in html
+
+
+def test_debug_hil_control_mode_is_wired():
+    html = console_source()
+    server_source = (
+        Path(__file__).resolve().parents[3] / "src" / "core" / "app" / "console" / "server.py"
+    ).read_text()
+
+    assert 'id="hil-control-mode"' in html
+    assert 'apiPost("/api/rollout_intervention_mode"' in html
+    assert "hil_control_mode" in html
+    assert "hil_control_modes" in html
+    assert '"hil_control_mode": r.hil_control_mode' in server_source
+    assert '"/api/rollout_intervention_mode"' in server_source
+
+
+def test_operator_action_api_is_wired():
+    server_source = (
+        Path(__file__).resolve().parents[3] / "src" / "core" / "app" / "console" / "server.py"
+    ).read_text()
+
+    assert '"/api/operator_action": ConsoleRequestHandler._post_operator_action' in server_source
+    assert 'self._enqueue_ok(f"web:operator_action:{intent}:ui")' in server_source
+
+
+def test_collect_and_rollout_controls_use_operator_action():
+    html = console_source()
+
+    assert 'apiPost("/api/operator_action", { intent: "start" })' in html
+    assert 'apiPost("/api/operator_action", { intent: "accept" })' in html
+    assert 'apiPost("/api/operator_action", { intent: "cancel" })' in html
+    assert (
+        '$("b-rollout-save").onclick = () => '
+        'apiPost("/api/operator_action", { intent: "accept" });'
+    ) in html
+    assert (
+        '$("b-rollout-intervention-abandon").onclick = () => '
+        'apiPost("/api/operator_action", { intent: "cancel" });'
+    ) in html
 
 
 def test_step_control_has_single_dynamic_instruction_line():
@@ -399,13 +499,19 @@ def test_tab_order_places_manual_and_collect_before_replay():
 def test_task_and_strategy_controls_are_dropdown_selects():
     html = console_source()
 
-    assert '<select class="choice-select task-select" id="prompt-list" aria-label="Task"></select>' in html
     assert (
-        '<select class="choice-select task-select" id="collect-prompt-list" aria-label="Collection task"></select>'
+        '<select class="choice-select task-select" id="prompt-list" '
+        'aria-label="Task"></select>'
         in html
     )
     assert (
-        '<select class="choice-select task-select" id="eval-prompt-list" aria-label="Evaluation task"></select>'
+        '<select class="choice-select task-select" id="collect-prompt-list" '
+        'aria-label="Collection task"></select>'
+        in html
+    )
+    assert (
+        '<select class="choice-select task-select" id="eval-prompt-list" '
+        'aria-label="Evaluation task"></select>'
         in html
     )
     assert (
@@ -508,7 +614,11 @@ def test_eval_unscored_trial_hint_is_english_and_not_shown_after_save_next():
     assert "（无备注）" not in html
     assert "(no note)" in html
     assert "EVAL_SHOW_UNSCORABLE_HINT && EVAL_PROMPT && !scorable" in html
-    assert "EVAL_SHOW_UNSCORABLE_HINT = false;\n        EVAL_TRIAL = saved < n ? saved + 1 : saved;" in html
+    assert (
+        "EVAL_SHOW_UNSCORABLE_HINT = false;\n"
+        "        EVAL_TRIAL = saved < n ? saved + 1 : saved;"
+        in html
+    )
 
 
 def test_eval_stop_latches_stopping_until_backend_settles():

--- a/tests/integration/web/test_replay_runtime.py
+++ b/tests/integration/web/test_replay_runtime.py
@@ -10,8 +10,8 @@ from _harness import console_config
 
 import robots  # noqa: F401
 from core.app import handlers
-from core.app import run as app
 from core.app.handlers import control as control_handlers
+from core.app import run as app
 from core.app.handlers.space import build_space
 from core.app.state import RuntimeState, SessionMode, SessionState, SessionStatus
 from core.config import ConfigDict
@@ -539,3 +539,23 @@ def test_joint_replay_does_not_treat_plain_action_as_missing_gripper(monkeypatch
 
     np.testing.assert_allclose(action, np.zeros(7, dtype=np.float32))
     assert runtime.ik_solver is None
+
+
+def test_joint_replay_snaps_gripper_to_configured_open_value():
+    runtime = RuntimeState(
+        robot=ROBOT_REGISTRY.build("r1_lite"),
+        transport=_FakeTransport(),
+    )
+    runtime.replay_trajectory = np.asarray(
+        [[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0]],
+        dtype=np.float32,
+    )
+    runtime.replay_action_mode = "joint"
+    config = _joint_config("r1_lite")
+    config.robot.gripper_threshold = 50.0
+    config.robot.gripper_open = 100.0
+    config.robot.gripper_close = 0.0
+
+    action = handlers._replay_action_at(config, runtime, 0)
+
+    np.testing.assert_allclose(action[[6, 13]], [100.0, 100.0], atol=1e-6)

--- a/tests/integration/web/test_replay_transforms.py
+++ b/tests/integration/web/test_replay_transforms.py
@@ -59,9 +59,5 @@ def test_arx_r5_dual_arm_scene_keeps_shared_urdf_parts_separate():
     arms = scene.transforms(None)
     assert set(arms) == {"left_arm", "right_arm"}
     assert set(arms["left_arm"]) == set(arms["right_arm"])
-    np.testing.assert_allclose(
-        np.asarray(arms["left_arm"]["base_link.STL"])[:3, 3], [-0.25, 0.0, 0.0]
-    )
-    np.testing.assert_allclose(
-        np.asarray(arms["right_arm"]["base_link.STL"])[:3, 3], [0.25, 0.0, 0.0]
-    )
+    np.testing.assert_allclose(np.asarray(arms["left_arm"]["base_link.STL"])[:3, 3], [-0.25, 0.0, 0.0])
+    np.testing.assert_allclose(np.asarray(arms["right_arm"]["base_link.STL"])[:3, 3], [0.25, 0.0, 0.0])

--- a/tests/recorder/test_collection_alignment.py
+++ b/tests/recorder/test_collection_alignment.py
@@ -1,0 +1,585 @@
+from __future__ import annotations
+
+import numpy as np
+
+from core.recorder.collection_alignment import align_collection_samples
+from core.types import CollectionRawBatch, CollectionRawImage, CollectionRawSample
+from robots.base import ActuatorGroup, CameraSpec, ObservationSchema, Robot
+
+
+def _robot() -> Robot:
+    return Robot(
+        name="fake",
+        actuator_groups=(ActuatorGroup("arm", 3, ("j0", "j1", "gripper"), gripper_index=2),),
+        initial_qpos=np.zeros(3, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam_high"),),
+            state_composition=("arm",),
+        ),
+    )
+
+
+def _sample(timestamp: float, value) -> CollectionRawSample:
+    return CollectionRawSample(timestamp=timestamp, value=value)
+
+
+def test_align_collection_samples_interpolates_vectors_on_fixed_grid():
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(1.00, np.full((2, 2, 3), 10, dtype=np.uint8)),
+                _sample(1.10, np.full((2, 2, 3), 20, dtype=np.uint8)),
+                _sample(1.20, np.full((2, 2, 3), 30, dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                _sample(1.00, np.array([0.0, 0.0, 0.0], dtype=np.float32)),
+                _sample(1.20, np.array([2.0, 4.0, 1.0], dtype=np.float32)),
+            ],
+            "action_qpos": [
+                _sample(1.00, np.array([10.0, 20.0, 0.0], dtype=np.float32)),
+                _sample(1.20, np.array([12.0, 24.0, 1.0], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos", "action_qpos"),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert [frame.timestamp for frame in frames] == [1.0, 1.1, 1.2]
+    np.testing.assert_allclose(frames[1].state_qpos, [1.0, 2.0, 0.0])
+    np.testing.assert_allclose(frames[1].action_qpos, [11.0, 22.0, 0.0])
+    assert frames[1].images["cam_high"][0, 0, 0] == 20
+    assert report.issues == []
+
+
+def test_align_collection_samples_decodes_lazy_image_only_when_selected():
+    decoded = []
+
+    def lazy(value: int) -> CollectionRawImage:
+        def decode() -> np.ndarray:
+            decoded.append(value)
+            return np.full((2, 2, 3), value, dtype=np.uint8)
+
+        return CollectionRawImage(decode)
+
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, lazy(10)),
+                _sample(0.1, lazy(20)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                _sample(0.0, np.zeros(3, dtype=np.float32)),
+                _sample(0.1, np.ones(3, dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos",),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    assert decoded == [10, 20]
+    assert frames[0].images["cam_high"][0, 0, 0] == 10
+    assert frames[1].images["cam_high"][0, 0, 0] == 20
+
+
+def test_align_collection_samples_reports_missing_required_vector_stream():
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos:arm": [
+                _sample(0.0, np.zeros(3, dtype=np.float32)),
+                _sample(0.1, np.ones(3, dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos", "action_qpos"),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert frames == []
+    assert [(issue.code, issue.detail) for issue in report.issues] == [
+        ("missing_vector_stream", "action_qpos:arm has no samples")
+    ]
+
+
+def test_align_collection_samples_holds_gripper_dimensions_discrete():
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                _sample(0.0, np.array([0.0, 0.0, 0.0], dtype=np.float32)),
+                _sample(0.1, np.array([1.0, 1.0, 1.0], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, _ = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos",),
+        fps=20.0,
+        image_skew_sec=0.06,
+    )
+
+    np.testing.assert_allclose(frames[1].state_qpos, [0.5, 0.5, 0.0])
+    np.testing.assert_allclose(frames[2].state_qpos, [1.0, 1.0, 1.0])
+
+
+def test_align_collection_samples_reports_image_skew_over_one_hz_tolerance():
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.2, np.ones((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                _sample(0.0, np.zeros(3, dtype=np.float32)),
+                _sample(0.2, np.ones(3, dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos",),
+        fps=10.0,
+        image_skew_sec=1.0 / (2.0 * 9.0),
+    )
+
+    assert [frame.timestamp for frame in frames] == [0.0, 0.1, 0.2]
+    assert [issue.code for issue in report.issues] == ["image_skew_exceeded"]
+    assert "cam_high" in report.issues[0].detail
+    assert "0.100000" in report.issues[0].detail
+
+
+def test_align_collection_samples_reports_raw_image_gap_stats():
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.00, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.02, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.04, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.24, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                _sample(0.0, np.zeros(3, dtype=np.float32)),
+                _sample(0.24, np.ones(3, dtype=np.float32)),
+            ],
+        },
+    )
+
+    _frames, report = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos",),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    stats = report.image_stream_stats["cam_high"]
+    assert stats["sample_count"] == 4
+    assert stats["estimated_hz"] == 12.5
+    assert stats["max_gap_sec"] == 0.20
+    assert stats["p99_gap_sec"] == 0.20
+    assert stats["gaps_over_tolerance"] == 1
+    assert stats["max_gap_start_time"] == 0.04
+    assert stats["max_gap_end_time"] == 0.24
+
+
+def test_align_collection_samples_concatenates_group_vector_streams():
+    robot = Robot(
+        name="fake_dual",
+        actuator_groups=(
+            ActuatorGroup("left", 2, ("l0", "l1")),
+            ActuatorGroup("right", 2, ("r0", "r1")),
+        ),
+        initial_qpos=np.zeros(4, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam_high"),),
+            state_composition=("left", "right"),
+        ),
+    )
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos:left": [
+                _sample(0.0, np.array([0.0, 1.0], dtype=np.float32)),
+                _sample(0.1, np.array([1.0, 2.0], dtype=np.float32)),
+            ],
+            "state_qpos:right": [
+                _sample(0.0, np.array([10.0, 11.0], dtype=np.float32)),
+                _sample(0.1, np.array([11.0, 12.0], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=robot,
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos",),
+        fps=20.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    np.testing.assert_allclose(frames[1].state_qpos, [0.5, 1.5, 10.5, 11.5])
+
+
+def test_align_collection_samples_interpolates_arm_and_holds_group_gripper():
+    robot = Robot(
+        name="fake_gripper",
+        actuator_groups=(
+            ActuatorGroup(
+                "arm",
+                7,
+                ("j0", "j1", "j2", "j3", "j4", "j5", "gripper"),
+                gripper_index=6,
+            ),
+        ),
+        initial_qpos=np.zeros(7, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam_high"),),
+            state_composition=("arm",),
+        ),
+    )
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.2, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos:arm": [
+                _sample(0.0, np.array([0, 0, 0, 0, 0, 0], dtype=np.float32)),
+                _sample(0.2, np.array([2, 4, 6, 8, 10, 12], dtype=np.float32)),
+            ],
+            "gripper:state_qpos:arm": [
+                _sample(0.0, np.array([100], dtype=np.float32)),
+                _sample(0.15, np.array([0], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=robot,
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos",),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    assert [frame.timestamp for frame in frames] == [0.0, 0.1, 0.2]
+    np.testing.assert_allclose(frames[1].state_qpos, [1, 2, 3, 4, 5, 6, 100])
+    np.testing.assert_allclose(frames[2].state_qpos, [2, 4, 6, 8, 10, 12, 0])
+
+
+def test_align_collection_samples_normalizes_mixed_group_gripper_shapes():
+    robot = Robot(
+        name="fake_gripper",
+        actuator_groups=(
+            ActuatorGroup(
+                "arm",
+                7,
+                ("j0", "j1", "j2", "j3", "j4", "j5", "gripper"),
+                gripper_index=6,
+            ),
+        ),
+        initial_qpos=np.zeros(7, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam_high"),),
+            state_composition=("arm",),
+        ),
+    )
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.2, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "action_qpos:arm": [
+                _sample(0.0, np.array([0, 0, 0, 0, 0, 0], dtype=np.float32)),
+                _sample(0.1, np.array([1, 2, 3, 4, 5, 6, 100], dtype=np.float32)),
+                _sample(0.2, np.array([2, 4, 6, 8, 10, 12, 0], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=robot,
+        camera_keys=("cam_high",),
+        vector_fields=("action_qpos",),
+        fps=20.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    np.testing.assert_allclose([frame.timestamp for frame in frames], [0.0, 0.05, 0.1, 0.15, 0.2])
+    np.testing.assert_allclose(frames[1].action_qpos, [0.5, 1, 1.5, 2, 2.5, 3, 0])
+    np.testing.assert_allclose(frames[3].action_qpos, [1.5, 3, 4.5, 6, 7.5, 9, 100])
+
+
+def test_align_collection_samples_holds_initial_gripper_when_stream_missing():
+    robot = Robot(
+        name="fake_gripper",
+        actuator_groups=(
+            ActuatorGroup(
+                "arm",
+                7,
+                ("j0", "j1", "j2", "j3", "j4", "j5", "gripper"),
+                gripper_index=6,
+            ),
+        ),
+        initial_qpos=np.array([0, 0, 0, 0, 0, 0, 42], dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam_high"),),
+            state_composition=("arm",),
+        ),
+    )
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos:arm": [
+                _sample(0.0, np.array([0, 0, 0, 0, 0, 0], dtype=np.float32)),
+                _sample(0.1, np.array([1, 2, 3, 4, 5, 6], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=robot,
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos",),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    np.testing.assert_allclose(frames[1].state_qpos, [1, 2, 3, 4, 5, 6, 42])
+
+
+def test_align_collection_samples_does_not_crop_start_to_first_gripper_sample():
+    robot = Robot(
+        name="fake_gripper",
+        actuator_groups=(
+            ActuatorGroup(
+                "arm",
+                7,
+                ("j0", "j1", "j2", "j3", "j4", "j5", "gripper"),
+                gripper_index=6,
+            ),
+        ),
+        initial_qpos=np.array([0, 0, 0, 0, 0, 0, 42], dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam_high"),),
+            state_composition=("arm",),
+        ),
+    )
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.2, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos:arm": [
+                _sample(0.0, np.array([0, 0, 0, 0, 0, 0], dtype=np.float32)),
+                _sample(0.2, np.array([2, 4, 6, 8, 10, 12], dtype=np.float32)),
+            ],
+            "gripper:state_qpos:arm": [
+                _sample(0.15, np.array([0], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=robot,
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos",),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    assert [frame.timestamp for frame in frames] == [0.0, 0.1, 0.2]
+    np.testing.assert_allclose(frames[0].state_qpos, [0, 0, 0, 0, 0, 0, 42])
+    np.testing.assert_allclose(frames[1].state_qpos, [1, 2, 3, 4, 5, 6, 42])
+    np.testing.assert_allclose(frames[2].state_qpos, [2, 4, 6, 8, 10, 12, 0])
+
+
+def test_align_collection_samples_does_not_extrapolate_action_qpos():
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.2, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                _sample(0.0, np.array([0, 0, 0], dtype=np.float32)),
+                _sample(0.2, np.array([2, 4, 1], dtype=np.float32)),
+            ],
+            "action_qpos": [
+                _sample(0.2, np.array([12, 24, 1], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos", "action_qpos"),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    assert [frame.timestamp for frame in frames] == [0.2]
+    np.testing.assert_allclose(frames[0].action_qpos, [12, 24, 1])
+
+
+def test_align_collection_samples_latches_action_qpos_to_episode_end():
+    batch = CollectionRawBatch(
+        end_time=0.2,
+        images={
+            "cam_high": [
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.2, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                _sample(0.0, np.array([0, 0, 0], dtype=np.float32)),
+                _sample(0.2, np.array([2, 4, 1], dtype=np.float32)),
+            ],
+            "action_qpos": [
+                _sample(0.0, np.array([10, 20, 0], dtype=np.float32)),
+                _sample(0.1, np.array([11, 22, 1], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos", "action_qpos"),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    assert [frame.timestamp for frame in frames] == [0.0, 0.1, 0.2]
+    np.testing.assert_allclose(frames[2].action_qpos, [11, 22, 1])
+
+
+def test_align_collection_samples_respects_episode_start_stop_bounds():
+    batch = CollectionRawBatch(
+        start_time=0.0,
+        end_time=0.2,
+        images={
+            "cam_high": [
+                _sample(-0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.2, np.zeros((2, 2, 3), dtype=np.uint8)),
+                _sample(0.3, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                _sample(-0.1, np.array([-1, -1, 0], dtype=np.float32)),
+                _sample(0.0, np.array([0, 0, 0], dtype=np.float32)),
+                _sample(0.2, np.array([2, 4, 1], dtype=np.float32)),
+                _sample(0.3, np.array([3, 6, 1], dtype=np.float32)),
+            ],
+            "action_qpos": [
+                _sample(-0.1, np.array([9, 18, 0], dtype=np.float32)),
+                _sample(0.0, np.array([10, 20, 0], dtype=np.float32)),
+                _sample(0.2, np.array([12, 24, 0], dtype=np.float32)),
+                _sample(0.3, np.array([13, 26, 1], dtype=np.float32)),
+            ],
+        },
+    )
+
+    frames, report = align_collection_samples(
+        batch,
+        robot=_robot(),
+        camera_keys=("cam_high",),
+        vector_fields=("state_qpos", "action_qpos"),
+        fps=10.0,
+        image_skew_sec=0.06,
+    )
+
+    assert report.issues == []
+    assert [frame.timestamp for frame in frames] == [0.0, 0.1, 0.2]
+    np.testing.assert_allclose(frames[0].state_qpos, [0, 0, 0])
+    np.testing.assert_allclose(frames[-1].action_qpos, [12, 24, 0])

--- a/tests/recorder/test_episode_logger.py
+++ b/tests/recorder/test_episode_logger.py
@@ -10,12 +10,13 @@ import threading
 
 import numpy as np
 import pyarrow.parquet as pq
+import pytest
 
 from core.config import ConfigDict
 from core.recorder import collection as collection_module
 from core.recorder import episode as episode_module
 from core.recorder.episode import EpisodeLogger, sanitize_path_component
-from core.types import Observation, RawCollectionSnapshot
+from core.types import CollectionRawBatch, CollectionRawSample, Observation, RawCollectionSnapshot
 from core.utils.lerobot import LeRobotDatasetIO
 from robots.base import (
     ActuatorGroup,
@@ -40,7 +41,27 @@ def _robot() -> Robot:
     )
 
 
-def _logger(log_dir, *, save_video: bool = False) -> EpisodeLogger:
+def _logger(log_dir, *, save_video: bool = False, fps: int = 30) -> EpisodeLogger:
+    return EpisodeLogger(
+        log_dir,
+        _robot(),
+        fps=fps,
+        dataset_keys=ConfigDict(
+            state_key="observations.state.qpos",
+            eef_key="observations.state.eef",
+            action_key="action",
+            video_keys={},
+        ),
+        async_save=False,
+    )
+
+
+def _rollout_logger(
+    log_dir,
+    *,
+    save_image_height: int | None = None,
+    save_image_width: int | None = None,
+) -> EpisodeLogger:
     return EpisodeLogger(
         log_dir,
         _robot(),
@@ -52,6 +73,8 @@ def _logger(log_dir, *, save_video: bool = False) -> EpisodeLogger:
             video_keys={},
         ),
         async_save=False,
+        save_image_height=save_image_height,
+        save_image_width=save_image_width,
     )
 
 
@@ -109,6 +132,75 @@ def _read_jsonl(path):
     return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
 
 
+def _collection_raw_snapshot(
+    timestamp: float,
+    *,
+    image: np.ndarray | None = None,
+    state: np.ndarray | None = None,
+    action: np.ndarray | None = None,
+    batch: CollectionRawBatch | None = None,
+) -> RawCollectionSnapshot:
+    if batch is None:
+        image_value = (
+            np.zeros((8, 8, 3), dtype=np.uint8) if image is None else np.asarray(image)
+        )
+        state_value = (
+            np.zeros(_DIM, dtype=np.float32)
+            if state is None
+            else np.asarray(state, dtype=np.float32)
+        )
+        action_value = state_value if action is None else np.asarray(action, dtype=np.float32)
+        batch = CollectionRawBatch(
+            images={"cam_high": [CollectionRawSample(timestamp, image_value)]},
+            vectors={
+                "state_qpos": [CollectionRawSample(timestamp, state_value)],
+                "action_qpos": [CollectionRawSample(timestamp, action_value)],
+            },
+        )
+    return RawCollectionSnapshot(timestamp=timestamp, decode_raw=lambda: batch)
+
+
+def _collection_raw_batch(
+    timestamps: tuple[float, ...],
+    *,
+    image: np.ndarray | None = None,
+    state: np.ndarray | None = None,
+    action: np.ndarray | None = None,
+) -> CollectionRawBatch:
+    image_value = np.zeros((8, 8, 3), dtype=np.uint8) if image is None else image
+    state_value = (
+        np.zeros(_DIM, dtype=np.float32) if state is None else np.asarray(state, dtype=np.float32)
+    )
+    action_value = state_value if action is None else np.asarray(action, dtype=np.float32)
+    return CollectionRawBatch(
+        images={"cam_high": [CollectionRawSample(ts, image_value) for ts in timestamps]},
+        vectors={
+            "state_qpos": [CollectionRawSample(ts, state_value) for ts in timestamps],
+            "action_qpos": [CollectionRawSample(ts, action_value) for ts in timestamps],
+        },
+    )
+
+
+def test_raw_collection_snapshot_rejects_decoded_frame_path():
+    qpos = np.zeros(_DIM, dtype=np.float32)
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    with pytest.raises(TypeError):
+        RawCollectionSnapshot(
+            timestamp=0.0,
+            decode=lambda: Observation(
+                timestamp=0.0,
+                images={"cam_high": image},
+                state_qpos=qpos,
+                action_qpos=qpos,
+            ),
+        )
+
+
+def test_collection_logger_has_no_decoded_frame_entrypoint(tmp_path):
+    logger = _collection_logger(tmp_path)
+    assert not hasattr(logger, "record_collection_frame")
+
+
 def test_live_series_streams_in_flight_buffer(tmp_path):
     # live_series exposes the in-memory step buffer (state/action/timestamp) so the
     # console can chart a rollout before it is ever saved. Shape mirrors
@@ -141,6 +233,27 @@ def test_live_series_streams_in_flight_buffer(tmp_path):
     # after the episode ends the buffer is no longer active.
     logger.end_episode()
     assert logger.live_series()["active"] is False
+
+
+def test_rollout_resizes_saved_frames_when_size_set(tmp_path, monkeypatch):
+    frame_shapes = []
+
+    class _Writer:
+        def append_data(self, frame: np.ndarray) -> None:
+            frame_shapes.append(frame.shape)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(episode_module.imageio, "get_writer", lambda *a, **k: _Writer())
+    logger = _rollout_logger(tmp_path, save_image_height=120, save_image_width=160)
+    state = np.zeros(_DIM, dtype=np.float32)
+    logger.start_episode("t")
+    for _ in range(3):
+        logger.record_step(_obs(state, np.zeros((480, 640, 3), dtype=np.uint8)), state)
+
+    assert logger.end_episode() is True
+    assert frame_shapes == [(120, 160, 3)] * 3
 
 
 def test_episode_logger_sync_save_writes_n_rows(tmp_path):
@@ -267,18 +380,15 @@ def test_collection_timestamp_is_ideal_grid_capture_time_keeps_raw(tmp_path):
     qpos = np.zeros(_DIM, dtype=np.float32)
     image = np.zeros((8, 8, 3), dtype=np.uint8)
 
-    raw = [73529.6, 73529.633, 73529.667, 73529.702]
+    raw = [73529.6, 73529.7, 73529.8, 73529.9]
     logger.start_episode("t")
-    for ts in raw:
-        logger.record_collection_frame(
-            Observation(
-                timestamp=ts,
-                images={"cam_high": image},
-                state_qpos=qpos,
-                action_qpos=qpos,
-            )
+    logger.ingest_collection_snapshot(
+        _collection_raw_snapshot(
+            raw[-1],
+            batch=_collection_raw_batch(tuple(raw), image=image, state=qpos, action=qpos),
         )
-    logger.end_episode()
+    )
+    assert logger.end_episode()
 
     task_dir = _collection_task_dir(tmp_path)
     table = pq.read_table(task_dir / "data" / "chunk-000" / "episode_000000.parquet")
@@ -288,21 +398,312 @@ def test_collection_timestamp_is_ideal_grid_capture_time_keeps_raw(tmp_path):
     np.testing.assert_allclose(table.column("capture_time").to_pylist(), raw)
 
 
+def test_collection_raw_batches_align_to_fixed_grid_before_save(tmp_path):
+    logger = _collection_logger(tmp_path)  # fps=10
+    image0 = np.full((8, 8, 3), 10, dtype=np.uint8)
+    image1 = np.full((8, 8, 3), 20, dtype=np.uint8)
+    image2 = np.full((8, 8, 3), 30, dtype=np.uint8)
+
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                CollectionRawSample(1.00, image0),
+                CollectionRawSample(1.10, image1),
+                CollectionRawSample(1.20, image2),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                CollectionRawSample(1.00, np.zeros(_DIM, dtype=np.float32)),
+                CollectionRawSample(1.20, np.full(_DIM, 2.0, dtype=np.float32)),
+            ],
+            "action_qpos": [
+                CollectionRawSample(1.00, np.full(_DIM, 10.0, dtype=np.float32)),
+                CollectionRawSample(1.20, np.full(_DIM, 12.0, dtype=np.float32)),
+            ],
+        },
+    )
+
+    logger.start_episode("t")
+    logger.ingest_collection_snapshot(
+        RawCollectionSnapshot(
+            timestamp=1.2,
+            decode_raw=lambda: batch,
+        )
+    )
+    assert logger.end_episode()
+
+    task_dir = _collection_task_dir(tmp_path)
+    table = pq.read_table(task_dir / "data" / "chunk-000" / "episode_000000.parquet")
+    np.testing.assert_allclose(table.column("timestamp").to_pylist(), [0.0, 0.1, 0.2])
+    np.testing.assert_allclose(table.column("capture_time").to_pylist(), [1.0, 1.1, 1.2])
+    np.testing.assert_allclose(table.column("observation.qpos").to_pylist()[1], [1.0] * _DIM)
+    np.testing.assert_allclose(table.column("action").to_pylist()[1], [11.0] * _DIM)
+
+    episode = _read_jsonl(task_dir / "meta" / "episodes.jsonl")[0]
+    assert episode["quality"] == "green"
+    assert episode["alignment_fps"] == 10.0
+    assert episode["alignment_image_skew_tolerance_sec"] == 1.0 / 18.0
+    assert episode["alignment_image_stream_stats"]["cam_high"]["sample_count"] == 3
+    assert episode["alignment_image_stream_stats"]["cam_high"]["max_gap_sec"] == 0.1
+
+
+def test_record_step_batches_align_to_fixed_grid_before_save(tmp_path):
+    logger = _logger(tmp_path, fps=10)
+    state0 = np.zeros(_DIM, dtype=np.float32)
+    state1 = np.full(_DIM, 2.0, dtype=np.float32)
+    action0 = np.full(_DIM, 10.0, dtype=np.float32)
+    action1 = np.full(_DIM, 12.0, dtype=np.float32)
+
+    logger.start_episode("t")
+    logger.record_step(_obs(state0), action0, timestamp=1.0)
+    logger.record_step(_obs(state1), action1, timestamp=1.2)
+    assert logger.end_episode()
+
+    table = pq.read_table(tmp_path / "data" / "chunk-000" / "episode_000000.parquet")
+    np.testing.assert_allclose(table.column("timestamp").to_pylist(), [0.0, 0.1, 0.2])
+    np.testing.assert_allclose(table.column("capture_time").to_pylist(), [1.0, 1.1, 1.2])
+    np.testing.assert_allclose(
+        table.column("observations.state.qpos").to_pylist()[1], [1.0] * _DIM
+    )
+    np.testing.assert_allclose(table.column("action").to_pylist()[1], [11.0] * _DIM)
+
+    episode = _read_jsonl(tmp_path / "meta" / "episodes.jsonl")[0]
+    assert episode["quality"] == "green"
+    assert episode["alignment_fps"] == 10.0
+
+
+def test_record_step_uses_observation_timestamp_when_present(tmp_path):
+    logger = _logger(tmp_path, fps=10)
+    state0 = np.zeros(_DIM, dtype=np.float32)
+    state1 = np.full(_DIM, 2.0, dtype=np.float32)
+
+    logger.start_episode("t")
+    logger.record_step(Observation(images={}, state_qpos=state0, timestamp=5.0), state0)
+    logger.record_step(Observation(images={}, state_qpos=state1, timestamp=5.2), state1)
+    assert logger.end_episode()
+
+    table = pq.read_table(tmp_path / "data" / "chunk-000" / "episode_000000.parquet")
+    np.testing.assert_allclose(table.column("capture_time").to_pylist(), [5.0, 5.1, 5.2])
+
+
+def test_collection_raw_batches_report_image_skew_qc(tmp_path):
+    logger = _collection_logger(tmp_path)  # fps=10, skew tolerance = 1/(2*9)
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                CollectionRawSample(0.0, np.zeros((8, 8, 3), dtype=np.uint8)),
+                CollectionRawSample(0.2, np.ones((8, 8, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                CollectionRawSample(0.0, np.zeros(_DIM, dtype=np.float32)),
+                CollectionRawSample(0.2, np.ones(_DIM, dtype=np.float32)),
+            ],
+            "action_qpos": [
+                CollectionRawSample(0.0, np.zeros(_DIM, dtype=np.float32)),
+                CollectionRawSample(0.2, np.ones(_DIM, dtype=np.float32)),
+            ],
+        },
+    )
+
+    logger.start_episode("t")
+    logger.ingest_collection_snapshot(
+        RawCollectionSnapshot(
+            timestamp=0.2,
+            decode_raw=lambda: batch,
+        )
+    )
+    assert logger.end_episode()
+
+    task_dir = _collection_task_dir(tmp_path)
+    episode = _read_jsonl(task_dir / "meta" / "episodes.jsonl")[0]
+    assert episode["quality"] == "red"
+    assert episode["alignment_image_max_skew_sec"]["cam_high"] == 0.1
+    assert "image_skew_exceeded" in {
+        issue["code"] for issue in episode["quality_issues"]
+    }
+
+
+def test_collection_raw_end_episode_defers_alignment_and_video_preprocess(
+    tmp_path, monkeypatch
+):
+    logger = _collection_logger(
+        tmp_path,
+        save_video=True,
+        save_image_height=4,
+        save_image_width=6,
+        async_save=True,
+    )
+    monkeypatch.setattr(logger, "_start_save_worker", lambda: None)
+    monkeypatch.setattr(
+        collection_module,
+        "align_collection_samples",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("alignment must run in the save worker")
+        ),
+    )
+    monkeypatch.setattr(
+        collection_module,
+        "resize_direct",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("video preprocessing must run in the save worker")
+        ),
+    )
+    decode_calls = []
+
+    def decode_raw() -> CollectionRawBatch:
+        decode_calls.append("decode")
+        raise AssertionError("raw decode must run in the save worker")
+
+    logger.start_episode("t")
+    logger.ingest_collection_snapshot(
+        RawCollectionSnapshot(
+            timestamp=0.1,
+            decode_raw=decode_raw,
+        )
+    )
+
+    assert logger.end_episode()
+    assert len(logger._save_jobs) == 1
+    assert logger._save_jobs[0].collection_columns is None
+    assert decode_calls == []
+
+
+def test_collection_raw_save_worker_aligns_and_prepares_video(tmp_path, monkeypatch):
+    frame_shapes = []
+
+    class _Writer:
+        def append_data(self, frame: np.ndarray) -> None:
+            frame_shapes.append(frame.shape)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(episode_module.imageio, "get_writer", lambda *a, **k: _Writer())
+    logger = _collection_logger(
+        tmp_path,
+        save_video=True,
+        save_image_height=4,
+        save_image_width=6,
+        async_save=True,
+    )
+    monkeypatch.setattr(logger, "_start_save_worker", lambda: None)
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                CollectionRawSample(1.0, np.full((8, 8, 3), 10, dtype=np.uint8)),
+                CollectionRawSample(1.1, np.full((8, 8, 3), 20, dtype=np.uint8)),
+                CollectionRawSample(1.2, np.full((8, 8, 3), 30, dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos": [
+                CollectionRawSample(1.0, np.zeros(_DIM, dtype=np.float32)),
+                CollectionRawSample(1.2, np.full(_DIM, 2.0, dtype=np.float32)),
+            ],
+            "action_qpos": [
+                CollectionRawSample(1.0, np.full(_DIM, 10.0, dtype=np.float32)),
+                CollectionRawSample(1.2, np.full(_DIM, 12.0, dtype=np.float32)),
+            ],
+        },
+    )
+    decode_calls = []
+
+    def decode_raw() -> CollectionRawBatch:
+        decode_calls.append("decode")
+        return batch
+
+    logger.start_episode("t")
+    logger.ingest_collection_snapshot(
+        RawCollectionSnapshot(
+            timestamp=1.2,
+            decode_raw=decode_raw,
+        )
+    )
+    assert logger.end_episode()
+    job = logger._save_jobs[0]
+    assert job.collection_columns is None
+    assert decode_calls == []
+
+    logger._write_job(job)
+
+    task_dir = _collection_task_dir(tmp_path)
+    table = pq.read_table(task_dir / "data" / "chunk-000" / "episode_000000.parquet")
+    np.testing.assert_allclose(table.column("capture_time").to_pylist(), [1.0, 1.1, 1.2])
+    np.testing.assert_allclose(table.column("observation.qpos").to_pylist()[1], [1.0] * _DIM)
+    np.testing.assert_allclose(table.column("action").to_pylist()[1], [11.0] * _DIM)
+    assert frame_shapes == [(4, 6, 3)] * 3
+    assert decode_calls == ["decode"]
+    episode = _read_jsonl(task_dir / "meta" / "episodes.jsonl")[0]
+    assert episode["length"] == 3
+    assert episode["quality"] == "green"
+
+
+def test_collection_save_error_reports_missing_required_stream(tmp_path):
+    logger = _collection_logger(tmp_path)
+    batch = CollectionRawBatch(
+        images={
+            "cam_high": [
+                CollectionRawSample(0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+                CollectionRawSample(0.1, np.zeros((2, 2, 3), dtype=np.uint8)),
+            ]
+        },
+        vectors={
+            "state_qpos:arm": [
+                CollectionRawSample(0.0, np.zeros(_DIM, dtype=np.float32)),
+                CollectionRawSample(0.1, np.ones(_DIM, dtype=np.float32)),
+            ],
+        },
+    )
+
+    logger.start_episode("t")
+    logger.ingest_collection_snapshot(
+        RawCollectionSnapshot(
+            timestamp=0.1,
+            decode_raw=lambda: batch,
+        )
+    )
+
+    with pytest.raises(ValueError, match="missing_vector_stream.*action_qpos:arm"):
+        logger.end_episode()
+
+
 def test_collection_flags_frame_count_mismatch_when_camera_frame_dropped(tmp_path):
-    # A frame that drops a camera image still occupies a parquet row but is skipped in
-    # the mp4 (_snapshot_videos), so video frames < data rows — the exact divergence that
-    # crashes LeRobot on load. end_episode must flag it red as frame_count_mismatch.
+    # An invalid raw camera sample still occupies an aligned parquet row but is skipped
+    # in the mp4, so video frames < data rows. end_episode must flag it red.
     logger = _collection_logger(tmp_path, save_video=True)
     qpos = np.zeros(_DIM, dtype=np.float32)
     image = np.zeros((8, 8, 3), dtype=np.uint8)
+    invalid_image = np.zeros((8, 8), dtype=np.uint8)
 
     logger.start_episode("t")
-    for i in range(3):
-        images = {} if i == 1 else {"cam_high": image}  # drop the camera on frame 1
-        logger.record_collection_frame(
-            Observation(timestamp=i / 10.0, images=images, state_qpos=qpos, action_qpos=qpos)
+    logger.ingest_collection_snapshot(
+        _collection_raw_snapshot(
+            0.2,
+            batch=CollectionRawBatch(
+                images={
+                    "cam_high": [
+                        CollectionRawSample(0.0, image),
+                        CollectionRawSample(0.1, invalid_image),
+                        CollectionRawSample(0.2, image),
+                    ]
+                },
+                vectors={
+                    "state_qpos": [
+                        CollectionRawSample(0.0, qpos),
+                        CollectionRawSample(0.2, qpos),
+                    ],
+                    "action_qpos": [
+                        CollectionRawSample(0.0, qpos),
+                        CollectionRawSample(0.2, qpos),
+                    ],
+                },
+            ),
         )
-    logger.end_episode()
+    )
+    assert logger.end_episode()
 
     task_dir = _collection_task_dir(tmp_path)
     episode = _read_jsonl(task_dir / "meta" / "episodes.jsonl")[0]
@@ -312,19 +713,70 @@ def test_collection_flags_frame_count_mismatch_when_camera_frame_dropped(tmp_pat
     assert "frame_count_mismatch" in codes
 
 
+def test_collection_prepares_video_frames_during_save(tmp_path, monkeypatch):
+    calls = []
+
+    def resize(image: np.ndarray, height: int, width: int) -> np.ndarray:
+        calls.append((image.shape, height, width))
+        return np.zeros((height, width, 3), dtype=image.dtype)
+
+    monkeypatch.setattr(collection_module, "resize_direct", resize)
+    logger = _collection_logger(
+        tmp_path, save_video=True, save_image_height=4, save_image_width=6
+    )
+    qpos = np.zeros(_DIM, dtype=np.float32)
+
+    logger.start_episode("t")
+    logger.ingest_collection_snapshot(
+        _collection_raw_snapshot(
+            0.0,
+            image=np.zeros((8, 8, 3), dtype=np.uint8),
+            state=qpos,
+            action=qpos,
+        )
+    )
+
+    assert calls == []
+    assert logger.end_episode()
+    assert calls == [((8, 8, 3), 4, 6)]
+
+
+def test_collection_skips_resize_when_saved_size_matches_frame(tmp_path, monkeypatch):
+    class _Writer:
+        def append_data(self, frame: np.ndarray) -> None:
+            assert frame.shape == (8, 8, 3)
+
+        def close(self) -> None:
+            pass
+
+    def resize(image: np.ndarray, height: int, width: int) -> np.ndarray:
+        raise AssertionError("resize should be skipped for matching collection frame size")
+
+    monkeypatch.setattr(collection_module, "resize_direct", resize)
+    monkeypatch.setattr(episode_module.imageio, "get_writer", lambda *a, **k: _Writer())
+    logger = _collection_logger(
+        tmp_path, save_video=True, save_image_height=8, save_image_width=8
+    )
+    qpos = np.zeros(_DIM, dtype=np.float32)
+
+    logger.start_episode("t")
+    logger.ingest_collection_snapshot(
+        _collection_raw_snapshot(
+            0.0,
+            image=np.zeros((8, 8, 3), dtype=np.uint8),
+            state=qpos,
+            action=qpos,
+        )
+    )
+    assert logger.end_episode()
+
+
 def test_collection_status_reflects_qc_written_after_save(tmp_path):
     logger = _collection_logger(tmp_path)
     qpos = np.zeros(_DIM, dtype=np.float32)
     image = np.zeros((8, 8, 3), dtype=np.uint8)
     logger.start_episode("t")
-    logger.record_collection_frame(
-        Observation(
-            timestamp=0.0,
-            images={"cam_high": image},
-            state_qpos=qpos,
-            action_qpos=qpos,
-        )
-    )
+    logger.ingest_collection_snapshot(_collection_raw_snapshot(0.0, image=image, state=qpos))
     logger.end_episode()
 
     task_dir = _collection_task_dir(tmp_path)
@@ -342,12 +794,12 @@ def test_collection_saves_each_task_in_own_dataset_dir(tmp_path):
 
     for task, value in (("pick up cup", 1.0), ("place cup", 2.0)):
         logger.start_episode(task)
-        logger.record_collection_frame(
-            Observation(
-                timestamp=0.0,
-                images={"cam_high": image},
-                state_qpos=qpos + value,
-                action_qpos=qpos + value,
+        logger.ingest_collection_snapshot(
+            _collection_raw_snapshot(
+                0.0,
+                image=image,
+                state=qpos + value,
+                action=qpos + value,
             )
         )
         assert logger.end_episode()
@@ -378,14 +830,7 @@ def test_collection_status_queue_is_scoped_to_selected_task_dir(tmp_path, monkey
 
     for task in ("pick up cup", "place cup"):
         logger.start_episode(task)
-        logger.record_collection_frame(
-            Observation(
-                timestamp=0.0,
-                images={"cam_high": image},
-                state_qpos=qpos,
-                action_qpos=qpos,
-            )
-        )
+        logger.ingest_collection_snapshot(_collection_raw_snapshot(0.0, image=image, state=qpos))
         assert logger.end_episode()
 
     pick_status = logger.status_snapshot("pick up cup")
@@ -398,31 +843,29 @@ def test_collection_status_queue_is_scoped_to_selected_task_dir(tmp_path, monkey
     assert place_status["episodes"] == []
 
 
-def test_collection_status_counts_raw_frames_before_ingest_catches_up(tmp_path):
+def test_collection_status_counts_raw_frames_before_save_worker_decodes(tmp_path):
     logger = _collection_logger(tmp_path)
     qpos = np.zeros(_DIM, dtype=np.float32)
     image = np.zeros((8, 8, 3), dtype=np.uint8)
-    release_decode = threading.Event()
+    release_raw = threading.Event()
 
-    def decode() -> Observation:
-        release_decode.wait(timeout=5.0)
-        return Observation(
-            timestamp=0.0,
-            images={"cam_high": image},
-            state_qpos=qpos,
-            action_qpos=qpos,
-        )
+    def raw_snapshot(timestamp: float) -> RawCollectionSnapshot:
+        def decode_raw() -> CollectionRawBatch:
+            release_raw.wait(timeout=5.0)
+            return _collection_raw_batch((timestamp,), image=image, state=qpos, action=qpos)
+
+        return RawCollectionSnapshot(timestamp=timestamp, decode_raw=decode_raw)
 
     logger.start_episode("t")
-    for _ in range(3):
-        logger.ingest_collection_snapshot(RawCollectionSnapshot(timestamp=0.0, decode=decode))
+    for i in range(3):
+        logger.ingest_collection_snapshot(raw_snapshot(float(i) / 10.0))
 
     status = logger.status_snapshot("t")
     assert status["current_episode_frames"] == 3
     assert status["current_episode_recorded_frames"] == 0
     assert status["current_episode_pending_frames"] == 3
 
-    release_decode.set()
+    release_raw.set()
     assert logger.end_episode()
 
 
@@ -432,15 +875,12 @@ def test_collection_start_cutoff_drops_cached_frames(tmp_path):
     image = np.zeros((8, 8, 3), dtype=np.uint8)
 
     def snapshot(timestamp: float) -> RawCollectionSnapshot:
-        def decode() -> Observation:
-            return Observation(
-                timestamp=timestamp,
-                images={"cam_high": image},
-                state_qpos=qpos + timestamp,
-                action_qpos=qpos + timestamp,
-            )
-
-        return RawCollectionSnapshot(timestamp=timestamp, decode=decode)
+        return _collection_raw_snapshot(
+            timestamp,
+            image=image,
+            state=qpos + timestamp,
+            action=qpos + timestamp,
+        )
 
     logger.start_episode("t", collection_min_capture_time=10.0)
     logger.ingest_collection_snapshot(snapshot(9.0))
@@ -456,6 +896,39 @@ def test_collection_start_cutoff_drops_cached_frames(tmp_path):
     table = pq.read_table(task_dir / "data" / "chunk-000" / "episode_000000.parquet")
     assert table.num_rows == 1
     np.testing.assert_allclose(table.column("capture_time").to_pylist(), [10.1])
+
+
+def test_collection_save_worker_decodes_snapshots_after_end_preserving_order(tmp_path):
+    logger = _collection_logger(tmp_path, async_save=True)
+    logger._start_save_worker = lambda: None
+    qpos = np.zeros(_DIM, dtype=np.float32)
+    image = np.zeros((8, 8, 3), dtype=np.uint8)
+    decode_order = []
+
+    def decode_raw_first() -> CollectionRawBatch:
+        decode_order.append("first")
+        return _collection_raw_batch((0.0,), image=image, state=qpos, action=qpos)
+
+    def decode_raw_second() -> CollectionRawBatch:
+        decode_order.append("second")
+        return _collection_raw_batch((0.1,), image=image, state=qpos, action=qpos)
+
+    logger.start_episode("t")
+    logger.ingest_collection_snapshot(
+        RawCollectionSnapshot(timestamp=0.0, decode_raw=decode_raw_first)
+    )
+    logger.ingest_collection_snapshot(
+        RawCollectionSnapshot(timestamp=0.1, decode_raw=decode_raw_second)
+    )
+
+    assert logger.end_episode()
+    assert decode_order == []
+    job = logger._save_jobs[0]
+    logger._write_job(job)
+
+    assert decode_order == ["first", "second"]
+    table = pq.read_table(_collection_task_dir(tmp_path) / "data/chunk-000/episode_000000.parquet")
+    assert table.column("capture_time").to_pylist() == [0.0, 0.1]
 
 
 def test_collection_info_fps_uses_target_fps_not_measured(tmp_path, monkeypatch):
@@ -477,18 +950,15 @@ def test_collection_info_fps_uses_target_fps_not_measured(tmp_path, monkeypatch)
     qpos = np.zeros(_DIM, dtype=np.float32)
     image = np.zeros((8, 8, 3), dtype=np.uint8)
 
-    for timestamps in ((0.0, 0.1, 0.2), (1.0, 1.05, 1.1)):
+    for timestamps in ((0.0, 0.1, 0.2), (1.0, 1.1, 1.2)):
         logger.start_episode("t")
-        for ts in timestamps:
-            logger.record_collection_frame(
-                Observation(
-                    timestamp=ts,
-                    images={"cam_high": image},
-                    state_qpos=qpos,
-                    action_qpos=qpos,
-                )
+        logger.ingest_collection_snapshot(
+            _collection_raw_snapshot(
+                timestamps[-1],
+                batch=_collection_raw_batch(timestamps, image=image, state=qpos, action=qpos),
             )
-        logger.end_episode()
+        )
+        assert logger.end_episode()
     logger.finalize()
 
     task_dir = _collection_task_dir(tmp_path)
@@ -501,14 +971,50 @@ def test_collection_info_fps_uses_target_fps_not_measured(tmp_path, monkeypatch)
     np.testing.assert_allclose(writer_fps, [10.0, 10.0])
 
 
+def test_image_episode_stats_does_not_stack_all_frames_as_float64(monkeypatch):
+    original_asarray = episode_module.np.asarray
+
+    def guarded_asarray(value, *args, **kwargs):
+        dtype = kwargs.get("dtype")
+        if dtype is None and args:
+            dtype = args[0]
+        if isinstance(value, list) and np.dtype(dtype) == np.dtype(np.float64):
+            raise AssertionError("image stats must stream frames instead of stacking them")
+        return original_asarray(value, *args, **kwargs)
+
+    monkeypatch.setattr(episode_module.np, "asarray", guarded_asarray)
+
+    frames = [
+        np.array([[[0, 10, 20], [30, 40, 50]]], dtype=np.uint8),
+        np.array([[[60, 70, 80], [90, 100, 110]]], dtype=np.uint8),
+    ]
+
+    stats = episode_module._image_episode_stats(frames)
+
+    expected = original_asarray(frames, dtype=np.float64).reshape(-1, 3) / 255.0
+    expected_mean = expected.mean(axis=0)
+    expected_std = expected.std(axis=0)
+    np.testing.assert_allclose(
+        stats["min"], [[[float(x)]] for x in expected.min(axis=0)]
+    )
+    np.testing.assert_allclose(
+        stats["max"], [[[float(x)]] for x in expected.max(axis=0)]
+    )
+    np.testing.assert_allclose(stats["mean"], [[[float(x)]] for x in expected_mean])
+    np.testing.assert_allclose(stats["std"], [[[float(x)]] for x in expected_std])
+    assert stats["count"] == [2]
+
+
 def _record_one_collection_episode(logger, image):
     qpos = np.zeros(_DIM, dtype=np.float32)
     logger.start_episode("t")
-    for ts in (0.0, 0.1, 0.2):
-        logger.record_collection_frame(
-            Observation(timestamp=ts, images={"cam_high": image}, state_qpos=qpos, action_qpos=qpos)
+    logger.ingest_collection_snapshot(
+        _collection_raw_snapshot(
+            0.2,
+            batch=_collection_raw_batch((0.0, 0.1, 0.2), image=image, state=qpos, action=qpos),
         )
-    logger.end_episode()
+    )
+    assert logger.end_episode()
     logger.finalize()
 
 
@@ -561,16 +1067,18 @@ def test_collection_stats_json_uses_episode_stats_without_parquet_rescan(tmp_pat
     for offset in (0.0, 10.0):
         qpos = np.arange(_DIM, dtype=np.float32) + offset
         logger.start_episode("t")
-        for ts in (0.0, 0.1, 0.2):
-            logger.record_collection_frame(
-                Observation(
-                    timestamp=ts,
-                    images={"cam_high": image},
-                    state_qpos=qpos,
-                    action_qpos=qpos + 1.0,
-                )
+        logger.ingest_collection_snapshot(
+            _collection_raw_snapshot(
+                0.2,
+                batch=_collection_raw_batch(
+                    (0.0, 0.1, 0.2),
+                    image=image,
+                    state=qpos,
+                    action=qpos + 1.0,
+                ),
             )
-        logger.end_episode()
+        )
+        assert logger.end_episode()
 
     def fail_read_table(*_args, **_kwargs):
         raise AssertionError("stats.json should use episodes_stats.jsonl")
@@ -655,7 +1163,7 @@ def test_episode_logger_info_and_video_fps_use_target_fps(tmp_path, monkeypatch)
     np.testing.assert_allclose(info["fps"], 30.0)
     np.testing.assert_allclose(video_info["video.fps"], 30.0)
     np.testing.assert_allclose(writer_fps, [30.0, 30.0])
-    assert writer_frames == [3, 3]
+    assert writer_frames == [7, 4]
     assert "capture_time" in info["features"]
 
 

--- a/tests/recorder/test_rollout_interventions.py
+++ b/tests/recorder/test_rollout_interventions.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pyarrow.parquet as pq
+
+from core.config import ConfigDict
+from core.recorder import episode as episode_module
+from core.recorder.episode import EpisodeLogger
+from core.types import Observation, RolloutInterventionSegment
+from robots.base import (
+    ActuatorGroup,
+    CameraSpec,
+    ObservationSchema,
+    Robot,
+)
+
+_DIM = 3
+
+
+def _robot() -> Robot:
+    joints = tuple(f"j{i}" for i in range(_DIM))
+    return Robot(
+        name="fake_arm",
+        actuator_groups=(ActuatorGroup("arm", _DIM, joints),),
+        initial_qpos=np.zeros(_DIM, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam_high"),),
+            state_composition=("arm",),
+        ),
+    )
+
+
+def _logger(
+    log_dir,
+    *,
+    save_image_height: int | None = None,
+    save_image_width: int | None = None,
+) -> EpisodeLogger:
+    return EpisodeLogger(
+        log_dir,
+        _robot(),
+        fps=10,
+        dataset_keys=ConfigDict(
+            state_key="observations.state.qpos",
+            eef_key="observations.state.eef",
+            action_key="action",
+            video_keys={},
+        ),
+        async_save=False,
+        save_image_height=save_image_height,
+        save_image_width=save_image_width,
+    )
+
+
+def _image(value: int) -> np.ndarray:
+    return np.full((4, 4, 3), value, dtype=np.uint8)
+
+
+def _obs(state: np.ndarray, image_value: int) -> Observation:
+    return Observation(images={"cam_high": _image(image_value)}, state_qpos=state)
+
+
+def _read_jsonl(path):
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_rollout_save_merges_intervention_into_episode_table(tmp_path):
+    logger = _logger(tmp_path)
+    keys = ConfigDict(state_key="observations.state.qpos", action_key="action")
+    segment = RolloutInterventionSegment(
+        segment_index=0,
+        start_policy_frame_index=1,
+        pre_intervention_qpos=np.array([0.0, 0.1, 0.2], dtype=np.float32),
+        resume_policy_frame_index=2,
+        frames=[
+            Observation(
+                timestamp=0.2,
+                images={"cam_high": _image(20)},
+                state_qpos=np.array([1.0, 1.1, 1.2], dtype=np.float32),
+                action_qpos=np.array([2.0, 2.1, 2.2], dtype=np.float32),
+            ),
+            Observation(
+                timestamp=0.3,
+                images={"cam_high": _image(30)},
+                state_qpos=np.array([3.0, 3.1, 3.2], dtype=np.float32),
+                action_qpos=np.array([4.0, 4.1, 4.2], dtype=np.float32),
+            ),
+        ],
+    )
+
+    logger.start_episode("pick")
+    logger.record_step(
+        _obs(np.array([0.0, 0.0, 0.0], dtype=np.float32), 1),
+        np.array([0.5, 0.5, 0.5], dtype=np.float32),
+        timestamp=0.0,
+    )
+    logger.record_step(
+        _obs(np.array([0.1, 0.1, 0.1], dtype=np.float32), 2),
+        np.array([0.6, 0.6, 0.6], dtype=np.float32),
+        timestamp=0.1,
+    )
+    logger.set_rollout_intervention_segments([segment])
+
+    assert logger.end_episode() is True
+
+    rollout_table = pq.read_table(str(tmp_path / "data" / "chunk-000" / "episode_000000.parquet"))
+    assert rollout_table.num_rows == 4
+    np.testing.assert_allclose(
+        np.array(rollout_table.column(keys.state_key).to_pylist(), dtype=np.float32),
+        np.array(
+            [
+                [0.0, 0.0, 0.0],
+                [0.1, 0.1, 0.1],
+                [1.0, 1.1, 1.2],
+                [3.0, 3.1, 3.2],
+            ],
+            dtype=np.float32,
+        ),
+    )
+    np.testing.assert_allclose(
+        np.array(rollout_table.column(keys.action_key).to_pylist(), dtype=np.float32),
+        np.array(
+            [
+                [0.5, 0.5, 0.5],
+                [0.6, 0.6, 0.6],
+                [2.0, 2.1, 2.2],
+                [4.0, 4.1, 4.2],
+            ],
+            dtype=np.float32,
+        ),
+    )
+    assert rollout_table.column("intervention").to_pylist() == [False, False, True, True]
+    assert rollout_table.column("intervention_segment_index").to_pylist() == [-1, -1, 0, 0]
+    assert not (tmp_path / "interventions").exists()
+
+    episodes = _read_jsonl(tmp_path / "meta" / "episodes.jsonl")
+    assert episodes[0]["has_intervention"] is True
+    assert episodes[0]["intervention_segments"] == 1
+    assert episodes[0]["intervention_frames"] == 2
+
+
+def test_rollout_intervention_video_uses_episode_writer_when_size_set(tmp_path, monkeypatch):
+    frame_shapes: dict[str, list[tuple[int, int, int]]] = {}
+
+    class _Writer:
+        def __init__(self, path: str) -> None:
+            self.path = path
+            frame_shapes[self.path] = []
+
+        def append_data(self, frame: np.ndarray) -> None:
+            frame_shapes[self.path].append(frame.shape)
+
+        def close(self) -> None:
+            pass
+
+    monkeypatch.setattr(
+        episode_module.imageio, "get_writer", lambda path, *a, **k: _Writer(str(path))
+    )
+    logger = _logger(tmp_path, save_image_height=120, save_image_width=160)
+    state = np.zeros(_DIM, dtype=np.float32)
+    segment = RolloutInterventionSegment(
+        segment_index=0,
+        start_policy_frame_index=1,
+        pre_intervention_qpos=state,
+        frames=[
+            Observation(
+                timestamp=10.0,
+                images={"cam_high": np.zeros((480, 640, 3), dtype=np.uint8)},
+                state_qpos=state,
+                action_qpos=state,
+            ),
+            Observation(
+                timestamp=10.1,
+                images={"cam_high": np.zeros((480, 640, 3), dtype=np.uint8)},
+                state_qpos=state,
+                action_qpos=state,
+            ),
+        ],
+    )
+
+    logger.start_episode("pick")
+    logger.record_step(_obs(state, 1), state, timestamp=9.9)
+    logger.set_rollout_intervention_segments([segment])
+
+    assert logger.end_episode() is True
+    episode_shapes = [
+        shapes for path, shapes in frame_shapes.items() if "/videos/chunk-000/" in path
+    ]
+    assert episode_shapes == [[(120, 160, 3), (120, 160, 3), (120, 160, 3)]]
+    intervention_dir = "/" + "inter" + "ventions/"
+    assert not any(intervention_dir in path for path in frame_shapes)

--- a/tests/transport/test_base.py
+++ b/tests/transport/test_base.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import threading
+import time
+import types
+from collections import deque
+from typing import Any
+
+import numpy as np
+import pytest
+
+import transport.utils as transport_utils
+from core.config import ConfigDict
+from core.types import CollectionRawImage, Observation
+from robots.base import ActuatorGroup, CameraSpec, ObservationSchema, Robot
+from transport.base import _RosTransportBase
+from transport.utils import StreamFreshness
+
+
+class _FakeRosCollectionTransport(_RosTransportBase):
+    def __init__(self, image: np.ndarray) -> None:
+        self._image = image
+        self._config = ConfigDict(
+            collection=ConfigDict(
+                schema=ConfigDict(
+                    columns={"qpos": "observation.qpos"},
+                    cameras={"cam_high": "observation.images.cam_high"},
+                ),
+            ),
+        )
+        self._robot = Robot(
+            name="fake",
+            actuator_groups=(ActuatorGroup("arm", 2, ("j0", "j1")),),
+            initial_qpos=np.zeros(2, dtype=np.float32),
+            observation_schema=ObservationSchema(
+                cameras=(CameraSpec("front", "cam_high"),),
+                state_composition=("arm",),
+            ),
+        )
+        self._bridge = object()
+        self._freshness = StreamFreshness()
+        self._image_rate = transport_utils.ImageRateTracker()
+        self._deque_lock = threading.RLock()
+        self._camera_deques = {"front": deque([self._msg(1.0)])}
+        self._collection_qpos_deques = {"arm": deque([self._msg(1.0, [1.0, 2.0])])}
+        self._collection_eef_deques = {}
+        self._collection_action_qpos_deques = {}
+        self._collection_action_eef_deques = {}
+        self._last_acquire_stamp = None
+        self._stamp_calls = 0
+        self._stamp_hook = None
+
+    @staticmethod
+    def _msg(t: float, position: list[float] | None = None) -> Any:
+        return types.SimpleNamespace(t=t, position=[] if position is None else position)
+
+    @property
+    def _collection_cfg(self) -> Any:
+        return ConfigDict(primary_camera="cam_high", max_frame_skew_sec=0.0)
+
+    def _stamp_to_sec(self, msg: Any) -> float:
+        self._stamp_calls += 1
+        if self._stamp_hook is not None:
+            self._stamp_hook(self, msg)
+        return float(msg.t)
+
+    def _decode_image_msg(self, camera_name: str, msg: Any) -> np.ndarray | None:
+        _ = camera_name, msg
+        return self._image
+
+    def _eef_from_msg(self, group: Any, msg: Any, frame_time: float) -> np.ndarray:
+        _ = group, msg, frame_time
+        return np.zeros(0, dtype=np.float32)
+
+    def get_frame(self) -> Observation | None:
+        return None
+
+    def publish_action(self, action: np.ndarray) -> None:
+        _ = action
+
+    def close(self) -> None:
+        pass
+
+
+def test_raw_collection_snapshot_has_no_decoded_frame_path():
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    transport = _FakeRosCollectionTransport(image)
+
+    snapshot = transport.acquire_collection_raw()
+    assert snapshot is not None
+    assert not hasattr(snapshot, "decode")
+
+
+def test_raw_collection_snapshot_exposes_raw_stream_batch():
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    transport = _FakeRosCollectionTransport(image)
+    transport._camera_deques["front"].append(transport._msg(1.1))
+    transport._collection_qpos_deques["arm"].append(transport._msg(1.1, [2.0, 3.0]))
+
+    snapshot = transport.acquire_collection_raw()
+    assert snapshot is not None
+    batch = snapshot.decode_raw()
+
+    assert [sample.timestamp for sample in batch.images["cam_high"]] == [1.0, 1.1]
+    assert [sample.timestamp for sample in batch.vectors["state_qpos:arm"]] == [1.0, 1.1]
+    np.testing.assert_allclose(batch.vectors["state_qpos:arm"][1].value, [2.0, 3.0])
+
+
+def test_raw_collection_snapshot_defers_image_decode_until_alignment():
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    transport = _FakeRosCollectionTransport(image)
+    transport._camera_deques["front"].append(transport._msg(1.1))
+    transport._collection_qpos_deques["arm"].append(transport._msg(1.1, [2.0, 3.0]))
+    decoded = 0
+
+    def decode(camera_name: str, msg: Any) -> np.ndarray:
+        nonlocal decoded
+        _ = camera_name, msg
+        decoded += 1
+        return image
+
+    transport._decode_image_msg = decode
+
+    snapshot = transport.acquire_collection_raw()
+    assert snapshot is not None
+    batch = snapshot.decode_raw()
+
+    assert decoded == 0
+    value = batch.images["cam_high"][0].value
+    assert isinstance(value, CollectionRawImage)
+    assert value.decode() is image
+    assert decoded == 1
+    assert value.decode() is image
+    assert decoded == 1
+
+
+def test_acquire_collection_raw_scans_only_messages_after_cursor():
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    transport = _FakeRosCollectionTransport(image)
+    old_images = [transport._msg(float(i)) for i in range(2000)]
+    old_qpos = [transport._msg(float(i), [float(i), float(i + 1)]) for i in range(2000)]
+    transport._camera_deques["front"] = deque(
+        [*old_images, transport._msg(2000.0), transport._msg(2000.1)]
+    )
+    transport._collection_qpos_deques["arm"] = deque(
+        [
+            *old_qpos,
+            transport._msg(2000.0, [2000.0, 2001.0]),
+            transport._msg(2000.1, [2000.1, 2001.1]),
+        ]
+    )
+    transport._collection_raw_cursors().update(
+        {
+            "image:cam_high:front": 1999.0,
+            "vector:state_qpos:arm": 1999.0,
+        }
+    )
+    transport._stamp_calls = 0
+
+    snapshot = transport.acquire_collection_raw()
+    assert snapshot is not None
+    batch = snapshot.decode_raw()
+
+    assert transport._stamp_calls < 30
+    assert [sample.timestamp for sample in batch.images["cam_high"]] == [2000.0, 2000.1]
+    assert [sample.timestamp for sample in batch.vectors["state_qpos:arm"]] == [
+        2000.0,
+        2000.1,
+    ]
+
+
+def test_acquire_collection_raw_blocks_concurrent_deque_append_during_scan():
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    transport = _FakeRosCollectionTransport(image)
+    transport._camera_deques["front"] = deque(
+        [transport._msg(float(i)) for i in range(10)]
+    )
+    transport._collection_qpos_deques["arm"] = deque(
+        [transport._msg(float(i), [float(i), float(i + 1)]) for i in range(10)]
+    )
+    transport._collection_raw_cursors().update(
+        {
+            "image:cam_high:front": 5.0,
+            "vector:state_qpos:arm": 5.0,
+        }
+    )
+    started = threading.Event()
+    appended = threading.Event()
+    launched = False
+
+    def append_during_scan() -> None:
+        started.wait(timeout=1.0)
+        transport._append_msg(transport._camera_deques["front"], transport._msg(10.0))
+        appended.set()
+
+    thread = threading.Thread(target=append_during_scan)
+    thread.start()
+
+    def stamp_hook(_transport: _FakeRosCollectionTransport, _msg: Any) -> None:
+        nonlocal launched
+        if not launched:
+            launched = True
+            started.set()
+            time.sleep(0.05)
+
+    transport._stamp_hook = stamp_hook
+    snapshot = transport.acquire_collection_raw()
+    thread.join(timeout=1.0)
+
+    assert snapshot is not None
+    assert appended.is_set()
+    batch = snapshot.decode_raw()
+    assert [sample.timestamp for sample in batch.images["cam_high"]] == [
+        6.0,
+        7.0,
+        8.0,
+        9.0,
+    ]
+
+
+def test_image_rate_tracker_reports_minimum_camera_hz():
+    assert hasattr(transport_utils, "ImageRateTracker")
+    tracker = transport_utils.ImageRateTracker()
+
+    tracker.mark("front", 0.0)
+    tracker.mark("left", 0.0)
+    assert tracker.min_hz(("front", "left")) is None
+
+    tracker.mark("front", 0.05)
+    tracker.mark("left", 0.10)
+
+    assert tracker.min_hz(("front", "left")) == pytest.approx(10.0)
+
+
+def test_ros_camera_append_updates_image_min_hz():
+    transport = _FakeRosCollectionTransport(np.zeros((4, 4, 3), dtype=np.uint8))
+    transport._camera_deques["left"] = deque()
+
+    transport._append_camera_msg(
+        "front", transport._camera_deques["front"], transport._msg(1.0), 0.0
+    )
+    transport._append_camera_msg(
+        "left", transport._camera_deques["left"], transport._msg(1.0), 0.0
+    )
+    transport._append_camera_msg(
+        "front", transport._camera_deques["front"], transport._msg(1.1), 0.05
+    )
+    transport._append_camera_msg(
+        "left", transport._camera_deques["left"], transport._msg(1.2), 0.10
+    )
+
+    assert transport.image_min_hz() == pytest.approx(10.0)

--- a/tests/transport/test_ros1.py
+++ b/tests/transport/test_ros1.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import types
+
+import numpy as np
+import pytest
+
+import transport.ros1 as ros1
+import transport.utils as transport_utils
+from core.config import ConfigDict
+from robots.base import ActuatorGroup, CameraSpec, ObservationSchema, Robot
+
+
+class _FakeRospy:
+    def __init__(self) -> None:
+        self.subscribers = []
+
+    def Subscriber(self, topic, msg_type, callback, queue_size, tcp_nodelay):
+        self.subscribers.append((topic, msg_type, callback, queue_size, tcp_nodelay))
+        return object()
+
+    def Publisher(self, topic, msg_type, queue_size):
+        return object()
+
+    def Rate(self, hz):
+        return types.SimpleNamespace(hz=hz)
+
+    def is_shutdown(self):
+        return False
+
+
+def _subscription_callback(rospy: _FakeRospy, topic: str):
+    for sub_topic, _msg_type, callback, _queue_size, _tcp_nodelay in rospy.subscribers:
+        if sub_topic == topic:
+            return callback
+    raise AssertionError(f"missing subscription for {topic}")
+
+
+def test_ros1_camera_subscriptions_report_minimum_image_hz(monkeypatch):
+    fake_rospy = _FakeRospy()
+    runtime = types.SimpleNamespace(
+        rospy=fake_rospy,
+        cv_bridge=object(),
+        image_type=object,
+        joint_state_type=object,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros1, "get_ros_runtime", lambda node_name: runtime)
+    now = [0.0]
+    monkeypatch.setattr(transport_utils.time, "monotonic", lambda: now[0])
+    config = ConfigDict(
+        transport=ConfigDict(
+            node_name="test_ros1",
+            topics=ConfigDict(
+                camera_topics={"front": "/cam/front", "left": "/cam/left"},
+                group_topics={
+                    "arm": {
+                        "state_topic": "/joint_states",
+                        "command_topic": "/joint_cmd",
+                    }
+                },
+            ),
+        ),
+        inference_cfg=ConfigDict(obs_space=types.SimpleNamespace(is_eef=lambda: False)),
+        collection=ConfigDict(
+            schema=ConfigDict(columns={}),
+            transport=ConfigDict(ros1=ConfigDict(groups={})),
+        ),
+    )
+    robot = Robot(
+        name="fake",
+        actuator_groups=(ActuatorGroup("arm", 2, ("j0", "j1")),),
+        initial_qpos=np.zeros(2, dtype=np.float32),
+        observation_schema=ObservationSchema(
+            cameras=(CameraSpec("front", "cam_front"), CameraSpec("left", "cam_left")),
+            state_composition=("arm",),
+        ),
+    )
+    transport = ros1.Ros1Transport(config, robot)
+
+    for topic in ("/cam/front", "/cam/left"):
+        now[0] = 0.0
+        _subscription_callback(fake_rospy, topic)(object())
+    now[0] = 0.05
+    _subscription_callback(fake_rospy, "/cam/front")(object())
+    now[0] = 0.10
+    _subscription_callback(fake_rospy, "/cam/left")(object())
+
+    assert transport.image_min_hz() == pytest.approx(10.0)

--- a/tests/transport/test_ros2.py
+++ b/tests/transport/test_ros2.py
@@ -4,14 +4,20 @@ from __future__ import annotations
 
 import sys
 import types
+from collections import deque
 from pathlib import Path
+
+import numpy as np
+import pytest
 
 import robots  # noqa: F401  (registers robots)
 import transport.ros2 as ros2
+import transport.utils as transport_utils
 from core.config import load_config
 from core.registry import ROBOT_REGISTRY
 
 _CONFIGS_DIR = Path(__file__).resolve().parents[2] / "configs"
+_R1LITE_COLLECTION = _CONFIGS_DIR / "02_collection" / "r1lite.py"
 
 
 class _FakeQoSProfile:
@@ -25,18 +31,65 @@ class _FakeNode:
     def __init__(self):
         self.subscriptions = []
         self.publishers = []
+        self.publishers_by_topic = {}
+        self.clock_stamp = types.SimpleNamespace(sec=0, nanosec=0)
+
+    def get_clock(self):
+        return types.SimpleNamespace(
+            now=lambda: types.SimpleNamespace(
+                to_msg=lambda: types.SimpleNamespace(
+                    sec=self.clock_stamp.sec,
+                    nanosec=self.clock_stamp.nanosec,
+                )
+            )
+        )
 
     def create_subscription(self, msg_type, topic, callback, qos):
         self.subscriptions.append((msg_type, topic, callback, qos))
 
     def create_publisher(self, msg_type, topic, qos):
+        publisher = _FakePublisher()
         self.publishers.append((msg_type, topic, qos))
-        return _FakePublisher()
+        self.publishers_by_topic[topic] = publisher
+        return publisher
 
 
 class _FakePublisher:
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, message):
+        self.messages.append(message)
+
     def destroy(self):
         pass
+
+
+class _FakeJointState:
+    def __init__(self):
+        self.header = types.SimpleNamespace(stamp=None)
+        self.name = []
+        self.position = []
+
+
+def _stamped_msg(sec: int, position=None, nanosec: int = 0):
+    stamp = types.SimpleNamespace(sec=sec, nanosec=nanosec)
+    if position is None:
+        position = [0.0]
+    return types.SimpleNamespace(header=types.SimpleNamespace(stamp=stamp), position=position)
+
+
+def _compressed_msg(sec: int, data: bytes):
+    msg = _stamped_msg(sec)
+    msg.data = data
+    return msg
+
+
+def _subscription_callback(node: _FakeNode, topic: str):
+    for _msg_type, sub_topic, callback, _qos in node.subscriptions:
+        if sub_topic == topic:
+            return callback
+    raise AssertionError(f"missing subscription for {topic}")
 
 
 def test_ros2_live_qos_matches_best_effort_publishers(monkeypatch):
@@ -78,3 +131,803 @@ def test_ros2_transport_uses_live_qos_for_entities(monkeypatch):
     assert node.publishers
     assert {call[-1] for call in node.subscriptions} == {qos}
     assert {call[-1] for call in node.publishers} == {qos}
+
+
+def test_ros2_camera_subscriptions_use_deeper_qos(monkeypatch):
+    node = _FakeNode()
+    qoses = {}
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=object,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+
+    def make_qos(depth=10):
+        qos = object()
+        qoses[qos] = depth
+        return qos
+
+    monkeypatch.setattr(ros2, "_make_live_qos", make_qos)
+
+    config = load_config(_CONFIGS_DIR / "01_deploy" / "r1lite" / "openpi_qpos.py")
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    camera_topics = set(transport._camera_topics.values())
+
+    assert camera_topics
+    seen_camera_topics = set()
+    for _msg_type, topic, _callback, qos in node.subscriptions:
+        if topic in camera_topics:
+            seen_camera_topics.add(topic)
+            assert qoses[qos] == ros2._CAMERA_QOS_DEPTH
+    assert seen_camera_topics == camera_topics
+
+
+def test_ros2_camera_subscriptions_report_minimum_image_hz(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=object,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+    now = [0.0]
+    monkeypatch.setattr(transport_utils.time, "monotonic", lambda: now[0])
+
+    config = load_config(_CONFIGS_DIR / "01_deploy" / "r1lite" / "openpi_qpos.py")
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+
+    topics = tuple(transport._camera_topics.values())
+    for topic in topics:
+        now[0] = 0.0
+        _subscription_callback(node, topic)(_stamped_msg(1))
+    for topic, t in zip(topics, (0.05, 0.10, 0.20), strict=True):
+        now[0] = t
+        _subscription_callback(node, topic)(_stamped_msg(2))
+
+    assert transport.image_min_hz() == pytest.approx(5.0)
+
+
+def test_ros2_hil_relay_subscriptions_use_depth_one_qos(monkeypatch):
+    node = _FakeNode()
+    qoses = {}
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+
+    def make_qos(depth=10):
+        qos = object()
+        qoses[qos] = depth
+        return qos
+
+    monkeypatch.setattr(ros2, "_make_live_qos", make_qos)
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    ros2.Ros2Transport(config, robot)
+
+    hil_qos_depths = {
+        topic: qoses[qos]
+        for _msg_type, topic, _callback, qos in node.subscriptions
+        if topic.startswith("/eva/hil/input_joint_state_arm_")
+    }
+    assert hil_qos_depths == {
+        "/eva/hil/input_joint_state_arm_left": 1,
+        "/eva/hil/input_joint_state_arm_right": 1,
+    }
+
+
+def test_ros2_hil_relative_relay_anchors_slave_to_first_cat_frame(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport.set_hil_control_mode("relative")
+    transport._group_state_deques["left_arm"].append(_stamped_msg(1, [10, 20, 30, 40, 50, 60]))
+    callback = _subscription_callback(node, "/eva/hil/input_joint_state_arm_left")
+
+    callback(_stamped_msg(2, [1, 2, 3, 4, 5, 6]))
+    callback(_stamped_msg(3, [1.5, 1, 3, 4, 5, 8]))
+
+    published = node.publishers_by_topic["/motion_target/target_joint_state_arm_left"].messages
+    np.testing.assert_allclose(published[0].position, [10, 20, 30, 40, 50, 60])
+    np.testing.assert_allclose(published[1].position, [10.5, 19, 30, 40, 50, 62])
+
+
+def test_ros2_hil_relay_does_not_write_collection_action_qpos(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport.set_hil_control_mode("relative")
+    transport._group_state_deques["left_arm"].append(_stamped_msg(1, [10, 20, 30, 40, 50, 60]))
+    callback = _subscription_callback(node, "/eva/hil/input_joint_state_arm_left")
+
+    node.clock_stamp = types.SimpleNamespace(sec=20, nanosec=0)
+    callback(_stamped_msg(2, [1, 2, 3, 4, 5, 6]))
+    node.clock_stamp = types.SimpleNamespace(sec=30, nanosec=0)
+    callback(_stamped_msg(3, [2, 4, 3, 4, 5, 8]))
+
+    samples = list(transport._collection_action_qpos_deques["left_arm"])
+    assert samples == []
+
+
+def test_ros2_hil_relay_restamps_commands_with_local_clock(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport.set_hil_control_mode("relative")
+    transport._group_state_deques["left_arm"].append(
+        _stamped_msg(100, [10, 20, 30, 40, 50, 60])
+    )
+    callback = _subscription_callback(node, "/eva/hil/input_joint_state_arm_left")
+
+    node.clock_stamp = types.SimpleNamespace(sec=100, nanosec=123)
+    callback(_stamped_msg(2, [1, 2, 3, 4, 5, 6]))
+    node.clock_stamp = types.SimpleNamespace(sec=101, nanosec=456)
+    callback(_stamped_msg(3, [2, 4, 3, 4, 5, 8]))
+
+    published = node.publishers_by_topic["/motion_target/target_joint_state_arm_left"].messages
+    samples = list(transport._collection_action_qpos_deques["left_arm"])
+    assert [(m.header.stamp.sec, m.header.stamp.nanosec) for m in published] == [
+        (100, 123),
+        (101, 456),
+    ]
+    assert samples == []
+
+
+def test_ros2_collection_action_qpos_subscribes_motion_target_when_hil_enabled(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    action_callback = _subscription_callback(
+        node, "/motion_target/target_joint_state_arm_left"
+    )
+
+    action_callback(_stamped_msg(2, [1, 2, 3, 4, 5, 6]))
+
+    samples = list(transport._collection_action_qpos_deques["left_arm"])
+    assert len(samples) == 1
+    np.testing.assert_allclose(samples[0].position, [1, 2, 3, 4, 5, 6])
+
+
+def test_ros2_does_not_subscribe_hil_when_intervention_disabled(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    config.rollout.intervention.enabled = False
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    ros2.Ros2Transport(config, robot)
+
+    subscribed_topics = {topic for _msg_type, topic, _callback, _qos in node.subscriptions}
+    assert "/eva/hil/input_joint_state_arm_left" not in subscribed_topics
+    assert "/eva/hil/input_joint_state_arm_right" not in subscribed_topics
+    assert "/motion_target/target_joint_state_arm_left" in subscribed_topics
+    assert "/motion_target/target_joint_state_arm_right" in subscribed_topics
+
+
+def test_ros2_hil_relative_relay_anchors_to_last_command_target(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport.set_hil_control_mode("relative")
+    transport.publish_action(
+        np.array(
+            [
+                12,
+                21,
+                30,
+                40,
+                50,
+                60,
+                100,
+                -10,
+                -20,
+                -30,
+                -40,
+                -50,
+                -60,
+                0,
+            ],
+            dtype=np.float32,
+        )
+    )
+    transport._group_state_deques["left_arm"].append(_stamped_msg(1, [10, 20, 30, 40, 50, 60]))
+    callback = _subscription_callback(node, "/eva/hil/input_joint_state_arm_left")
+
+    callback(_stamped_msg(2, [1, 2, 3, 4, 5, 6]))
+
+    published = node.publishers_by_topic["/motion_target/target_joint_state_arm_left"].messages
+    np.testing.assert_allclose(published[-1].position, [12, 21, 30, 40, 50, 60])
+
+
+def test_ros2_hil_relay_does_not_publish_gripper_target(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport._group_state_deques["left_arm"].append(_stamped_msg(1, [10, 20, 30, 40, 50, 60]))
+    transport._group_gripper_deques["left_arm"].append(_stamped_msg(1, [77]))
+    callback = _subscription_callback(node, "/eva/hil/input_joint_state_arm_left")
+
+    callback(_stamped_msg(2, [1, 2, 3, 4, 5, 6]))
+
+    published = node.publishers_by_topic["/motion_target/target_position_gripper_left"].messages
+    assert published == []
+
+
+def test_ros2_hil_relative_relay_keeps_gripper_absolute(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    group = robot.actuator_groups[0]
+    transport.set_hil_control_mode("relative")
+
+    first = transport._resolve_hil_joint_command(
+        group,
+        np.array([1, 2, 3, 4, 5, 6, 10], dtype=np.float32),
+        np.array([10, 20, 30, 40, 50, 60, 100], dtype=np.float32),
+    )
+    second = transport._resolve_hil_joint_command(
+        group,
+        np.array([2, 1, 3, 4, 7, 6, 0], dtype=np.float32),
+        np.array([90, 90, 90, 90, 90, 90, 90], dtype=np.float32),
+    )
+
+    np.testing.assert_allclose(first, [10, 20, 30, 40, 50, 60, 10])
+    np.testing.assert_allclose(second, [11, 19, 30, 40, 52, 60, 0])
+
+
+def test_ros2_hil_mode_switch_resets_relative_anchor(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    group = robot.actuator_groups[0]
+    transport.set_hil_control_mode("relative")
+    transport._resolve_hil_joint_command(
+        group,
+        np.array([1, 2, 3, 4, 5, 6], dtype=np.float32),
+        np.array([10, 20, 30, 40, 50, 60], dtype=np.float32),
+    )
+
+    transport.set_hil_control_mode("absolute")
+    transport.set_hil_control_mode("relative")
+    resolved = transport._resolve_hil_joint_command(
+        group,
+        np.array([9, 9, 9, 9, 9, 9], dtype=np.float32),
+        np.array([100, 101, 102, 103, 104, 105], dtype=np.float32),
+    )
+
+    np.testing.assert_allclose(resolved, [100, 101, 102, 103, 104, 105])
+
+
+def test_pop_synced_msg_returns_none_when_queue_drains_before_frame_time():
+    messages = deque([_stamped_msg(1)])
+
+    assert ros2.Ros2Transport._pop_synced_msg(None, messages, 2.0) is None
+    assert not messages
+
+
+def test_ros2_get_camera_frame_reads_latest_without_consuming(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=object,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    monkeypatch.setattr(transport, "_decode_image_msg", lambda camera_name, msg: image)
+    transport._camera_deques["head"].append(_stamped_msg(1))
+
+    frame = transport.get_camera_frame("cam_high")
+
+    np.testing.assert_array_equal(frame, image)
+    assert len(transport._camera_deques["head"]) == 1
+
+
+def test_ros2_get_camera_jpeg_reads_compressed_payload_without_consuming(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=object,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    payload = b"\xff\xd8raw-jpeg\xff\xd9"
+    transport._camera_deques["head"].append(_compressed_msg(1, payload))
+
+    jpeg = transport.get_camera_jpeg("cam_high")
+
+    assert jpeg == payload
+    assert len(transport._camera_deques["head"]) == 1
+
+
+def test_ros2_collection_joint_vector_merges_configured_gripper_topics(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=object,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport._collection_qpos_deques["left_arm"].append(_stamped_msg(1, [0, 1, 2, 3, 4, 5]))
+    transport._collection_qpos_deques["right_arm"].append(
+        _stamped_msg(1, [10, 11, 12, 13, 14, 15])
+    )
+    transport._collection_qpos_gripper_deques["left_arm"].append(_stamped_msg(1, [42]))
+    transport._collection_qpos_gripper_deques["right_arm"].append(_stamped_msg(1, [43]))
+
+    qpos = transport._collection_joint_vector(
+        transport._collection_qpos_deques,
+        1.0,
+        gripper_deques_by_group=transport._collection_qpos_gripper_deques,
+    )
+
+    np.testing.assert_array_equal(
+        qpos,
+        np.array([0, 1, 2, 3, 4, 5, 42, 10, 11, 12, 13, 14, 15, 43], dtype=np.float32),
+    )
+
+
+def test_ros2_collection_action_gripper_snaps_to_robot_open_close(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=object,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport._collection_action_qpos_deques["left_arm"].append(
+        _stamped_msg(1, [0, 1, 2, 3, 4, 5])
+    )
+    transport._collection_action_qpos_deques["right_arm"].append(
+        _stamped_msg(1, [10, 11, 12, 13, 14, 15])
+    )
+    transport._collection_action_qpos_gripper_deques["left_arm"].append(_stamped_msg(1, [1]))
+    transport._collection_action_qpos_gripper_deques["right_arm"].append(_stamped_msg(1, [0]))
+
+    action = transport._collection_joint_vector(
+        transport._collection_action_qpos_deques,
+        1.0,
+        gripper_deques_by_group=transport._collection_action_qpos_gripper_deques,
+        action_gripper=True,
+    )
+
+    np.testing.assert_array_equal(
+        action,
+        np.array([0, 1, 2, 3, 4, 5, 100, 10, 11, 12, 13, 14, 15, 0], dtype=np.float32),
+    )
+
+
+def test_ros2_collection_raw_batch_merges_gripper_topics(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    monkeypatch.setattr(
+        transport,
+        "_decode_image_msg",
+        lambda _camera_name, _msg: np.zeros((2, 2, 3), dtype=np.uint8),
+    )
+    for camera in transport._collection_camera_specs():
+        transport._camera_deques[camera.name].append(_compressed_msg(1, b"jpeg"))
+    transport._collection_qpos_deques["left_arm"].append(_stamped_msg(1, [0, 1, 2, 3, 4, 5]))
+    transport._collection_qpos_deques["right_arm"].append(
+        _stamped_msg(1, [10, 11, 12, 13, 14, 15])
+    )
+    transport._collection_qpos_gripper_deques["left_arm"].append(_stamped_msg(1, [42]))
+    transport._collection_qpos_gripper_deques["right_arm"].append(_stamped_msg(1, [43]))
+
+    snapshot = transport.acquire_collection_raw()
+    assert snapshot is not None
+    batch = snapshot.decode_raw()
+
+    np.testing.assert_array_equal(
+        batch.vectors["state_qpos:left_arm"][0].value,
+        np.array([0, 1, 2, 3, 4, 5, 42], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        batch.vectors["state_qpos:right_arm"][0].value,
+        np.array([10, 11, 12, 13, 14, 15, 43], dtype=np.float32),
+    )
+
+
+def test_ros2_collection_operator_gripper_action_seed_is_latched(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport._group_gripper_deques["left_arm"].append(_stamped_msg(1, [100]))
+    transport._group_gripper_deques["right_arm"].append(_stamped_msg(1, [0]))
+    transport.start_collection()
+    transport._collection_action_qpos_deques["left_arm"].append(
+        _stamped_msg(10, [0, 1, 2, 3, 4, 5])
+    )
+    transport._collection_action_qpos_deques["right_arm"].append(
+        _stamped_msg(10, [10, 11, 12, 13, 14, 15])
+    )
+
+    action = transport._collection_joint_vector(transport._collection_action_qpos_deques, 10.0)
+
+    np.testing.assert_array_equal(
+        action,
+        np.array([0, 1, 2, 3, 4, 5, 100, 10, 11, 12, 13, 14, 15, 0], dtype=np.float32),
+    )
+
+
+def test_ros2_clear_collection_backlog_seeds_operator_gripper_action(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport._group_gripper_deques["left_arm"].append(_stamped_msg(1, [100]))
+    transport._group_gripper_deques["right_arm"].append(_stamped_msg(1, [0]))
+
+    transport.clear_collection_backlog()
+
+    assert len(transport._collection_action_qpos_gripper_deques["left_arm"]) == 1
+    assert len(transport._collection_action_qpos_gripper_deques["right_arm"]) == 1
+
+
+def test_ros2_clear_collection_backlog_does_not_synthesize_action_qpos(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+
+    transport.clear_collection_backlog()
+
+    assert list(transport._collection_action_qpos_deques["left_arm"]) == []
+    assert list(transport._collection_action_qpos_deques["right_arm"]) == []
+
+
+def test_ros2_collection_raw_requires_motion_target_action_after_clear(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+
+    transport.clear_collection_backlog()
+
+    assert len(transport._collection_action_qpos_deques["left_arm"]) == 0
+    assert len(transport._collection_action_qpos_deques["right_arm"]) == 0
+
+    left = _stamped_msg(2, [0, 1, 2, 3, 4, 5])
+    right = _stamped_msg(2, [10, 11, 12, 13, 14, 15])
+    transport._collection_qpos_deques["left_arm"].append(left)
+    transport._collection_qpos_deques["right_arm"].append(right)
+
+    snapshot = transport.acquire_collection_raw()
+    assert snapshot is not None
+    batch = snapshot.decode_raw()
+
+    assert "action_qpos:left_arm" not in batch.vectors
+    assert "action_qpos:right_arm" not in batch.vectors
+
+
+def test_ros2_collection_operator_gripper_action_records_new_latched_target(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport._group_gripper_deques["left_arm"].append(_stamped_msg(1, [100]))
+    transport._group_gripper_deques["right_arm"].append(_stamped_msg(1, [0]))
+    transport.start_collection()
+    transport.record_collection_gripper_action(
+        "left_arm",
+        0.0,
+        stamp=_stamped_msg(5).header.stamp,
+    )
+    transport._collection_action_qpos_deques["left_arm"].append(
+        _stamped_msg(10, [0, 1, 2, 3, 4, 5])
+    )
+    transport._collection_action_qpos_deques["right_arm"].append(
+        _stamped_msg(10, [10, 11, 12, 13, 14, 15])
+    )
+
+    action = transport._collection_joint_vector(transport._collection_action_qpos_deques, 10.0)
+
+    np.testing.assert_array_equal(
+        action,
+        np.array([0, 1, 2, 3, 4, 5, 0, 10, 11, 12, 13, 14, 15, 0], dtype=np.float32),
+    )
+
+
+def test_ros2_collection_raw_action_qpos_is_complete_from_seeded_gripper(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=_FakeJointState,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    monkeypatch.setattr(
+        transport,
+        "_decode_image_msg",
+        lambda _camera_name, _msg: np.zeros((2, 2, 3), dtype=np.uint8),
+    )
+    transport._group_gripper_deques["left_arm"].append(_stamped_msg(1, [100]))
+    transport._group_gripper_deques["right_arm"].append(_stamped_msg(1, [0]))
+    transport.clear_collection_backlog()
+    for camera in transport._collection_camera_specs():
+        transport._camera_deques[camera.name].append(_compressed_msg(2, b"jpeg"))
+    transport._collection_qpos_deques["left_arm"].append(_stamped_msg(2, [0, 1, 2, 3, 4, 5]))
+    transport._collection_qpos_deques["right_arm"].append(
+        _stamped_msg(2, [10, 11, 12, 13, 14, 15])
+    )
+    transport._collection_action_qpos_deques["left_arm"].append(
+        _stamped_msg(2, [20, 21, 22, 23, 24, 25])
+    )
+    transport._collection_action_qpos_deques["right_arm"].append(
+        _stamped_msg(2, [30, 31, 32, 33, 34, 35])
+    )
+
+    snapshot = transport.acquire_collection_raw()
+    assert snapshot is not None
+    batch = snapshot.decode_raw()
+
+    np.testing.assert_array_equal(
+        batch.vectors["action_qpos:left_arm"][0].value,
+        np.array([20, 21, 22, 23, 24, 25, 100], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        batch.vectors["action_qpos:right_arm"][0].value,
+        np.array([30, 31, 32, 33, 34, 35, 0], dtype=np.float32),
+    )
+
+
+def test_ros2_collection_diagnostics_reports_missing_action_gripper(monkeypatch):
+    node = _FakeNode()
+    runtime = types.SimpleNamespace(
+        node=node,
+        cv_bridge=object(),
+        image_type=object,
+        compressed_image_type=object,
+        joint_state_type=object,
+        pose_stamped_type=object,
+    )
+    monkeypatch.setattr(ros2, "get_ros2_runtime", lambda node_name: runtime)
+    monkeypatch.setattr(ros2, "_make_live_qos", lambda depth=10: object())
+
+    config = load_config(_R1LITE_COLLECTION)
+    robot = ROBOT_REGISTRY.build(config.robot.type)
+    transport = ros2.Ros2Transport(config, robot)
+    transport._collection_action_qpos_deques["left_arm"].append(
+        _stamped_msg(1, [0, 1, 2, 3, 4, 5])
+    )
+    transport._collection_action_qpos_deques["right_arm"].append(
+        _stamped_msg(1, [10, 11, 12, 13, 14, 15])
+    )
+    transport._collection_qpos_gripper_deques["left_arm"].append(_stamped_msg(1, [42]))
+    transport._collection_action_qpos_gripper_deques["right_arm"].append(_stamped_msg(1, [0]))
+
+    diagnostics = transport.collection_diagnostics()
+
+    assert "action_qpos_gripper:left_arm" in diagnostics
+    assert "source=operator" in diagnostics
+    assert "no messages" in diagnostics


### PR DESCRIPTION
## Summary
- Replace collection saving with raw episode buffering plus fixed-clock alignment across cameras, state, and action streams.
- Route collect, rollout, HIL intervention, and eval outputs through the shared EpisodeLogger save path.
- Update ROS1/ROS2/ZMQ collection capture and focused tests for alignment, operator control, rollout interventions, and transport raw streams.

## Test Plan
- `git diff --check origin/main..HEAD`
- `pytest -q` in clean detached worktree: 465 passed, 12 warnings