### PR TITLE
Sync async save pipeline for eval and rollout

### DIFF
--- a/configs/00_base/defaults.py
+++ b/configs/00_base/defaults.py
@@ -106,7 +106,7 @@ rollout = dict(
         log_dir="",
         fps=30,
         save_queue_max=15,
-        async_save=False,
+        async_save=True,
     ),
     intervention=dict(
         enabled=False,

--- a/configs/01_deploy/r1lite/_base.py
+++ b/configs/01_deploy/r1lite/_base.py
@@ -97,7 +97,7 @@ rollout = dict(
         log_dir='work_dirs/rollout/r1lite',
         fps=15,
         save_queue_max=15,
-        async_save=False,
+        async_save=True,
         image_height=360,
         image_width=640,
     ),

--- a/configs/03_evaluation/r1lite_eval.py
+++ b/configs/03_evaluation/r1lite_eval.py
@@ -1,0 +1,46 @@
+"""R1 Lite: openpi qpos eval."""
+
+_base_ = ['../01_deploy/r1lite/openpi_qpos.py']
+
+eval_cfg = dict(
+    storage=dict(
+        fps=15,
+        save_queue_max=15,
+    ),
+    trials_per_prompt=5,
+    cli_mode='real',
+    inference_strategy='rtc',
+    reset_after_each_trial=False,
+    skip_warmup_after_first=True,
+    checkpoints=[
+        dict(
+            name='r1lite_baseline_A',
+            config='../01_deploy/r1lite/openpi_qpos.py',
+            port=9000,
+        ),
+        # dict(
+        #     name='pi05_huawei_ww_lora_2606_task1_0621_100000',
+        #     config='../01_deploy/r1lite/openpi_qpos.py',
+        #     port=9001,
+        # ),
+    ],
+    shuffle_ckpts=False,
+    shuffle_seed=42,
+    enable_ssh_forward=False,
+    tasks=[
+        dict(
+            prompt_en='pack up a smart phone',
+            milestones=(
+                ('half', 'about half of the objects are stored correctly'),
+                ('all', 'all objects are stored correctly'),
+            ),
+        ),
+        # dict(
+        #     prompt_en='Sort the tabletop items: put trash into the black bin and useful items into the white bin.',  # noqa: E501
+        #     milestones=(
+        #         ('half', 'about half of the tabletop items are sorted correctly'),
+        #         ('all', 'all tabletop items are sorted correctly'),
+        #     ),
+        # ),
+    ],
+)

--- a/examples/hardware/r1_lite/README.md
+++ b/examples/hardware/r1_lite/README.md
@@ -11,6 +11,64 @@ topics and publishes to the `/motion_target/...` command topics declared in
 `run_hardware.sh` starts the robot's own bringup remotely over SSH and then
 launches EVA locally; a ZMQ fake node is provided for no-hardware dev.
 
+## Communication Architecture
+
+`run_hardware.sh` uses two separate communication paths. Configure both for your
+own network; the default hostnames are examples, not universal robot addresses.
+
+```text
+Your workstation
+  |
+  | 1. SSH: start/stop the robot bringup in remote tmux
+  v
+Robot computer (R1LITE_HOST, default: r1lite)
+  |
+  | runs ~/r1lite/robot/start_robot.sh and publishes/subscribes ROS 2 topics
+  v
+ROS 2 / FastDDS network
+  ^
+  | 2. DDS: EVA subscribes camera/state topics and publishes command topics
+  |
+Your workstation running EVA
+```
+
+The SSH path only starts the robot-side software. If `ssh r1lite` fails with
+`Could not resolve hostname`, set `R1LITE_HOST` to the robot's real SSH target
+or add an SSH alias. This can be an IP address, a DNS name, or `user@host`:
+
+```bash
+R1LITE_HOST=192.168.1.42 bash examples/hardware/r1_lite/run_hardware.sh
+R1LITE_HOST=robot@192.168.1.42 bash examples/hardware/r1_lite/run_hardware.sh
+```
+
+The ROS 2 path is controlled by your local ROS 2 environment and FastDDS profile.
+This repository includes a reference profile at
+`examples/hardware/r1_lite/fastdds_r1lite_super_client.xml`, and
+`run_hardware.sh` uses it by default. Different labs often have different robot
+IPs, discovery-server addresses, or workstation interface IPs, so treat the
+bundled XML as a starting point. If your network differs, copy it, edit the
+addresses, and pass your copy explicitly:
+
+```bash
+cp examples/hardware/r1_lite/fastdds_r1lite_super_client.xml \
+  ~/.ros/fastdds_r1lite_my_robot.xml
+
+# Edit ~/.ros/fastdds_r1lite_my_robot.xml for your network, then run:
+FASTRTPS_DEFAULT_PROFILES_FILE=~/.ros/fastdds_r1lite_my_robot.xml \
+R1LITE_HOST=robot@192.168.1.42 \
+  bash examples/hardware/r1_lite/run_hardware.sh
+```
+
+In the XML, change the `interfaceWhiteList/address` value to your workstation's
+IP on the robot network. Change the `discoveryServersList/.../udpv4/address`
+value to the FastDDS discovery server IP used by your robot stack. Keep the port
+and `RemoteServer prefix` only if they match the robot-side FastDDS setup.
+
+The local EVA process then uses the ROS 2 topics declared in
+`configs/01_deploy/r1lite/_base.py` and `configs/02_collection/r1lite.py`. If SSH
+works but EVA cannot see camera/state topics, debug the DDS/profile/network side;
+changing `R1LITE_HOST` only changes the remote startup SSH target.
+
 ## Files
 
 - `run_hardware.sh`: starts the on-robot bringup in a remote tmux session over
@@ -25,10 +83,13 @@ launches EVA locally; a ZMQ fake node is provided for no-hardware dev.
 `run_hardware.sh` against the real robot assumes:
 
 - ROS 2 Humble at `/opt/ros/humble/setup.bash` (sourced if present).
-- A FastDDS super-client profile at `~/.ros/fastdds_r1lite_super_client.xml`
-  (overridable via `FASTRTPS_DEFAULT_PROFILES_FILE`). The script **errors out**
-  if this file is missing.
-- Passwordless SSH access to the robot host (`r1lite` by default) where
+- A FastDDS XML profile for your robot network. The script defaults to
+  `examples/hardware/r1_lite/fastdds_r1lite_super_client.xml` and **errors out**
+  if the selected file is missing. If your robot network differs from that
+  reference profile, copy the XML and set `FASTRTPS_DEFAULT_PROFILES_FILE` to
+  your edited copy.
+- Passwordless SSH access to the robot host (`r1lite` by default, overridable via
+  `R1LITE_HOST`) where
   `~/r1lite/robot/start_robot.sh` brings up the robot, with `tmux` installed
   there.
 
@@ -80,15 +141,43 @@ bash examples/hardware/r1_lite/run_hardware.sh \
   --config configs/01_deploy/r1lite/openpi_qpos.py --web-port 8080
 ```
 
+The default command uses the bundled FastDDS reference profile. If your SSH
+target or DDS network differs, provide both your SSH target and your edited
+profile:
+
+```bash
+FASTRTPS_DEFAULT_PROFILES_FILE=/path/to/your/r1lite_fastdds_profile.xml \
+R1LITE_HOST=robot@192.168.1.42 \
+  bash examples/hardware/r1_lite/run_hardware.sh
+```
+
+Use the bundled XML as the reference for what to change:
+
+```xml
+<interfaceWhiteList>
+  <address>192.168.12.30</address>  <!-- your workstation IP -->
+</interfaceWhiteList>
+
+<udpv4>
+  <address>192.168.12.12</address>  <!-- robot FastDDS discovery server IP -->
+  <port>11811</port>
+</udpv4>
+```
+
+Do not copy another machine's edited profile blindly: it may contain that
+machine's local IP address or a robot/discovery-server address from a different
+network.
+
 Environment overrides:
 
 ```text
-R1LITE_HOST                       Robot SSH host                     (default: r1lite)
+R1LITE_HOST                       Robot SSH target, IP, DNS name, or user@host (default: r1lite)
 R1LITE_SESSION                    Remote tmux session for the robot  (default: eva_r1lite_robot)
 CAT_HOST / CAT_SESSION            Teleop host / session (teleop line is commented out by default)
 EVA_CONFIG                        Default config when no --config is passed (default: configs/02_collection/r1lite.py)
-FASTRTPS_DEFAULT_PROFILES_FILE    FastDDS profile path
+FASTRTPS_DEFAULT_PROFILES_FILE    FastDDS profile XML (default: examples/hardware/r1_lite/fastdds_r1lite_super_client.xml)
 RMW_IMPLEMENTATION                RMW backend (default: rmw_fastrtps_cpp)
+ROS_SETUP_BASH                    ROS 2 setup script (default: /opt/ros/humble/setup.bash)
 ```
 
 The teleop bringup line (host `cat`, session `eva_r1lite_teleop`) is commented

--- a/examples/hardware/r1_lite/fake_node.py
+++ b/examples/hardware/r1_lite/fake_node.py
@@ -1,14 +1,1139 @@
 #!/usr/bin/env python3
-"""Fake r1_lite hardware node — thin wrapper over examples/hardware/fake_common.py."""
+"""ROS2-only fake R1 Lite node with an embedded local control UI."""
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
+import argparse
+import dataclasses
+import io
+import json
+import logging
+import threading
+import time
+import webbrowser
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import numpy as np
+from PIL import Image
 
-from fake_common import main  # noqa: E402
+LOGGER = logging.getLogger(__name__)
+
+LEFT_ARM_JOINTS = tuple(f"left_arm_joint{i}" for i in range(1, 7))
+RIGHT_ARM_JOINTS = tuple(f"right_arm_joint{i}" for i in range(1, 7))
+GRIPPER_OPEN = 100.0
+GRIPPER_CLOSE = 0.0
+JOINT_STEP = 0.05
+OPERATOR_BUTTON_TOPIC = "/eva/operator_button"
+SUPPORTED_OPERATOR_BUTTONS = frozenset(
+    {
+        "x",
+        "y",
+        "left_gripper_open",
+        "left_gripper_close",
+        "right_gripper_open",
+        "right_gripper_close",
+    }
+)
+
+CAMERA_TOPICS = {
+    "head": "/hdas/camera_head/right_raw/image_raw_color/compressed",
+    "left_wrist": "/hdas/camera_wrist_left/color/image_raw/compressed",
+    "right_wrist": "/hdas/camera_wrist_right/color/image_raw/compressed",
+}
+
+CAMERA_OBSERVATION_KEYS = {
+    "head": "cam_high",
+    "left_wrist": "cam_left_wrist",
+    "right_wrist": "cam_right_wrist",
+}
+
+CAMERA_COLORS = {
+    "head": (170, 70, 45),
+    "left_wrist": (45, 95, 170),
+    "right_wrist": (45, 160, 95),
+}
+CAMERA_FRAME_CACHE_SIZE = 30
+
+
+@dataclasses.dataclass(frozen=True)
+class ArmTopics:
+    """ROS2 topic names for one R1 Lite arm group."""
+
+    feedback: str
+    command: str
+    eef: str
+    gripper_feedback: str
+    gripper_command: str
+    hil: str
+
+
+ARM_TOPICS = {
+    "left_arm": ArmTopics(
+        feedback="/hdas/feedback_arm_left",
+        command="/motion_target/target_joint_state_arm_left",
+        eef="/relaxed_ik/motion_control/pose_ee_arm_left",
+        gripper_feedback="/hdas/feedback_gripper_left",
+        gripper_command="/motion_target/target_position_gripper_left",
+        hil="/eva/hil/input_joint_state_arm_left",
+    ),
+    "right_arm": ArmTopics(
+        feedback="/hdas/feedback_arm_right",
+        command="/motion_target/target_joint_state_arm_right",
+        eef="/relaxed_ik/motion_control/pose_ee_arm_right",
+        gripper_feedback="/hdas/feedback_gripper_right",
+        gripper_command="/motion_target/target_position_gripper_right",
+        hil="/eva/hil/input_joint_state_arm_right",
+    ),
+}
+
+JOINT_NAMES = {
+    "left_arm": LEFT_ARM_JOINTS,
+    "right_arm": RIGHT_ARM_JOINTS,
+}
+
+
+@dataclasses.dataclass(frozen=True)
+class Ros2MessageTypes:
+    """ROS2 message constructors used by the fake runtime."""
+
+    compressed_image: type
+    joint_state: type
+    pose_stamped: type
+    string: type
+
+
+class R1LiteFakeState:
+    """Thread-safe synthetic R1 Lite feedback, command, and UI HIL state."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._feedback = {
+            "left_arm": np.zeros(6, dtype=np.float32),
+            "right_arm": np.zeros(6, dtype=np.float32),
+        }
+        self._commands = {
+            "left_arm": np.zeros(6, dtype=np.float32),
+            "right_arm": np.zeros(6, dtype=np.float32),
+        }
+        self._hil = {
+            "left_arm": np.zeros(6, dtype=np.float32),
+            "right_arm": np.zeros(6, dtype=np.float32),
+        }
+        self._grippers = {
+            "left_arm": float(GRIPPER_OPEN),
+            "right_arm": float(GRIPPER_OPEN),
+        }
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a JSON-serializable copy of feedback, gripper, and HIL state.
+
+        Returns:
+            snapshot: dict with arm feedback joints [6], gripper scalar, command
+                joints [6], and HIL joints [6] for each group.
+        """
+        with self._lock:
+            return {
+                "feedback": {
+                    group: {
+                        "joints": self._feedback[group].astype(float).tolist(),
+                        "gripper": float(self._grippers[group]),
+                    }
+                    for group in ARM_TOPICS
+                },
+                "hil": {group: self._hil[group].astype(float).tolist() for group in ARM_TOPICS},
+                "command": {
+                    group: self._commands[group].astype(float).tolist()
+                    for group in ARM_TOPICS
+                },
+                "joint_step": JOINT_STEP,
+            }
+
+    def feedback_copy(self) -> tuple[dict[str, np.ndarray], dict[str, float]]:
+        """Return copies of feedback arm joints and gripper positions.
+
+        Returns:
+            arms: group -> arm joint vector [6].
+            grippers: group -> gripper position scalar.
+        """
+        with self._lock:
+            arms = {group: value.copy() for group, value in self._feedback.items()}
+            grippers = dict(self._grippers)
+        return arms, grippers
+
+    def hil_copy(self) -> dict[str, np.ndarray]:
+        """Return copies of the current HIL joint vectors.
+
+        Returns:
+            hil: group -> HIL joint vector [6].
+        """
+        with self._lock:
+            return {group: value.copy() for group, value in self._hil.items()}
+
+    def command_copy(self) -> dict[str, np.ndarray]:
+        """Return copies of current arm command targets.
+
+        Returns:
+            commands: group -> command target vector [6].
+        """
+        with self._lock:
+            return {group: value.copy() for group, value in self._commands.items()}
+
+    def sync_hil_to_feedback(self) -> dict[str, np.ndarray]:
+        """Copy current feedback arm joints into the HIL input state.
+
+        Returns:
+            hil: group -> synchronized HIL joint vector [6].
+        """
+        with self._lock:
+            for group_name, feedback in self._feedback.items():
+                self._hil[group_name] = feedback.copy()
+            return {group: value.copy() for group, value in self._hil.items()}
+
+    def set_hil_joint(self, group_name: str, joint_index: int, value: float) -> np.ndarray:
+        """Set one HIL slider joint and return the group's full HIL vector.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            joint_index: arm-local joint index in [0, 5].
+            value: new joint position.
+
+        Returns:
+            positions: [6] float32 HIL joint vector.
+        """
+        self._require_group(group_name)
+        self._require_joint_index(joint_index)
+        with self._lock:
+            self._hil[group_name][joint_index] = float(value)
+            return self._hil[group_name].copy()
+
+    def apply_hil_delta(self, group_name: str, joint_index: int, delta: float) -> np.ndarray:
+        """Add a delta to one HIL slider joint and return the full HIL vector.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            joint_index: arm-local joint index in [0, 5].
+            delta: signed joint increment.
+
+        Returns:
+            positions: [6] float32 HIL joint vector.
+        """
+        self._require_group(group_name)
+        self._require_joint_index(joint_index)
+        with self._lock:
+            self._hil[group_name][joint_index] += float(delta)
+            return self._hil[group_name].copy()
+
+    def apply_command_delta(
+        self, group_name: str, joint_index: int, delta: float
+    ) -> np.ndarray:
+        """Add a delta to one feedback joint and return the full command vector.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            joint_index: arm-local joint index in [0, 5].
+            delta: signed joint increment.
+
+        Returns:
+            positions: [6] float32 command vector.
+        """
+        self._require_group(group_name)
+        self._require_joint_index(joint_index)
+        with self._lock:
+            self._commands[group_name][joint_index] += float(delta)
+            self._feedback[group_name] = self._commands[group_name].copy()
+            return self._commands[group_name].copy()
+
+    def apply_arm_command(self, group_name: str, positions: np.ndarray) -> None:
+        """Apply an incoming motion target command to fake arm feedback.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            positions: [6] arm joint target, or [7] group target with gripper.
+        """
+        self._require_group(group_name)
+        vector = np.asarray(positions, dtype=np.float32).reshape(-1)
+        if vector.shape == (7,):
+            with self._lock:
+                self._commands[group_name] = vector[:6].copy()
+                self._feedback[group_name] = vector[:6].copy()
+                self._grippers[group_name] = float(vector[6])
+            return
+        if vector.shape != (6,):
+            raise ValueError(
+                f"{group_name} arm command must have 6 or 7 positions, got {vector.shape}"
+            )
+        with self._lock:
+            self._commands[group_name] = vector.copy()
+            self._feedback[group_name] = vector.copy()
+
+    def apply_gripper_command(self, group_name: str, value: float) -> None:
+        """Apply an incoming gripper command to fake gripper feedback.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            value: gripper position scalar.
+        """
+        self._require_group(group_name)
+        with self._lock:
+            self._grippers[group_name] = float(value)
+
+    def _require_group(self, group_name: str) -> None:
+        if group_name not in ARM_TOPICS:
+            allowed = ", ".join(ARM_TOPICS)
+            raise ValueError(f"unsupported group {group_name!r}; expected one of: {allowed}")
+
+    def _require_joint_index(self, joint_index: int) -> None:
+        if joint_index < 0 or joint_index >= 6:
+            raise ValueError(f"joint_index must be in [0, 5], got {joint_index}")
+
+
+class R1LiteFakeControlApi:
+    """UI-facing command API over the synthetic state and ROS2 bridge."""
+
+    def __init__(self, state: R1LiteFakeState, bridge: Any) -> None:
+        self._state = state
+        self._bridge = bridge
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return current UI state.
+
+        Returns:
+            snapshot: JSON-serializable state from R1LiteFakeState.
+        """
+        return self._state.snapshot()
+
+    def operator_button(self, label: str) -> dict[str, str]:
+        """Publish one EVA operator button label.
+
+        Args:
+            label: x, y, or one of the gripper operator labels.
+
+        Returns:
+            result: JSON-serializable acknowledgement.
+        """
+        value = str(label).strip().lower()
+        if value not in SUPPORTED_OPERATOR_BUTTONS:
+            raise ValueError(f"unsupported operator button {label!r}")
+        self._bridge.publish_operator_button(value)
+        return {"ok": "true", "button": value}
+
+    def gripper(self, side: str, command: str) -> dict[str, str]:
+        """Publish one gripper operator label.
+
+        Args:
+            side: left or right.
+            command: open or close.
+
+        Returns:
+            result: JSON-serializable acknowledgement.
+        """
+        side_value = str(side).strip().lower()
+        command_value = str(command).strip().lower()
+        if side_value not in {"left", "right"}:
+            raise ValueError(f"unsupported gripper side {side!r}")
+        if command_value not in {"open", "close"}:
+            raise ValueError(f"unsupported gripper command {command!r}")
+        return self.operator_button(f"{side_value}_gripper_{command_value}")
+
+    def set_joint(self, group_name: str, joint_index: int, value: float) -> dict[str, Any]:
+        """Set one HIL joint and publish the full HIL vector.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            joint_index: arm-local joint index in [0, 5].
+            value: new joint position.
+
+        Returns:
+            result: group and updated [6] HIL positions.
+        """
+        positions = self._state.set_hil_joint(group_name, int(joint_index), float(value))
+        self._bridge.publish_hil(group_name, positions)
+        return {"group": group_name, "positions": positions.astype(float).tolist()}
+
+    def adjust_joint(self, group_name: str, joint_index: int, delta: float) -> dict[str, Any]:
+        """Add a delta to one HIL joint and publish the full HIL vector.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            joint_index: arm-local joint index in [0, 5].
+            delta: signed joint increment.
+
+        Returns:
+            result: group and updated [6] HIL positions.
+        """
+        positions = self._state.apply_hil_delta(group_name, int(joint_index), float(delta))
+        self._bridge.publish_hil(group_name, positions)
+        return {"group": group_name, "positions": positions.astype(float).tolist()}
+
+    def adjust_command(
+        self, group_name: str, joint_index: int, delta: float
+    ) -> dict[str, Any]:
+        """Add a delta to one command joint and publish a motion target.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            joint_index: arm-local joint index in [0, 5].
+            delta: signed joint increment.
+
+        Returns:
+            result: group and updated [6] command positions.
+        """
+        positions = self._state.apply_command_delta(
+            group_name,
+            int(joint_index),
+            float(delta),
+        )
+        self._bridge.publish_command(group_name, positions)
+        return {"group": group_name, "positions": positions.astype(float).tolist()}
+
+    def sync_hil_to_feedback(self) -> dict[str, str]:
+        """Sync all HIL joint vectors to the current fake feedback and publish them.
+
+        Returns:
+            result: JSON-serializable acknowledgement.
+        """
+        synced = self._state.sync_hil_to_feedback()
+        for group_name, positions in synced.items():
+            self._bridge.publish_hil(group_name, positions)
+        return {"ok": "true"}
+
+
+class R1LiteRos2Fake:
+    """ROS2 publisher/subscriber bridge for the synthetic R1 Lite state."""
+
+    def __init__(
+        self,
+        *,
+        node: Any,
+        message_types: Ros2MessageTypes,
+        state: R1LiteFakeState,
+        rate_hz: float,
+        image_height: int,
+        image_width: int,
+        qos: Any,
+        camera_qos: Any = None,
+        control_node: Any = None,
+        command_callback_group: Any = None,
+        timer_callback_group: Any = None,
+        create_timer: bool = True,
+        publish_cameras: bool = True,
+        publish_robot: bool = True,
+        subscribe_commands: bool = True,
+    ) -> None:
+        if rate_hz <= 0.0:
+            raise ValueError(f"rate_hz must be positive, got {rate_hz}")
+        if image_height <= 0 or image_width <= 0:
+            raise ValueError(f"image size must be positive, got {image_width}x{image_height}")
+
+        self._node = node
+        self._control_node = control_node or node
+        self._types = message_types
+        self._state = state
+        self._image_height = image_height
+        self._image_width = image_width
+        self._frame_index = 0
+        self._camera_frame_cache = {}
+        if publish_cameras:
+            self._camera_frame_cache = {
+                camera_name: [
+                    _jpeg_image(
+                        CAMERA_COLORS[camera_name],
+                        image_height,
+                        image_width,
+                        frame_index,
+                    )
+                    for frame_index in range(CAMERA_FRAME_CACHE_SIZE)
+                ]
+                for camera_name in CAMERA_TOPICS
+            }
+
+        self._camera_publishers = {}
+        if publish_cameras:
+            self._camera_publishers = {
+                name: node.create_publisher(
+                    message_types.compressed_image,
+                    topic,
+                    camera_qos if camera_qos is not None else qos,
+                )
+                for name, topic in CAMERA_TOPICS.items()
+            }
+        self._arm_publishers = {}
+        self._command_publishers = {}
+        self._gripper_publishers = {}
+        self._eef_publishers = {}
+        self._operator_button_publisher = None
+        self._hil_publishers = {}
+        if publish_robot:
+            self._arm_publishers = {
+                group: node.create_publisher(message_types.joint_state, topics.feedback, qos)
+                for group, topics in ARM_TOPICS.items()
+            }
+            self._gripper_publishers = {
+                group: node.create_publisher(message_types.joint_state, topics.gripper_feedback, qos)
+                for group, topics in ARM_TOPICS.items()
+            }
+            self._eef_publishers = {
+                group: node.create_publisher(message_types.pose_stamped, topics.eef, qos)
+                for group, topics in ARM_TOPICS.items()
+            }
+            self._operator_button_publisher = self._control_node.create_publisher(
+                message_types.string,
+                OPERATOR_BUTTON_TOPIC,
+                10,
+            )
+            self._hil_publishers = {
+                group: self._control_node.create_publisher(message_types.joint_state, topics.hil, qos)
+                for group, topics in ARM_TOPICS.items()
+            }
+            self._command_publishers = {
+                group: self._control_node.create_publisher(
+                    message_types.joint_state,
+                    topics.command,
+                    qos,
+                )
+                for group, topics in ARM_TOPICS.items()
+            }
+
+        if subscribe_commands:
+            for group_name, topics in ARM_TOPICS.items():
+                self._control_node.create_subscription(
+                    message_types.joint_state,
+                    topics.command,
+                    lambda msg, group=group_name: self._on_arm_command(group, msg),
+                    qos,
+                    callback_group=command_callback_group,
+                )
+                self._control_node.create_subscription(
+                    message_types.joint_state,
+                    topics.gripper_command,
+                    lambda msg, group=group_name: self._on_gripper_command(group, msg),
+                    qos,
+                    callback_group=command_callback_group,
+                )
+
+        self._timer = None
+        if create_timer:
+            self._timer = node.create_timer(
+                1.0 / rate_hz,
+                self.publish_once,
+                callback_group=timer_callback_group,
+            )
+
+    def publish_operator_button(self, label: str) -> None:
+        """Publish one operator button event on /eva/operator_button.
+
+        Args:
+            label: normalized button label accepted by EVA operator_control.
+        """
+        if label not in SUPPORTED_OPERATOR_BUTTONS:
+            raise ValueError(f"unsupported operator button {label!r}")
+        if self._operator_button_publisher is None:
+            raise RuntimeError("operator button publisher is disabled")
+        message = self._types.string()
+        message.data = label
+        self._operator_button_publisher.publish(message)
+
+    def publish_hil(self, group_name: str, positions: np.ndarray) -> None:
+        """Publish one HIL input JointState for a group.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            positions: [6] arm joint vector.
+        """
+        if group_name not in ARM_TOPICS:
+            raise ValueError(f"unsupported HIL group {group_name!r}")
+        vector = np.asarray(positions, dtype=np.float32).reshape(-1)
+        if vector.shape != (6,):
+            raise ValueError(f"{group_name} HIL input must have 6 positions, got {vector.shape}")
+        if group_name not in self._hil_publishers:
+            raise RuntimeError(f"HIL publisher is disabled for {group_name}")
+        message = self._joint_state(group_name, vector, self._stamp())
+        self._hil_publishers[group_name].publish(message)
+
+    def publish_command(self, group_name: str, positions: np.ndarray) -> None:
+        """Publish one direct motion target command for a group.
+
+        Args:
+            group_name: "left_arm" or "right_arm".
+            positions: [6] arm joint vector.
+        """
+        if group_name not in ARM_TOPICS:
+            raise ValueError(f"unsupported command group {group_name!r}")
+        vector = np.asarray(positions, dtype=np.float32).reshape(-1)
+        if vector.shape != (6,):
+            raise ValueError(f"{group_name} command must have 6 positions, got {vector.shape}")
+        if group_name not in self._command_publishers:
+            raise RuntimeError(f"command publisher is disabled for {group_name}")
+        message = self._joint_state(group_name, vector, self._stamp())
+        self._command_publishers[group_name].publish(message)
+
+    def publish_once(self) -> None:
+        """Publish one full synthetic sensor frame."""
+        stamp = self._stamp()
+        arms, grippers = self._state.feedback_copy()
+        commands = self._state.command_copy()
+
+        for camera_name, publisher in self._camera_publishers.items():
+            message = self._types.compressed_image()
+            message.header.stamp = stamp
+            message.format = "jpeg"
+            frames = self._camera_frame_cache[camera_name]
+            message.data = frames[self._frame_index % len(frames)]
+            publisher.publish(message)
+
+        for group_name, arm in arms.items():
+            if group_name not in self._arm_publishers:
+                continue
+            self._arm_publishers[group_name].publish(self._joint_state(group_name, arm, stamp))
+            self._gripper_publishers[group_name].publish(
+                self._gripper_state(group_name, grippers[group_name], stamp)
+            )
+            self._eef_publishers[group_name].publish(
+                self._eef_pose(group_name, arm, grippers[group_name], stamp)
+            )
+            self._command_publishers[group_name].publish(
+                self._joint_state(group_name, commands[group_name], stamp)
+            )
+
+        self._frame_index += 1
+
+    def _on_arm_command(self, group_name: str, msg: Any) -> None:
+        self._state.apply_arm_command(group_name, np.asarray(msg.position, dtype=np.float32))
+
+    def _on_gripper_command(self, group_name: str, msg: Any) -> None:
+        position = list(msg.position)
+        if not position:
+            raise ValueError(f"{group_name} gripper command has no position")
+        self._state.apply_gripper_command(group_name, float(position[0]))
+
+    def _stamp(self) -> Any:
+        return self._node.get_clock().now().to_msg()
+
+    def _joint_state(self, group_name: str, positions: np.ndarray, stamp: Any) -> Any:
+        message = self._types.joint_state()
+        message.header.stamp = stamp
+        message.name = list(JOINT_NAMES[group_name])
+        message.position = [float(v) for v in positions]
+        return message
+
+    def _gripper_state(self, group_name: str, value: float, stamp: Any) -> Any:
+        message = self._types.joint_state()
+        message.header.stamp = stamp
+        side = "left" if group_name == "left_arm" else "right"
+        message.name = [f"{side}_gripper_joint"]
+        message.position = [float(value)]
+        return message
+
+    def _eef_pose(self, group_name: str, positions: np.ndarray, gripper: float, stamp: Any) -> Any:
+        message = self._types.pose_stamped()
+        message.header.stamp = stamp
+        sign = 1.0 if group_name == "left_arm" else -1.0
+        message.pose.position.x = 0.35 + 0.015 * float(positions[0])
+        message.pose.position.y = sign * (0.22 + 0.01 * float(positions[1]))
+        message.pose.position.z = 0.45 + 0.005 * float(positions[2]) + 0.0002 * float(gripper)
+        message.pose.orientation.w = 1.0
+        message.pose.orientation.x = 0.0
+        message.pose.orientation.y = 0.0
+        message.pose.orientation.z = 0.0
+        return message
+
+
+def _jpeg_image(
+    color: tuple[int, int, int],
+    height: int,
+    width: int,
+    frame_index: int,
+) -> bytes:
+    """Build one synthetic RGB JPEG image with a moving bright band.
+
+    Args:
+        color: base RGB color.
+        height: image height in pixels.
+        width: image width in pixels.
+        frame_index: running frame counter.
+
+    Returns:
+        data: JPEG bytes.
+    """
+    pulse = 0.5 + 0.5 * float(np.sin(frame_index * 0.05))
+    rgb = np.asarray(color, dtype=np.float32) * (0.45 + 0.55 * pulse)
+    image = np.empty((height, width, 3), dtype=np.uint8)
+    image[:] = rgb.astype(np.uint8)
+    band = int((frame_index * 4) % height)
+    image[band : min(band + max(height // 18, 2), height), :, :] = 255
+
+    buffer = io.BytesIO()
+    Image.fromarray(image).save(buffer, format="JPEG", quality=85)
+    return buffer.getvalue()
+
+
+def make_ui_handler(api: R1LiteFakeControlApi) -> type[BaseHTTPRequestHandler]:
+    """Create a request handler class bound to one fake control API.
+
+    Args:
+        api: UI command API.
+
+    Returns:
+        handler_class: BaseHTTPRequestHandler subclass for ThreadingHTTPServer.
+    """
+
+    class R1LiteFakeUiHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            if self.path == "/":
+                body = UI_HTML.encode("utf-8")
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return
+            if self.path == "/api/state":
+                self._send_json(api.snapshot())
+                return
+            self.send_error(HTTPStatus.NOT_FOUND, "unknown path")
+
+        def do_POST(self) -> None:
+            try:
+                payload = self._read_json()
+                if self.path == "/api/operator":
+                    self._send_json(api.operator_button(payload["button"]))
+                    return
+                if self.path == "/api/gripper":
+                    self._send_json(api.gripper(payload["side"], payload["command"]))
+                    return
+                if self.path == "/api/joint":
+                    self._send_json(
+                        api.set_joint(
+                            payload["group"],
+                            int(payload["index"]),
+                            float(payload["value"]),
+                        )
+                    )
+                    return
+                if self.path == "/api/joint_delta":
+                    self._send_json(
+                        api.adjust_joint(
+                            payload["group"],
+                            int(payload["index"]),
+                            float(payload["delta"]),
+                        )
+                    )
+                    return
+                if self.path == "/api/command_delta":
+                    self._send_json(
+                        api.adjust_command(
+                            payload["group"],
+                            int(payload["index"]),
+                            float(payload["delta"]),
+                        )
+                    )
+                    return
+                if self.path == "/api/sync_hil_to_feedback":
+                    self._send_json(api.sync_hil_to_feedback())
+                    return
+                self.send_error(HTTPStatus.NOT_FOUND, "unknown path")
+            except (KeyError, TypeError, ValueError) as exc:
+                self._send_json({"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
+
+        def _read_json(self) -> dict[str, Any]:
+            length = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(length)
+            return json.loads(raw.decode("utf-8"))
+
+        def _send_json(self, payload: dict[str, Any], status: HTTPStatus = HTTPStatus.OK) -> None:
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    return R1LiteFakeUiHandler
+
+
+UI_HTML = """<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>R1 Lite Fake</title>
+<style>
+:root {
+  color-scheme: light;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: #f4f5f7;
+  color: #18202a;
+}
+body {
+  margin: 0;
+}
+main {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 18px;
+}
+h1 {
+  margin: 0 0 14px;
+  font-size: 22px;
+  font-weight: 650;
+}
+.toolbar, .arms {
+  display: grid;
+  gap: 12px;
+}
+.toolbar {
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  margin-bottom: 16px;
+}
+.panel {
+  background: #ffffff;
+  border: 1px solid #d8dde5;
+  border-radius: 8px;
+  padding: 12px;
+}
+.panel h2 {
+  margin: 0 0 10px;
+  font-size: 14px;
+  font-weight: 650;
+}
+.buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+button {
+  min-height: 34px;
+  border: 1px solid #aeb7c2;
+  border-radius: 6px;
+  background: #f8fafc;
+  color: #18202a;
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+button:hover {
+  background: #edf2f7;
+}
+.buttons button {
+  min-width: 52px;
+  padding: 0 10px;
+}
+.arms {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+.joint {
+  display: grid;
+  grid-template-columns: 34px 34px minmax(120px, 1fr) 34px 62px;
+  align-items: center;
+  gap: 8px;
+  min-height: 42px;
+}
+.joint span {
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+}
+.joint input {
+  width: 100%;
+}
+.status {
+  margin-top: 8px;
+  color: #526170;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+</style>
+</head>
+<body>
+<main>
+  <h1>R1 Lite Fake</h1>
+  <section class="toolbar">
+    <div class="panel">
+      <h2>Operator</h2>
+      <div class="buttons">
+        <button data-button="x">X</button>
+        <button data-button="y">Y</button>
+        <button id="sync-hil">Sync HIL</button>
+      </div>
+    </div>
+    <div class="panel">
+      <h2>Left Gripper</h2>
+      <div class="buttons">
+        <button data-gripper-side="left" data-gripper-command="open">Open</button>
+        <button data-gripper-side="left" data-gripper-command="close">Close</button>
+      </div>
+    </div>
+    <div class="panel">
+      <h2>Right Gripper</h2>
+      <div class="buttons">
+        <button data-gripper-side="right" data-gripper-command="open">Open</button>
+        <button data-gripper-side="right" data-gripper-command="close">Close</button>
+      </div>
+    </div>
+  </section>
+  <section id="arms" class="arms"></section>
+</main>
+<script>
+const groups = [
+  ["left_arm", "Left Arm"],
+  ["right_arm", "Right Arm"],
+];
+const jointStep = 0.05;
+
+function postJson(path, payload) {
+  return fetch(path, {
+    method: "POST",
+    headers: {"Content-Type": "application/json"},
+    body: JSON.stringify(payload),
+  }).then((response) => {
+    if (!response.ok) {
+      return response.json().then((body) => {
+        throw new Error(body.error || response.statusText);
+      });
+    }
+    return response.json();
+  });
+}
+
+function buildArm(group, title) {
+  const panel = document.createElement("div");
+  panel.className = "panel";
+  panel.innerHTML = `<h2>${title}</h2>`;
+  for (let index = 0; index < 6; index += 1) {
+    const row = document.createElement("div");
+    row.className = "joint";
+    row.innerHTML = `
+      <span>J${index + 1}</span>
+      <button data-delta="-1">-</button>
+      <input type="range" min="-3.14" max="3.14" step="0.01" value="0">
+      <button data-delta="1">+</button>
+      <span data-value>0.00</span>
+    `;
+    const slider = row.querySelector("input");
+    const value = row.querySelector("[data-value]");
+    slider.addEventListener("input", () => {
+      value.textContent = Number(slider.value).toFixed(2);
+      postJson("/api/joint", {group, index, value: Number(slider.value)}).catch(console.error);
+    });
+    row.querySelectorAll("button").forEach((button) => {
+      button.addEventListener("click", () => {
+        postJson("/api/joint_delta", {
+          group,
+          index,
+          delta: Number(button.dataset.delta) * jointStep,
+        }).then(refresh).catch(console.error);
+      });
+    });
+    panel.appendChild(row);
+  }
+  const status = document.createElement("div");
+  status.className = "status";
+  status.dataset.status = group;
+  panel.appendChild(status);
+  return panel;
+}
+
+function install() {
+  const arms = document.querySelector("#arms");
+  groups.forEach(([group, title]) => arms.appendChild(buildArm(group, title)));
+  document.querySelectorAll("[data-button]").forEach((button) => {
+    button.addEventListener("click", () => {
+      postJson("/api/operator", {button: button.dataset.button}).catch(console.error);
+    });
+  });
+  document.querySelector("#sync-hil").addEventListener("click", () => {
+    postJson("/api/sync_hil_to_feedback", {}).then(refresh).catch(console.error);
+  });
+  document.querySelectorAll("[data-gripper-side]").forEach((button) => {
+    button.addEventListener("click", () => postJson("/api/gripper", {
+      side: button.dataset.gripperSide,
+      command: button.dataset.gripperCommand,
+    }).catch(console.error));
+  });
+}
+
+function refresh() {
+  return fetch("/api/state")
+    .then((response) => response.json())
+    .then((state) => {
+      groups.forEach(([group]) => {
+        const panel = document.querySelector(`[data-status="${group}"]`).parentElement;
+        panel.querySelectorAll(".joint").forEach((row, index) => {
+          const slider = row.querySelector("input");
+          const value = row.querySelector("[data-value]");
+          const next = state.hil[group][index];
+          slider.value = next;
+          value.textContent = Number(next).toFixed(2);
+        });
+        const feedback = state.feedback[group];
+        const joints = feedback.joints.map((v) => Number(v).toFixed(2)).join(" ");
+        const gripper = Number(feedback.gripper).toFixed(1);
+        document.querySelector(`[data-status="${group}"]`).textContent =
+          `feedback ${joints} | gripper ${gripper}`;
+      });
+    });
+}
+
+install();
+refresh();
+setInterval(refresh, 500);
+</script>
+</body>
+</html>
+"""
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="ROS2 fake R1 Lite node with local UI.")
+    parser.add_argument("--role", choices=("all", "cameras", "robot"), default="all")
+    parser.add_argument("--rate", type=float, default=30.0)
+    parser.add_argument("--ui-host", default="127.0.0.1")
+    parser.add_argument("--ui-port", type=int, default=8765)
+    parser.add_argument("--image-height", type=int, default=360)
+    parser.add_argument("--image-width", type=int, default=640)
+    parser.add_argument("--no-open-ui", action="store_true")
+    return parser
+
+
+def _make_live_qos(depth: int = 10) -> Any:
+    from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
+
+    return QoSProfile(
+        depth=depth,
+        reliability=QoSReliabilityPolicy.BEST_EFFORT,
+        durability=QoSDurabilityPolicy.VOLATILE,
+    )
+
+
+def _run_sensor_publish_loop(
+    bridge: R1LiteRos2Fake,
+    rate_hz: float,
+    stop_event: threading.Event,
+    is_running=None,
+) -> None:
+    """Publish fake sensor frames at a fixed rate outside the ROS2 executor.
+
+    Args:
+        bridge: ROS2 fake bridge whose ``publish_once`` emits one sensor frame.
+        rate_hz: target sensor publish rate.
+        stop_event: set to stop the loop.
+    """
+    period_s = 1.0 / rate_hz
+    next_tick = time.monotonic()
+    while not stop_event.is_set() and (is_running is None or is_running()):
+        bridge.publish_once()
+        next_tick += period_s
+        delay_s = next_tick - time.monotonic()
+        if delay_s <= 0.0:
+            next_tick = time.monotonic()
+            continue
+        stop_event.wait(delay_s)
+
+
+def main() -> None:
+    """Run the ROS2 fake node and embedded HTTP UI until interrupted."""
+    args = build_arg_parser().parse_args()
+
+    import rclpy
+    from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+    from rclpy.executors import MultiThreadedExecutor
+    from geometry_msgs.msg import PoseStamped
+    from rclpy.node import Node
+    from sensor_msgs.msg import CompressedImage, JointState
+    from std_msgs.msg import String
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if not rclpy.ok():
+        rclpy.init()
+
+    publish_cameras = args.role in {"all", "cameras"}
+    publish_robot = args.role in {"all", "robot"}
+    subscribe_commands = args.role in {"all", "robot"}
+    if args.role == "cameras":
+        sensor_node = Node("eva_r1lite_fake_cameras")
+        control_node = None
+    elif args.role == "robot":
+        sensor_node = Node("eva_r1lite_fake_robot")
+        control_node = Node("eva_r1lite_fake_control")
+    else:
+        sensor_node = Node("eva_r1lite_fake_sensor")
+        control_node = Node("eva_r1lite_fake_control")
+    state = R1LiteFakeState()
+    command_callback_group = MutuallyExclusiveCallbackGroup()
+    timer_callback_group = MutuallyExclusiveCallbackGroup()
+    bridge = R1LiteRos2Fake(
+        node=sensor_node,
+        control_node=control_node,
+        message_types=Ros2MessageTypes(
+            compressed_image=CompressedImage,
+            joint_state=JointState,
+            pose_stamped=PoseStamped,
+            string=String,
+        ),
+        state=state,
+        rate_hz=args.rate,
+        image_height=args.image_height,
+        image_width=args.image_width,
+        qos=_make_live_qos(),
+        camera_qos=_make_live_qos(depth=1),
+        command_callback_group=command_callback_group,
+        timer_callback_group=timer_callback_group,
+        create_timer=False,
+        publish_cameras=publish_cameras,
+        publish_robot=publish_robot,
+        subscribe_commands=subscribe_commands,
+    )
+    server = None
+    if publish_robot:
+        api = R1LiteFakeControlApi(state, bridge)
+        server = ThreadingHTTPServer((args.ui_host, args.ui_port), make_ui_handler(api))
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+
+        url = f"http://{args.ui_host}:{args.ui_port}/"
+        sensor_node.get_logger().info(f"R1 Lite fake UI: {url}")
+        if not args.no_open_ui:
+            opened = webbrowser.open(url)
+            if not opened:
+                sensor_node.get_logger().warning(f"Could not open browser automatically: {url}")
+
+    stop_event = threading.Event()
+    sensor_thread = threading.Thread(
+        target=_run_sensor_publish_loop,
+        args=(bridge, args.rate, stop_event, rclpy.ok),
+        daemon=True,
+    )
+    sensor_thread.start()
+    executor = None
+    if control_node is not None:
+        executor = MultiThreadedExecutor(num_threads=4)
+        executor.add_node(control_node)
+
+    try:
+        if executor is None:
+            while rclpy.ok():
+                time.sleep(0.5)
+        else:
+            executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        stop_event.set()
+        sensor_thread.join(timeout=2.0)
+        if executor is not None:
+            executor.shutdown()
+        if server is not None:
+            server.shutdown()
+            server.server_close()
+        if control_node is not None:
+            control_node.destroy_node()
+        sensor_node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
 
 if __name__ == "__main__":
-    main("r1_lite")
+    main()

--- a/examples/hardware/r1_lite/fastdds_r1lite_super_client.xml
+++ b/examples/hardware/r1_lite/fastdds_r1lite_super_client.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dds>
+  <profiles xmlns="http://www.eprosima.com/XMLSchemas/fastRTPS_Profiles">
+    <transport_descriptors>
+      <transport_descriptor>
+        <transport_id>udp_transport</transport_id>
+        <type>UDPv4</type>
+        <interfaceWhiteList>
+          <!-- Workstation IP on the robot/DDS network. Change this for your machine. -->
+          <address>192.168.12.30</address>
+        </interfaceWhiteList>
+      </transport_descriptor>
+    </transport_descriptors>
+    <participant profile_name="super_client_profile" is_default_profile="true">
+      <rtps>
+        <userTransports>
+          <transport_id>udp_transport</transport_id>
+        </userTransports>
+        <useBuiltinTransports>false</useBuiltinTransports>
+        <builtin>
+          <discovery_config>
+            <discoveryProtocol>SUPER_CLIENT</discoveryProtocol>
+            <discoveryServersList>
+              <RemoteServer prefix="44.53.00.5f.45.50.52.4f.53.49.4d.41">
+                <metatrafficUnicastLocatorList>
+                  <locator>
+                    <udpv4>
+                      <!-- FastDDS discovery server IP on the robot network. -->
+                      <address>192.168.12.12</address>
+                      <port>11811</port>
+                    </udpv4>
+                  </locator>
+                </metatrafficUnicastLocatorList>
+              </RemoteServer>
+            </discoveryServersList>
+          </discovery_config>
+        </builtin>
+      </rtps>
+    </participant>
+  </profiles>
+</dds>

--- a/examples/hardware/r1_lite/run_fake_node.sh
+++ b/examples/hardware/r1_lite/run_fake_node.sh
@@ -5,9 +5,44 @@ cd "$(dirname "$0")/../../.."
 source .venv/bin/activate
 export PYTHONPATH="$PWD:${PYTHONPATH:-}:$PWD/src"
 unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY all_proxy ALL_PROXY
+unset FASTRTPS_DEFAULT_PROFILES_FILE ROS_DISCOVERY_SERVER RMW_IMPLEMENTATION
+export ROS_LOCALHOST_ONLY=1
+
+camera_pid=""
+robot_pid=""
+
+cleanup() {
+  trap - EXIT INT TERM
+  for pid in "${camera_pid}" "${robot_pid}"; do
+    if [[ -n "${pid}" ]] && kill -0 "${pid}" 2>/dev/null; then
+      kill "${pid}" 2>/dev/null || true
+    fi
+  done
+  wait "${camera_pid}" "${robot_pid}" 2>/dev/null || true
+}
+
+trap cleanup EXIT INT TERM
 
 python examples/hardware/r1_lite/fake_node.py \
-  --obs-endpoint "${OBS_ENDPOINT:-tcp://127.0.0.1:5555}" \
-  --action-endpoint "${ACTION_ENDPOINT:-tcp://127.0.0.1:5556}" \
+  --role cameras \
   --rate "${PUBLISH_RATE:-30}" \
-  "$@"
+  --image-height "${IMAGE_HEIGHT:-360}" \
+  --image-width "${IMAGE_WIDTH:-640}" \
+  --no-open-ui &
+camera_pid=$!
+
+python examples/hardware/r1_lite/fake_node.py \
+  --role robot \
+  --rate "${PUBLISH_RATE:-30}" \
+  --ui-host "${UI_HOST:-127.0.0.1}" \
+  --ui-port "${UI_PORT:-8765}" \
+  --image-height "${IMAGE_HEIGHT:-360}" \
+  --image-width "${IMAGE_WIDTH:-640}" \
+  "$@" &
+robot_pid=$!
+
+set +e
+wait -n "${camera_pid}" "${robot_pid}"
+status=$?
+set -e
+exit "${status}"

--- a/examples/hardware/r1_lite/run_hardware.sh
+++ b/examples/hardware/r1_lite/run_hardware.sh
@@ -3,13 +3,32 @@ set -euo pipefail
 
 cd "$(dirname "$0")/../../.."
 
-if [[ -f /opt/ros/humble/setup.bash ]]; then
-  source /opt/ros/humble/setup.bash
+source_ros_setup() {
+  local setup_path="$1"
+  local restore_nounset=0
+
+  if [[ $- == *u* ]]; then
+    restore_nounset=1
+    set +u
+  fi
+
+  # ROS setup scripts read optional environment variables before defining them.
+  source "${setup_path}"
+
+  if [[ "${restore_nounset}" == "1" ]]; then
+    set -u
+  fi
+}
+
+ROS_SETUP_BASH="${ROS_SETUP_BASH:-/opt/ros/humble/setup.bash}"
+if [[ -f "${ROS_SETUP_BASH}" ]]; then
+  source_ros_setup "${ROS_SETUP_BASH}"
 fi
 source .venv/bin/activate
 export PYTHONPATH="$PWD:${PYTHONPATH:-}:$PWD/src"
 
-export FASTRTPS_DEFAULT_PROFILES_FILE="${FASTRTPS_DEFAULT_PROFILES_FILE:-$HOME/.ros/fastdds_r1lite_super_client.xml}"
+export FASTRTPS_DEFAULT_PROFILES_FILE="${FASTRTPS_DEFAULT_PROFILES_FILE:-$PWD/examples/hardware/r1_lite/fastdds_r1lite_super_client.xml}"
+export FASTRTPS_DEFAULT_PROFILES_FILE
 export RMW_IMPLEMENTATION="${RMW_IMPLEMENTATION:-rmw_fastrtps_cpp}"
 
 if [[ ! -f "${FASTRTPS_DEFAULT_PROFILES_FILE}" ]]; then

--- a/src/core/app/console/server.py
+++ b/src/core/app/console/server.py
@@ -905,18 +905,13 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         if not clip_id:
             self._send_json(400, {"ok": False, "error": "clip_id required"})
             return
-        self._sync_preview_to_active_model()
-        ep = None
-        if self.ctx.preview is not None:
-            ep = self.ctx.preview.episode_index_by_clip().get(clip_id)
-        if ep is None or runtime.episode_logger is None:
+        if runtime.episode_logger is None:
             self._send_json(
                 409,
                 {"ok": False, "error": "no recorded episode for this trial yet — run it first"},
             )
             return
-        runtime.episode_logger.patch_episode_meta(
-            int(ep),
+        fields = dict(
             prompt=body.get("prompt"),
             trial=body.get("trial"),
             score=body.get("score"),
@@ -926,6 +921,21 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
             scored_at=_dt.datetime.now().isoformat(timespec="seconds"),
             duration_ms=body.get("duration_ms", 0),
         )
+        ep = runtime.episode_logger.patch_episode_meta_by_clip(
+            str(clip_id),
+            **fields,
+        )
+        if ep is None:
+            self._sync_preview_to_active_model()
+            if self.ctx.preview is not None:
+                ep = self.ctx.preview.episode_index_by_clip().get(clip_id)
+            if ep is None:
+                self._send_json(
+                    409,
+                    {"ok": False, "error": "no recorded episode for this trial yet — run it first"},
+                )
+                return
+            runtime.episode_logger.patch_episode_meta(int(ep), **fields)
         self._send_json(200, {"ok": True, "episode_index": ep})
 
     def _stream_camera(self, key: str) -> None:

--- a/src/core/app/handlers/recording.py
+++ b/src/core/app/handlers/recording.py
@@ -199,7 +199,7 @@ def maybe_build_rollout_episode_logger(config: ConfigDict, runtime: RuntimeState
         dataset_keys=config.transport.dataset_keys,
         convert_bgr_to_rgb=config.transport.convert_bgr_to_rgb,
         collection=None,
-        async_save=storage.async_save,
+        async_save=True,
         save_queue_max=storage.save_queue_max,
         save_image_height=storage.get("image_height"),
         save_image_width=storage.get("image_width"),
@@ -420,9 +420,11 @@ def rebuild_eval_episode_logger(config: ConfigDict, runtime: RuntimeState) -> No
         dataset_keys=config.transport.dataset_keys,
         convert_bgr_to_rgb=config.transport.convert_bgr_to_rgb,
         collection=None,
-        async_save=False,  # eval patches scores post-flush; needs synchronous writes
+        async_save=True,
         save_queue_max=storage.save_queue_max,
         eval_mode=True,
+        save_image_height=storage.get("image_height"),
+        save_image_width=storage.get("image_width"),
     )
 
 
@@ -759,19 +761,19 @@ def record_executed_action(
     action: np.ndarray,
     runtime: RuntimeState | None = None,
 ) -> None:
-    """Main table: pair the freshly-captured obs[t] with the executed action[t]."""
+    """Capture one raw eval/rollout sample paired with the executed action."""
+    _ = config, session
     if runtime is None:
         return
     loggers = _active_loggers(runtime)
     if not loggers:
         return
-    frame = runtime.transport.get_frame()
-    if frame is None:
+    snapshot = runtime.transport.acquire_collection_raw()
+    if snapshot is None:
         return
-    _fill_record_eef(config, runtime, frame, action)
+    state_qpos = runtime.transport.get_latest_qpos()
     for logger_obj in loggers:
-        logger_obj.record_step(frame, action)
-    _ = session
+        logger_obj.ingest_raw_episode_snapshot(snapshot, action, state_qpos)
 
 
 __all__ = [

--- a/src/core/recorder/episode.py
+++ b/src/core/recorder/episode.py
@@ -128,9 +128,8 @@ class SaveJob:
         default_factory=list
     )
     reason: str = ""
-    # When True the episodes.jsonl row + tasks.jsonl were already written synchronously
-    # (eval path: the meta row lands on STOP so the trial is immediately scorable); the
-    # background worker then only writes parquet/video and must NOT re-append the row.
+    # When True the episodes.jsonl row + tasks.jsonl were already written before the
+    # background worker reaches this job; the worker then only writes parquet/video.
     meta_written: bool = False
     status: str = "queued"  # queued -> saving -> saved | failed
     error: BaseException | None = None
@@ -154,6 +153,17 @@ class RawEpisodeSavePayload:
 
     raw_batch: CollectionRawBatch
     frame_labels: list[RawEpisodeFrameLabel]
+    raw_snapshots: list[RawEpisodeSnapshot] = dataclasses.field(default_factory=list)
+
+
+@dataclasses.dataclass
+class RawEpisodeSnapshot:
+    """One raw eval/rollout source snapshot plus the action executed at that tick."""
+
+    snapshot: RawCollectionSnapshot
+    action_qpos: np.ndarray
+    intervention: bool = False
+    segment_index: int = -1
 
 
 class EpisodeLogger:
@@ -197,9 +207,8 @@ class EpisodeLogger:
         self._save_image_height = save_image_height
         self._save_image_width = save_image_width
         # Eval datasets carry per-episode scoring (score/milestones/note/...) entered by
-        # the operator. When on, those land as episodes.jsonl keys only (not in parquet),
-        # and the episode's meta row is written synchronously on STOP so the trial is
-        # immediately scorable while parquet/video flush in the background.
+        # the operator. Those fields live in episodes.jsonl only and may be patched while
+        # the episode save job is still queued.
         self._eval_mode = eval_mode
         from core.recorder.collection import CollectionEpisodeWriter  # local: break import cycle
 
@@ -222,17 +231,17 @@ class EpisodeLogger:
         self._active = False
         self._task: str | None = None
         self._steps: list[Observation] = []
+        self._live_steps: list[Observation] = []
         self._episode_meta: dict[str, Any] = {}
         self._image_shape: tuple[int, int] | None = None  # (h, w) from first frame
         self._intervention_segments: list[RolloutInterventionSegment] = []
         self._raw_episode_batch = CollectionRawBatch()
         self._raw_episode_frame_labels: list[RawEpisodeFrameLabel] = []
+        self._raw_episode_snapshots: list[RawEpisodeSnapshot] = []
 
-        # async save queue (data-collection mode): end_episode hands a SaveJob
-        # snapshot to a background worker so the main loop can start the next
-        # episode without waiting for parquet/video/meta to flush. Eval keeps
-        # async_save off and writes synchronously (its post-hoc score patching
-        # needs the row on disk before the trial ends).
+        # async save queue: end_episode hands a frozen SaveJob snapshot to a background
+        # worker so live capture/control can resume without waiting for alignment,
+        # parquet, video, or meta writes.
         self._async_save = async_save
         self._save_queue_max = max(1, save_queue_max)
         # Per dataset_dir monotonic counters for collection episodes. Seeded from disk
@@ -249,6 +258,7 @@ class EpisodeLogger:
         )
         self._completed_episodes = len(self._collection_history)
         self._save_durations: list[float] = []
+        self._pending_episode_meta_by_clip: dict[str, dict[str, Any]] = {}
 
     # -- episode lifecycle ------------------------------------------------------
 
@@ -263,10 +273,12 @@ class EpisodeLogger:
         self._active = True
         self._task = task
         self._steps = []
+        self._live_steps = []
         self._episode_meta = {}
         self._intervention_segments = []
         self._raw_episode_batch = CollectionRawBatch()
         self._raw_episode_frame_labels = []
+        self._raw_episode_snapshots = []
         if self._collection_writer is not None:
             self._collection_writer.start_episode(collection_min_capture_time)
             return
@@ -296,6 +308,7 @@ class EpisodeLogger:
         record.timestamp = source_timestamp
         record.action_qpos = np.asarray(action, dtype=np.float32).copy()
         self._steps.append(record)
+        self._live_steps.append(_copy_observation(record))
         self._append_raw_episode_observation(
             self._raw_episode_batch,
             record,
@@ -306,6 +319,32 @@ class EpisodeLogger:
             ),
             self._raw_episode_frame_labels,
         )
+
+    def ingest_raw_episode_snapshot(
+        self,
+        snapshot: RawCollectionSnapshot,
+        action: np.ndarray,
+        state_qpos: np.ndarray | None = None,
+    ) -> None:
+        """Store one pre-decode eval/rollout snapshot and executed action."""
+        if not self._active:
+            return
+        action_qpos = np.asarray(action, dtype=np.float32).copy()
+        self._raw_episode_snapshots.append(
+            RawEpisodeSnapshot(
+                snapshot=snapshot,
+                action_qpos=action_qpos,
+            )
+        )
+        if state_qpos is not None:
+            self._live_steps.append(
+                Observation(
+                    images={},
+                    state_qpos=np.asarray(state_qpos, dtype=np.float32).copy(),
+                    action_qpos=action_qpos.copy(),
+                    timestamp=float(snapshot.timestamp),
+                )
+            )
 
     def ingest_collection_snapshot(self, snapshot: RawCollectionSnapshot) -> None:
         """Hand one pre-decode snapshot to the collection writer (O(1))."""
@@ -348,6 +387,28 @@ class EpisodeLogger:
                 self._write_info_json()
         return patched
 
+    def patch_episode_meta_by_clip(self, clip_id: str, **fields: Any) -> int | None:
+        """Merge eval metadata into an existing or still-saving episode for clip_id.
+
+        Returns:
+            Episode index when the clip is known, otherwise None.
+        """
+        if not clip_id:
+            return None
+        episode_index = self._episode_index_for_clip_id(clip_id)
+        if episode_index is not None:
+            self.patch_episode_meta(episode_index, **fields)
+            return episode_index
+        with self._lock:
+            job = self._queued_job_for_clip_id_locked(clip_id)
+            if job is None:
+                return None
+            job.episode_meta.update(fields)
+            if job.collection_episode_row is not None:
+                job.collection_episode_row.update(fields)
+            self._pending_episode_meta_by_clip.setdefault(clip_id, {}).update(fields)
+            return job.episode_index
+
     @property
     def current_episode_index(self) -> int:
         """Index the next end_episode() will assign (i.e. the in-flight episode)."""
@@ -370,15 +431,19 @@ class EpisodeLogger:
             return 0
         if self._collection_writer is not None:
             return self._collection_writer.frame_counts()["received"]
-        return len(self._steps)
+        return max(
+            len(self._live_steps),
+            len(self._raw_episode_frame_labels),
+            len(self._raw_episode_snapshots),
+        )
 
     def end_episode(self) -> bool:
         """Finish the current episode.
 
         When async_save is on, the recorded buffers are snapshotted into a SaveJob
         and parquet/video/meta writing happens on a background worker so the
-        caller can immediately start the next episode. Otherwise the episode is
-        written synchronously (eval path).
+        caller can immediately start the next episode. Otherwise the same payload
+        is written inline before returning.
 
         Returns:
             True when the episode was saved/queued, False when it held no frames
@@ -411,6 +476,7 @@ class EpisodeLogger:
             self._intervention_segments = []
             self._raw_episode_batch = CollectionRawBatch()
             self._raw_episode_frame_labels = []
+            self._raw_episode_snapshots = []
             return False
 
         episode_index = self._episode_index
@@ -445,6 +511,15 @@ class EpisodeLogger:
         self._active = False
         raw_batch = self._copy_raw_episode_batch(self._raw_episode_batch)
         frame_labels = list(self._raw_episode_frame_labels)
+        raw_snapshots = [
+            RawEpisodeSnapshot(
+                snapshot=sample.snapshot,
+                action_qpos=sample.action_qpos.copy(),
+                intervention=sample.intervention,
+                segment_index=sample.segment_index,
+            )
+            for sample in self._raw_episode_snapshots
+        ]
         self._append_intervention_segments_to_raw_episode(
             raw_batch,
             frame_labels,
@@ -461,15 +536,17 @@ class EpisodeLogger:
             steps=[],
             episode_meta=episode_meta,
             task_to_index=dict(self._task_to_index),
-            raw_episode_payload=RawEpisodeSavePayload(raw_batch, frame_labels),
+            raw_episode_payload=RawEpisodeSavePayload(raw_batch, frame_labels, raw_snapshots),
             video_fps=float(self._fps),
             queued_wall_time=time.time(),
         )
         self._steps = []
+        self._live_steps = []
         self._episode_meta = {}
         self._intervention_segments = []
         self._raw_episode_batch = CollectionRawBatch()
         self._raw_episode_frame_labels = []
+        self._raw_episode_snapshots = []
         self._task = None
         if self._async_save:
             self._enqueue_save_job(job)
@@ -491,19 +568,23 @@ class EpisodeLogger:
         if self._collection_writer is not None:
             self._collection_writer.cancel_episode()
             self._steps = []
+            self._live_steps = []
             self._episode_meta = {}
             self._intervention_segments = []
             self._raw_episode_batch = CollectionRawBatch()
             self._raw_episode_frame_labels = []
+            self._raw_episode_snapshots = []
             self._active = False
             self._task = None
             logger.info("Cancelled episode %d (%s)", self._episode_index, reason)
             return
         self._steps = []
+        self._live_steps = []
         self._episode_meta = {}
         self._intervention_segments = []
         self._raw_episode_batch = CollectionRawBatch()
         self._raw_episode_frame_labels = []
+        self._raw_episode_snapshots = []
         self._active = False
         self._task = None
         logger.info("Cancelled episode %d (%s)", self._episode_index, reason)
@@ -606,6 +687,66 @@ class EpisodeLogger:
             batch.end_time = timestamp
         labels.append(label)
 
+    def _merge_raw_episode_batch(
+        self,
+        target: CollectionRawBatch,
+        batch: CollectionRawBatch,
+    ) -> None:
+        if batch.start_time is not None:
+            target.start_time = (
+                batch.start_time
+                if target.start_time is None
+                else min(target.start_time, batch.start_time)
+            )
+        if batch.end_time is not None:
+            target.end_time = (
+                batch.end_time
+                if target.end_time is None
+                else max(target.end_time, batch.end_time)
+            )
+        for key, samples in batch.images.items():
+            target.images.setdefault(key, []).extend(samples)
+            self._extend_raw_episode_time_bounds(target, samples)
+        for key, samples in batch.vectors.items():
+            target.vectors.setdefault(key, []).extend(samples)
+            self._extend_raw_episode_time_bounds(target, samples)
+
+    def _extend_raw_episode_time_bounds(
+        self,
+        batch: CollectionRawBatch,
+        samples: list[CollectionRawSample],
+    ) -> None:
+        for sample in samples:
+            batch.start_time = (
+                sample.timestamp
+                if batch.start_time is None
+                else min(batch.start_time, sample.timestamp)
+            )
+            batch.end_time = (
+                sample.timestamp
+                if batch.end_time is None
+                else max(batch.end_time, sample.timestamp)
+            )
+
+    def _decode_raw_episode_snapshots(self, payload: RawEpisodeSavePayload) -> None:
+        for raw in payload.raw_snapshots:
+            batch = raw.snapshot.decode_raw()
+            batch.vectors.setdefault("action_qpos", []).append(
+                CollectionRawSample(
+                    raw.snapshot.timestamp,
+                    raw.action_qpos.copy(),
+                )
+            )
+            self._merge_raw_episode_batch(payload.raw_batch, batch)
+            payload.frame_labels.append(
+                RawEpisodeFrameLabel(
+                    timestamp=raw.snapshot.timestamp,
+                    intervention=raw.intervention,
+                    segment_index=raw.segment_index,
+                )
+            )
+        payload.raw_snapshots = []
+
     def _append_intervention_segments_to_raw_episode(
         self,
         batch: CollectionRawBatch,
@@ -638,8 +779,10 @@ class EpisodeLogger:
         return time.time()
 
     def _has_raw_episode_samples(self) -> bool:
-        return any(self._raw_episode_batch.vectors.values()) or any(
-            segment.frames for segment in self._intervention_segments
+        return (
+            any(self._raw_episode_batch.vectors.values())
+            or bool(self._raw_episode_snapshots)
+            or any(segment.frames for segment in self._intervention_segments)
         )
 
     def _copy_raw_episode_batch(self, batch: CollectionRawBatch) -> CollectionRawBatch:
@@ -684,6 +827,7 @@ class EpisodeLogger:
     def _write_raw_episode_job(self, job: SaveJob) -> None:
         if job.raw_episode_payload is not None:
             self._prepare_raw_episode_job(job)
+        self._apply_pending_episode_meta_for_job(job)
         columns = job.collection_columns
         row = job.collection_episode_row
         if columns is None or row is None:
@@ -700,11 +844,13 @@ class EpisodeLogger:
             self._write_tasks_jsonl_from(job.task_to_index)
             if self._eval_mode:
                 self._write_info_json()
+        self._clear_pending_episode_meta_for_job(job)
 
     def _prepare_raw_episode_job(self, job: SaveJob) -> None:
         payload = job.raw_episode_payload
         if payload is None:
             return
+        self._decode_raw_episode_snapshots(payload)
         fields = self._raw_episode_vector_fields(payload.raw_batch)
         camera_keys = tuple(payload.raw_batch.images.keys())
         frames, report = align_collection_samples(
@@ -795,6 +941,43 @@ class EpisodeLogger:
         job.videos = videos
         job.video_fps = fps
         job.raw_episode_payload = None
+
+    def _episode_index_for_clip_id(self, clip_id: str) -> int | None:
+        match = None
+        for row in _read_jsonl(self._meta_path("episodes.jsonl")):
+            if row.get("clip_id") == clip_id and row.get("episode_index") is not None:
+                match = int(row["episode_index"])
+        return match
+
+    def _queued_job_for_clip_id_locked(self, clip_id: str) -> SaveJob | None:
+        for job in reversed(self._save_jobs):
+            row = job.collection_episode_row or {}
+            if job.episode_meta.get("clip_id") == clip_id or row.get("clip_id") == clip_id:
+                return job
+        return None
+
+    def _apply_pending_episode_meta_for_job(self, job: SaveJob) -> None:
+        clip_id = job.episode_meta.get("clip_id")
+        if clip_id is None and job.collection_episode_row is not None:
+            clip_id = job.collection_episode_row.get("clip_id")
+        if not clip_id:
+            return
+        with self._lock:
+            pending = dict(self._pending_episode_meta_by_clip.get(str(clip_id), {}))
+        if not pending:
+            return
+        job.episode_meta.update(pending)
+        if job.collection_episode_row is not None:
+            job.collection_episode_row.update(pending)
+
+    def _clear_pending_episode_meta_for_job(self, job: SaveJob) -> None:
+        clip_id = job.episode_meta.get("clip_id")
+        if clip_id is None and job.collection_episode_row is not None:
+            clip_id = job.collection_episode_row.get("clip_id")
+        if not clip_id:
+            return
+        with self._lock:
+            self._pending_episode_meta_by_clip.pop(str(clip_id), None)
 
     def _labels_for_aligned_frames(
         self,
@@ -1071,9 +1254,9 @@ class EpisodeLogger:
         """In-memory per-frame state/action of the in-flight episode for live charts.
 
         Mirrors load_episode_series' shape so the frontend reuses one chart path,
-        but reads the live ``self._steps`` buffer instead of disk — RUN feeds this
-        continuously (record_step), so the console can plot and scrub the current
-        run before it is ever saved.
+        but reads the live in-memory buffer instead of disk. RUN feeds this
+        continuously, so the console can plot and scrub the current run before it
+        is ever saved.
 
         Args:
             since: Return only frames with index >= since for incremental polling.
@@ -1082,10 +1265,10 @@ class EpisodeLogger:
             {"active": bool, "n": int (total frames), "timestamp": [k],
              "state": [k, Ds], "action": [k, Da]} where k = total - since.
         """
-        steps = self._steps[since:] if since > 0 else self._steps[:]
+        steps = self._live_steps[since:] if since > 0 else self._live_steps[:]
         return {
             "active": self._active,
-            "n": len(self._steps),
+            "n": len(self._live_steps),
             "timestamp": [float(cast(float, s.timestamp)) for s in steps],
             "state": [s.state_qpos.tolist() for s in steps],
             "action": [cast(np.ndarray, s.action_qpos).tolist() for s in steps],

--- a/src/transport/base.py
+++ b/src/transport/base.py
@@ -600,12 +600,15 @@ class _RosTransportBase(TransportBridge):
 
     def _collection_raw_streams(self) -> list[tuple[str, str, str, Any, collections.deque]]:
         streams: list[tuple[str, str, str, Any, collections.deque]] = []
+        columns = self._config.collection.schema.columns
+        if not columns:
+            return self._raw_episode_streams()
+
         for camera in self._collection_camera_specs():
             deque = self._camera_deques.get(camera.name)
             if deque is not None:
                 streams.append(("image", camera.observation_key, camera.name, camera, deque))
 
-        columns = self._config.collection.schema.columns
         if "qpos" in columns:
             for group in self._robot.actuator_groups:
                 deque = self._collection_qpos_deques.get(group.name)
@@ -626,6 +629,23 @@ class _RosTransportBase(TransportBridge):
                 deque = self._collection_action_eef_deques.get(group.name)
                 if deque is not None:
                     streams.append(("vector", "action_eef", group.name, group, deque))
+        return streams
+
+    def _raw_episode_streams(self) -> list[tuple[str, str, str, Any, collections.deque]]:
+        streams: list[tuple[str, str, str, Any, collections.deque]] = []
+        for camera in self._robot.observation_schema.cameras:
+            deque = self._camera_deques.get(camera.name)
+            if deque is not None:
+                streams.append(("image", camera.observation_key, camera.name, camera, deque))
+        group_state_deques = getattr(self, "_group_state_deques", {})
+        for group_name in self._robot.observation_schema.state_composition:
+            deque = group_state_deques.get(group_name)
+            if deque is None:
+                continue
+            group = next(
+                group for group in self._robot.actuator_groups if group.name == group_name
+            )
+            streams.append(("vector", "state_qpos", group.name, group, deque))
         return streams
 
     def _collection_raw_context_streams(self) -> list[tuple[str, collections.deque]]:
@@ -751,8 +771,6 @@ class _RosTransportBase(TransportBridge):
 
     def acquire_collection_raw(self) -> RawCollectionSnapshot | None:
         """O(1) capture of raw collection stream messages since the previous tick."""
-        if not self._config.collection.schema.columns:
-            return None
         streams = self._collection_raw_streams()
         if not streams:
             return None

--- a/tests/config/test_control_state.py
+++ b/tests/config/test_control_state.py
@@ -19,7 +19,13 @@ from core.app.state import (
     resolve_inference_strategy_label,
 )
 from core.config import ConfigDict
-from core.types import Observation, RolloutInterventionSegment
+from core.types import (
+    CollectionRawBatch,
+    CollectionRawSample,
+    Observation,
+    RawCollectionSnapshot,
+    RolloutInterventionSegment,
+)
 from robots.base import ActuatorGroup, CameraSpec, ObservationSchema, Robot
 
 
@@ -90,6 +96,7 @@ class _CollectionTransport:
         self.cleared = 0
         self.latest_qpos = np.array([0.1, 0.2], dtype=np.float32)
         self.collection_frames: list[Observation] = []
+        self.raw_snapshots: list[RawCollectionSnapshot] = []
         self.diagnostics = ""
         self.hil_resets = 0
         self.hil_modes: list[str] = []
@@ -116,8 +123,13 @@ class _CollectionTransport:
             return None
         return self.collection_frames.pop(0)
 
+    def get_frame(self) -> Observation | None:
+        raise AssertionError("recording must not decode a frame before raw save")
+
     def acquire_collection_raw(self):
-        return None
+        if not self.raw_snapshots:
+            return None
+        return self.raw_snapshots.pop(0)
 
     def collection_diagnostics(self) -> str:
         return self.diagnostics
@@ -157,6 +169,28 @@ class _ActiveRolloutLogger:
 
     def cancel_episode(self, _reason: str) -> None:
         raise AssertionError("active rollout should not be cancelled")
+
+
+class _RawEpisodeLogger:
+    def __init__(self) -> None:
+        self.snapshots: list[RawCollectionSnapshot] = []
+        self.actions: list[np.ndarray] = []
+        self.states: list[np.ndarray | None] = []
+
+    def ingest_raw_episode_snapshot(
+        self,
+        snapshot: RawCollectionSnapshot,
+        action: np.ndarray,
+        state_qpos: np.ndarray | None = None,
+    ) -> None:
+        self.snapshots.append(snapshot)
+        self.actions.append(np.asarray(action, dtype=np.float32).copy())
+        self.states.append(
+            None if state_qpos is None else np.asarray(state_qpos, dtype=np.float32).copy()
+        )
+
+    def record_step(self, _frame: Observation, _action: np.ndarray) -> None:
+        raise AssertionError("recording must use raw snapshots")
 
 
 class _ResettableStrategy:
@@ -215,6 +249,82 @@ def _config(*, intervention_enabled: bool = False) -> ConfigDict:
         ),
         inference_cfg=ConfigDict(publish_rate=1000),
     )
+
+
+def _recording_config(tmp_path) -> ConfigDict:
+    return ConfigDict(
+        eval=ConfigDict(
+            storage=ConfigDict(fps=10, save_queue_max=2),
+            checkpoints=[],
+        ),
+        rollout=ConfigDict(
+            storage=ConfigDict(
+                enabled=True,
+                log_dir=str(tmp_path / "rollout"),
+                fps=10,
+                save_queue_max=2,
+                async_save=False,
+            ),
+        ),
+        transport=ConfigDict(
+            dataset_keys=ConfigDict(
+                state_key="observations.state.qpos",
+                eef_key="observations.state.eef",
+                action_key="action",
+                video_keys={},
+            ),
+            convert_bgr_to_rgb=True,
+        ),
+        robot=ConfigDict(type="fake_arm"),
+    )
+
+
+def test_eval_episode_logger_uses_async_save(tmp_path):
+    runtime, _session = _runtime_and_session()
+    runtime.eval_output_dir = str(tmp_path)
+
+    recording.rebuild_eval_episode_logger(_recording_config(tmp_path), runtime)
+
+    assert runtime.episode_logger is not None
+    assert runtime.episode_logger._async_save is True
+
+
+def test_rollout_episode_logger_uses_async_save(tmp_path):
+    runtime, _session = _runtime_and_session()
+
+    recording.maybe_build_rollout_episode_logger(_recording_config(tmp_path), runtime)
+
+    assert runtime.rollout_episode_logger is not None
+    assert runtime.rollout_episode_logger._async_save is True
+
+
+def test_record_executed_action_ingests_raw_snapshot_for_active_loggers():
+    runtime, session = _runtime_and_session()
+    eval_logger = _RawEpisodeLogger()
+    rollout_logger = _RawEpisodeLogger()
+    runtime.episode_logger = eval_logger
+    runtime.rollout_episode_logger = rollout_logger
+    snapshot = RawCollectionSnapshot(
+        timestamp=3.0,
+        decode_raw=lambda: CollectionRawBatch(
+            vectors={
+                "state_qpos": [
+                    CollectionRawSample(3.0, np.array([0.1, 0.2], dtype=np.float32)),
+                ],
+            }
+        ),
+    )
+    runtime.transport.raw_snapshots.append(snapshot)
+    action = np.array([0.7, 0.8], dtype=np.float32)
+
+    recording.record_executed_action(_config(), session, action, runtime)
+
+    assert eval_logger.snapshots == [snapshot]
+    assert rollout_logger.snapshots == [snapshot]
+    np.testing.assert_allclose(eval_logger.actions[0], action)
+    np.testing.assert_allclose(rollout_logger.actions[0], action)
+    np.testing.assert_allclose(eval_logger.states[0], runtime.transport.latest_qpos)
+    np.testing.assert_allclose(rollout_logger.states[0], runtime.transport.latest_qpos)
 
 
 def _observation(timestamp: float = 1.0) -> Observation:

--- a/tests/hardware/test_r1lite_fake_e2e_harness.py
+++ b/tests/hardware/test_r1lite_fake_e2e_harness.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_PATH = REPO_ROOT / "tools" / "run_r1lite_fake_e2e.py"
+
+
+def _load_harness():
+    spec = importlib.util.spec_from_file_location("run_r1lite_fake_e2e", HARNESS_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_write_e2e_configs_pins_ports_and_output_dirs(tmp_path):
+    harness = _load_harness()
+
+    paths = harness.write_e2e_configs(tmp_path, policy_port=19000)
+
+    rollout = paths.deploy_config.read_text()
+    rollout_hil = paths.rollout_hil_config.read_text()
+    hil = paths.hil_config.read_text()
+    collection = paths.collection_config.read_text()
+    collection_no_hil = paths.collection_no_hil_config.read_text()
+    eval_text = paths.eval_config.read_text()
+    assert "policy = dict(" in rollout
+    assert "port=19000" in rollout
+    assert str(paths.rollout_no_hil_dir) in rollout
+    assert "intervention=dict(enabled=False" in rollout
+    assert str(paths.rollout_hil_dir) in rollout_hil
+    assert "intervention=dict(enabled=True" in rollout_hil
+    assert str(paths.hil_dir) in hil
+    assert "intervention=dict(enabled=True" in hil
+    assert "policy = dict(" in collection
+    assert "port=19000" in collection
+    assert str(paths.collection_hil_dir) in collection
+    assert "intervention=dict(enabled=True" in collection
+    assert f"_base_ = ['{paths.collection_config}']" in collection_no_hil
+    assert str(paths.collection_no_hil_dir) in collection_no_hil
+    assert "intervention=dict(enabled=False" in collection_no_hil
+    assert "inference_strategy='sync'" in eval_text
+    assert "port=19000" in eval_text
+    assert str(paths.eval_dir) in eval_text
+
+
+def test_assert_fixed_clock_accepts_exact_grid_and_rejects_jitter():
+    harness = _load_harness()
+    exact = pa.table({"timestamp": [0.0, 1.0 / 15.0, 2.0 / 15.0]})
+    jitter = pa.table({"timestamp": [0.0, 0.08, 0.12]})
+
+    harness.assert_fixed_clock(exact, fps=15)
+    try:
+        harness.assert_fixed_clock(jitter, fps=15)
+    except AssertionError as exc:
+        assert "timestamp is not fixed-clock" in str(exc)
+    else:
+        raise AssertionError("jittered timestamp table was accepted")
+
+
+def test_assert_vector_varies_requires_motion_in_selected_columns():
+    harness = _load_harness()
+    fixed = np.zeros((4, 14), dtype=np.float32)
+    moving = fixed.copy()
+    moving[:, 2] = [0.0, 0.1, 0.2, 0.3]
+
+    harness.assert_vector_varies(moving, columns=(2, 10), label="action.qpos")
+    try:
+        harness.assert_vector_varies(fixed, columns=(2, 10), label="action.qpos")
+    except AssertionError as exc:
+        assert "action.qpos did not vary" in str(exc)
+    else:
+        raise AssertionError("fixed action vector was accepted")
+
+
+def test_poll_status_for_keeps_eva_watchdog_alive(monkeypatch):
+    harness = _load_harness()
+    now = [0.0]
+    calls = []
+
+    def fake_monotonic():
+        return now[0]
+
+    def fake_sleep(duration):
+        now[0] += duration
+
+    monkeypatch.setattr(harness.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(harness.time, "sleep", fake_sleep)
+    monkeypatch.setattr(harness, "get_json", lambda base_url, path: calls.append((base_url, path)))
+
+    harness.poll_status_for("http://eva", duration_s=0.7, interval_s=0.2)
+
+    assert calls == [
+        ("http://eva", "/api/status"),
+        ("http://eva", "/api/status"),
+        ("http://eva", "/api/status"),
+        ("http://eva", "/api/status"),
+    ]
+
+
+def test_drive_motion_target_publishes_direct_command_deltas(monkeypatch):
+    harness = _load_harness()
+    calls = []
+
+    monkeypatch.setattr(
+        harness,
+        "post_json",
+        lambda base_url, path, payload: calls.append((base_url, path, payload)),
+    )
+    monkeypatch.setattr(harness.time, "sleep", lambda _duration: None)
+
+    harness.drive_motion_target("http://fake", repeats=2, delay_s=0.1)
+
+    assert calls == [
+        (
+            "http://fake",
+            "/api/command_delta",
+            {"group": "left_arm", "index": 2, "delta": 0.03},
+        ),
+        (
+            "http://fake",
+            "/api/command_delta",
+            {"group": "right_arm", "index": 3, "delta": -0.02},
+        ),
+        (
+            "http://fake",
+            "/api/command_delta",
+            {"group": "left_arm", "index": 2, "delta": 0.03},
+        ),
+        (
+            "http://fake",
+            "/api/command_delta",
+            {"group": "right_arm", "index": 3, "delta": -0.02},
+        ),
+    ]

--- a/tests/hardware/test_r1lite_fake_node.py
+++ b/tests/hardware/test_r1lite_fake_node.py
@@ -1,0 +1,559 @@
+from __future__ import annotations
+
+from pathlib import Path
+import inspect
+from types import SimpleNamespace
+
+import numpy as np
+
+from examples.hardware.r1_lite import fake_node
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+R1_LITE_DIR = REPO_ROOT / "examples" / "hardware" / "r1_lite"
+
+
+def test_run_fake_node_launches_ros2_fake_without_zmq_endpoints():
+    text = (R1_LITE_DIR / "run_fake_node.sh").read_text()
+
+    assert "python examples/hardware/r1_lite/fake_node.py" in text
+    assert "--role cameras" in text
+    assert "--role robot" in text
+    assert "--ui-host" in text
+    assert "--ui-port" in text
+    assert "--image-height" in text
+    assert "--image-width" in text
+    assert "--obs-endpoint" not in text
+    assert "--action-endpoint" not in text
+    assert "OBS_ENDPOINT" not in text
+    assert "ACTION_ENDPOINT" not in text
+
+
+def test_r1lite_ros2_fake_uses_real_r1lite_topics():
+    assert fake_node.CAMERA_TOPICS == {
+        "head": "/hdas/camera_head/right_raw/image_raw_color/compressed",
+        "left_wrist": "/hdas/camera_wrist_left/color/image_raw/compressed",
+        "right_wrist": "/hdas/camera_wrist_right/color/image_raw/compressed",
+    }
+    assert fake_node.ARM_TOPICS["left_arm"].feedback == "/hdas/feedback_arm_left"
+    assert fake_node.ARM_TOPICS["left_arm"].command == "/motion_target/target_joint_state_arm_left"
+    assert fake_node.ARM_TOPICS["left_arm"].hil == "/eva/hil/input_joint_state_arm_left"
+    assert fake_node.ARM_TOPICS["right_arm"].gripper_command == (
+        "/motion_target/target_position_gripper_right"
+    )
+    assert fake_node.OPERATOR_BUTTON_TOPIC == "/eva/operator_button"
+
+
+def test_fake_state_tracks_feedback_and_hil_positions_separately():
+    state = fake_node.R1LiteFakeState()
+
+    state.apply_hil_delta("left_arm", joint_index=2, delta=0.25)
+    state.apply_arm_command("left_arm", np.arange(6, dtype=np.float32))
+    state.apply_gripper_command("left_arm", 0.0)
+    snapshot = state.snapshot()
+
+    assert snapshot["hil"]["left_arm"][2] == 0.25
+    assert snapshot["feedback"]["left_arm"]["joints"] == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+    assert snapshot["feedback"]["left_arm"]["gripper"] == 0.0
+    assert snapshot["feedback"]["right_arm"]["gripper"] == fake_node.GRIPPER_OPEN
+
+
+def test_fake_state_accepts_full_group_command_and_splits_gripper():
+    state = fake_node.R1LiteFakeState()
+
+    state.apply_arm_command("left_arm", np.array([0, 1, 2, 3, 4, 5, 12], dtype=np.float32))
+    snapshot = state.snapshot()
+
+    assert snapshot["feedback"]["left_arm"]["joints"] == [0, 1, 2, 3, 4, 5]
+    assert snapshot["feedback"]["left_arm"]["gripper"] == 12.0
+
+
+def test_control_api_publishes_operator_buttons_and_hil_joint_updates():
+    state = fake_node.R1LiteFakeState()
+    bridge = _FakeBridge()
+    api = fake_node.R1LiteFakeControlApi(state, bridge)
+
+    api.operator_button("x")
+    api.gripper("right", "close")
+    api.set_joint("left_arm", 1, 0.5)
+    api.adjust_joint("left_arm", 1, -0.125)
+
+    assert bridge.operator_buttons == ["x", "right_gripper_close"]
+    assert [msg[0] for msg in bridge.hil_messages] == ["left_arm", "left_arm"]
+    np.testing.assert_allclose(bridge.hil_messages[-1][1], [0.0, 0.375, 0.0, 0.0, 0.0, 0.0])
+
+
+def test_control_api_can_publish_direct_motion_target_commands():
+    state = fake_node.R1LiteFakeState()
+    bridge = _FakeBridge()
+    api = fake_node.R1LiteFakeControlApi(state, bridge)
+
+    api.adjust_command("right_arm", 3, -0.2)
+    api.adjust_command("right_arm", 3, -0.3)
+
+    snapshot = state.snapshot()
+    np.testing.assert_allclose(snapshot["feedback"]["right_arm"]["joints"], [0, 0, 0, -0.5, 0, 0])
+    assert [msg[0] for msg in bridge.command_messages] == ["right_arm", "right_arm"]
+    np.testing.assert_allclose(bridge.command_messages[-1][1], [0, 0, 0, -0.5, 0, 0])
+
+
+def test_control_api_can_sync_hil_to_feedback_without_eva_web_commands():
+    state = fake_node.R1LiteFakeState()
+    bridge = _FakeBridge()
+    api = fake_node.R1LiteFakeControlApi(state, bridge)
+    state.apply_arm_command("left_arm", np.arange(6, dtype=np.float32))
+    state.apply_arm_command("right_arm", np.arange(10, 16, dtype=np.float32))
+
+    result = api.sync_hil_to_feedback()
+    snapshot = state.snapshot()
+
+    assert result == {"ok": "true"}
+    np.testing.assert_allclose(snapshot["hil"]["left_arm"], [0, 1, 2, 3, 4, 5])
+    np.testing.assert_allclose(snapshot["hil"]["right_arm"], [10, 11, 12, 13, 14, 15])
+    assert [msg[0] for msg in bridge.hil_messages] == ["left_arm", "right_arm"]
+    np.testing.assert_allclose(bridge.hil_messages[0][1], [0, 1, 2, 3, 4, 5])
+    np.testing.assert_allclose(bridge.hil_messages[1][1], [10, 11, 12, 13, 14, 15])
+
+
+def test_fake_node_ui_never_calls_eva_web_commands_directly():
+    assert "127.0.0.1:8080" not in fake_node.UI_HTML
+    assert "/api/halt" not in fake_node.UI_HTML
+    assert "/api/run" not in fake_node.UI_HTML
+    assert "/api/collect_start" not in fake_node.UI_HTML
+    assert "/api/operator" in fake_node.UI_HTML
+    assert "/api/joint_delta" in fake_node.UI_HTML
+
+
+def test_ros2_fake_registers_publishers_subscribers_and_publishes_hil():
+    node = _FakeNode()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+    live_qos = object()
+    bridge = fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=fake_node.R1LiteFakeState(),
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=live_qos,
+    )
+
+    assert set(node.publishers) >= {
+        "/hdas/camera_head/right_raw/image_raw_color/compressed",
+        "/hdas/feedback_arm_left",
+        "/hdas/feedback_gripper_left",
+        "/relaxed_ik/motion_control/pose_ee_arm_right",
+        "/eva/operator_button",
+        "/eva/hil/input_joint_state_arm_right",
+        "/motion_target/target_joint_state_arm_right",
+    }
+    assert set(node.subscriptions) >= {
+        "/motion_target/target_joint_state_arm_left",
+        "/motion_target/target_position_gripper_left",
+        "/motion_target/target_joint_state_arm_right",
+        "/motion_target/target_position_gripper_right",
+    }
+    assert node.publisher_qos["/eva/operator_button"] == 10
+    assert node.publisher_qos["/eva/hil/input_joint_state_arm_right"] is live_qos
+    assert set(node.subscription_callback_groups.values()) == {None}
+    assert node.timer_callback_groups == [None]
+
+    bridge.publish_operator_button("y")
+    bridge.publish_hil("right_arm", np.arange(6, dtype=np.float32))
+    bridge.publish_command("right_arm", np.arange(10, 16, dtype=np.float32))
+
+    assert node.publishers["/eva/operator_button"].messages[-1].data == "y"
+    hil_msg = node.publishers["/eva/hil/input_joint_state_arm_right"].messages[-1]
+    assert hil_msg.name == list(fake_node.RIGHT_ARM_JOINTS)
+    np.testing.assert_allclose(hil_msg.position, [0.0, 1.0, 2.0, 3.0, 4.0, 5.0])
+    command_msg = node.publishers["/motion_target/target_joint_state_arm_right"].messages[-1]
+    assert command_msg.name == list(fake_node.RIGHT_ARM_JOINTS)
+    np.testing.assert_allclose(command_msg.position, [10, 11, 12, 13, 14, 15])
+
+
+def test_ros2_fake_publish_once_publishes_current_motion_targets_for_both_arms():
+    node = _FakeNode()
+    state = fake_node.R1LiteFakeState()
+    state.apply_arm_command("left_arm", np.arange(6, dtype=np.float32))
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+    bridge = fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=state,
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=object(),
+        create_timer=False,
+    )
+
+    bridge.publish_once()
+
+    left_msg = node.publishers["/motion_target/target_joint_state_arm_left"].messages[-1]
+    right_msg = node.publishers["/motion_target/target_joint_state_arm_right"].messages[-1]
+    assert left_msg.name == list(fake_node.LEFT_ARM_JOINTS)
+    assert right_msg.name == list(fake_node.RIGHT_ARM_JOINTS)
+    np.testing.assert_allclose(left_msg.position, [0, 1, 2, 3, 4, 5])
+    np.testing.assert_allclose(right_msg.position, [0, 0, 0, 0, 0, 0])
+
+
+def test_ros2_fake_uses_separate_camera_qos_from_robot_live_qos():
+    node = _FakeNode()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+    live_qos = object()
+    camera_qos = object()
+
+    fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=fake_node.R1LiteFakeState(),
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=live_qos,
+        camera_qos=camera_qos,
+    )
+
+    assert node.publisher_qos["/hdas/camera_head/right_raw/image_raw_color/compressed"] is (
+        camera_qos
+    )
+    assert node.publisher_qos["/hdas/feedback_arm_left"] is live_qos
+    assert node.publisher_qos["/eva/hil/input_joint_state_arm_right"] is live_qos
+
+
+def test_ros2_fake_separates_command_subscriptions_from_sensor_timer_callback_group():
+    node = _FakeNode()
+    state = fake_node.R1LiteFakeState()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+    command_group = object()
+    timer_group = object()
+
+    fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=state,
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=object(),
+        command_callback_group=command_group,
+        timer_callback_group=timer_group,
+    )
+
+    assert node.subscription_callback_groups["/motion_target/target_joint_state_arm_left"] is (
+        command_group
+    )
+    assert node.subscription_callback_groups["/motion_target/target_position_gripper_right"] is (
+        command_group
+    )
+    assert node.timer_callback_groups == [timer_group]
+
+
+def test_ros2_fake_can_skip_executor_timer_for_external_sensor_loop():
+    node = _FakeNode()
+    state = fake_node.R1LiteFakeState()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+
+    fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=state,
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=object(),
+        create_timer=False,
+    )
+
+    assert node.timers == []
+
+
+def test_ros2_fake_can_use_separate_control_node_for_command_subscriptions():
+    sensor_node = _FakeNode()
+    control_node = _FakeNode()
+    state = fake_node.R1LiteFakeState()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+
+    fake_node.R1LiteRos2Fake(
+        node=sensor_node,
+        control_node=control_node,
+        message_types=types,
+        state=state,
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=object(),
+    )
+
+    assert "/hdas/feedback_arm_left" in sensor_node.publishers
+    assert "/eva/operator_button" not in sensor_node.publishers
+    assert "/motion_target/target_joint_state_arm_left" not in sensor_node.subscriptions
+    assert "/eva/operator_button" in control_node.publishers
+    assert "/eva/hil/input_joint_state_arm_left" in control_node.publishers
+    assert "/motion_target/target_joint_state_arm_left" in control_node.subscriptions
+    assert "/motion_target/target_position_gripper_right" in control_node.subscriptions
+
+
+def test_ros2_fake_can_disable_camera_publishers_for_robot_process():
+    node = _FakeNode()
+    state = fake_node.R1LiteFakeState()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+
+    fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=state,
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=object(),
+        publish_cameras=False,
+    )
+
+    assert "/hdas/camera_head/right_raw/image_raw_color/compressed" not in node.publishers
+    assert "/hdas/feedback_arm_left" in node.publishers
+    assert "/motion_target/target_joint_state_arm_left" in node.subscriptions
+
+
+def test_ros2_fake_can_disable_robot_topics_for_camera_process():
+    node = _FakeNode()
+    state = fake_node.R1LiteFakeState()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+
+    bridge = fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=state,
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=object(),
+        publish_robot=False,
+        subscribe_commands=False,
+    )
+    bridge.publish_once()
+
+    assert "/hdas/camera_head/right_raw/image_raw_color/compressed" in node.publishers
+    assert "/hdas/feedback_arm_left" not in node.publishers
+    assert "/motion_target/target_joint_state_arm_left" not in node.subscriptions
+    assert len(node.publishers["/hdas/camera_head/right_raw/image_raw_color/compressed"].messages) == 1
+
+
+def test_fake_node_main_uses_multithreaded_executor_for_ros_callbacks():
+    source = inspect.getsource(fake_node.main)
+
+    assert "MultiThreadedExecutor" in source
+    assert 'Node("eva_r1lite_fake_sensor")' in source
+    assert 'Node("eva_r1lite_fake_control")' in source
+    assert "control_node=control_node" in source
+    assert "executor.add_node(control_node)" in source
+    assert "executor.spin()" in source
+    assert "create_timer=False" in source
+    assert "_run_sensor_publish_loop" in source
+
+
+def test_ros2_fake_does_not_publish_idle_hil_that_overrides_policy_commands():
+    node = _FakeNode()
+    state = fake_node.R1LiteFakeState()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+    bridge = fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=state,
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=object(),
+    )
+
+    bridge.publish_once()
+    state.apply_hil_delta("left_arm", joint_index=2, delta=0.25)
+    bridge.publish_once()
+
+    left_messages = node.publishers["/eva/hil/input_joint_state_arm_left"].messages
+    right_messages = node.publishers["/eva/hil/input_joint_state_arm_right"].messages
+    assert left_messages == []
+    assert right_messages == []
+
+    bridge.publish_hil("left_arm", np.asarray(state.snapshot()["hil"]["left_arm"], dtype=np.float32))
+    assert len(left_messages) == 1
+    np.testing.assert_allclose(left_messages[0].position, [0.0, 0.0, 0.25, 0.0, 0.0, 0.0])
+
+
+def test_ros2_fake_reuses_precomputed_camera_frames_while_publishing(monkeypatch):
+    calls = []
+
+    def fake_jpeg(_color, _height, _width, frame_index):
+        calls.append(frame_index)
+        return bytes([frame_index % 256])
+
+    monkeypatch.setattr(fake_node, "_jpeg_image", fake_jpeg)
+    node = _FakeNode()
+    state = fake_node.R1LiteFakeState()
+    types = fake_node.Ros2MessageTypes(
+        compressed_image=_CompressedImage,
+        joint_state=_JointState,
+        pose_stamped=_PoseStamped,
+        string=_String,
+    )
+    bridge = fake_node.R1LiteRos2Fake(
+        node=node,
+        message_types=types,
+        state=state,
+        rate_hz=30.0,
+        image_height=32,
+        image_width=48,
+        qos=object(),
+    )
+    precomputed_calls = len(calls)
+
+    bridge.publish_once()
+    bridge.publish_once()
+
+    assert precomputed_calls == len(fake_node.CAMERA_TOPICS) * fake_node.CAMERA_FRAME_CACHE_SIZE
+    assert len(calls) == precomputed_calls
+
+
+class _FakeBridge:
+    def __init__(self) -> None:
+        self.operator_buttons: list[str] = []
+        self.hil_messages: list[tuple[str, np.ndarray]] = []
+        self.command_messages: list[tuple[str, np.ndarray]] = []
+
+    def publish_operator_button(self, label: str) -> None:
+        self.operator_buttons.append(label)
+
+    def publish_hil(self, group_name: str, positions: np.ndarray) -> None:
+        self.hil_messages.append((group_name, np.asarray(positions, dtype=np.float32)))
+
+    def publish_command(self, group_name: str, positions: np.ndarray) -> None:
+        self.command_messages.append((group_name, np.asarray(positions, dtype=np.float32)))
+
+
+class _FakePublisher:
+    def __init__(self) -> None:
+        self.messages = []
+
+    def publish(self, message) -> None:
+        self.messages.append(message)
+
+
+class _FakeNode:
+    def __init__(self) -> None:
+        self.publishers: dict[str, _FakePublisher] = {}
+        self.publisher_qos = {}
+        self.subscriptions = {}
+        self.subscription_callback_groups = {}
+        self.timers = []
+        self.timer_callback_groups = []
+        self.clock = _FakeClock()
+
+    def create_publisher(self, _msg_type, topic: str, qos) -> _FakePublisher:
+        publisher = _FakePublisher()
+        self.publishers[topic] = publisher
+        self.publisher_qos[topic] = qos
+        return publisher
+
+    def create_subscription(self, _msg_type, topic: str, callback, _qos, callback_group=None):
+        self.subscriptions[topic] = callback
+        self.subscription_callback_groups[topic] = callback_group
+        return callback
+
+    def create_timer(self, period_s: float, callback, callback_group=None):
+        self.timers.append((period_s, callback))
+        self.timer_callback_groups.append(callback_group)
+        return callback
+
+    def get_clock(self):
+        return self.clock
+
+    def get_logger(self):
+        return SimpleNamespace(info=lambda *_args, **_kwargs: None)
+
+
+class _FakeClock:
+    def now(self):
+        return SimpleNamespace(to_msg=lambda: _Stamp())
+
+
+class _Stamp:
+    def __init__(self) -> None:
+        self.sec = 1
+        self.nanosec = 2
+
+
+class _Header:
+    def __init__(self) -> None:
+        self.stamp = _Stamp()
+
+
+class _CompressedImage:
+    def __init__(self) -> None:
+        self.header = _Header()
+        self.format = ""
+        self.data = b""
+
+
+class _JointState:
+    def __init__(self) -> None:
+        self.header = _Header()
+        self.name = []
+        self.position = []
+
+
+class _String:
+    def __init__(self) -> None:
+        self.data = ""
+
+
+class _PoseStamped:
+    def __init__(self) -> None:
+        self.header = _Header()
+        self.pose = SimpleNamespace(
+            position=SimpleNamespace(x=0.0, y=0.0, z=0.0),
+            orientation=SimpleNamespace(w=1.0, x=0.0, y=0.0, z=0.0),
+        )

--- a/tests/hardware/test_r1lite_run_hardware.py
+++ b/tests/hardware/test_r1lite_run_hardware.py
@@ -1,0 +1,93 @@
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_run_hardware_sources_ros_setup_that_reads_unset_variables(tmp_path):
+    fake_ros_setup = tmp_path / "setup.bash"
+    fake_ros_setup.write_text(
+        """
+echo "[fake-ros] setup reached" >&2
+if [ -n "$AMENT_TRACE_SETUP_FILES" ]; then
+  echo "trace enabled" >&2
+fi
+export FAKE_ROS_SETUP_SOURCED=1
+"""
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "ssh",
+        """#!/usr/bin/env bash
+exit 0
+""",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{fake_bin}:{env['PATH']}",
+            "ROS_SETUP_BASH": str(fake_ros_setup),
+            "FASTRTPS_DEFAULT_PROFILES_FILE": str(tmp_path / "missing-fastdds.xml"),
+        }
+    )
+    env.pop("AMENT_TRACE_SETUP_FILES", None)
+
+    result = subprocess.run(
+        ["bash", "examples/hardware/r1_lite/run_hardware.sh"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "[fake-ros] setup reached" in result.stderr
+    assert "missing FastDDS profile" in result.stderr
+
+
+def test_run_hardware_uses_bundled_fastdds_profile_by_default(tmp_path):
+    fake_ros_setup = tmp_path / "setup.bash"
+    fake_ros_setup.write_text("export FAKE_ROS_SETUP_SOURCED=1\n")
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _write_executable(
+        fake_bin / "ssh",
+        """#!/usr/bin/env bash
+echo "[fake-ssh] $*" >&2
+echo "[fake-ssh] FASTRTPS_DEFAULT_PROFILES_FILE=${FASTRTPS_DEFAULT_PROFILES_FILE}" >&2
+test -f "${FASTRTPS_DEFAULT_PROFILES_FILE}"
+exit 42
+""",
+    )
+
+    env = os.environ.copy()
+    env["HOME"] = str(tmp_path)
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+    env["ROS_SETUP_BASH"] = str(fake_ros_setup)
+    env.pop("FASTRTPS_DEFAULT_PROFILES_FILE", None)
+
+    result = subprocess.run(
+        ["bash", "examples/hardware/r1_lite/run_hardware.sh"],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 42
+    assert "[fake-ssh]" in result.stderr
+    assert "[fake-ssh] FASTRTPS_DEFAULT_PROFILES_FILE=" in result.stderr
+    assert "examples/hardware/r1_lite/fastdds_r1lite_super_client.xml" in result.stderr

--- a/tests/integration/web/_harness.py
+++ b/tests/integration/web/_harness.py
@@ -33,7 +33,7 @@ from core.app.console.server import (
 from core.app.state import RuntimeState, SessionState
 from core.config import ConfigDict, load_config
 from core.registry import ROBOT_REGISTRY, TRANSPORT_REGISTRY
-from core.types import Observation
+from core.types import CollectionRawBatch, CollectionRawSample, Observation, RawCollectionSnapshot
 from robots.base import Robot
 from transport.base import TransportBridge, build_transport
 
@@ -53,6 +53,7 @@ class _DebugTransport(TransportBridge):
         self._shutdown = threading.Event()
         self._qpos = np.asarray(robot.initial_qpos, dtype=np.float32).copy()
         self._camera_names = [cam.observation_key for cam in robot.observation_schema.cameras]
+        self._raw_index = 0
 
     def get_frame(self) -> Observation | None:
         if self._shutdown.is_set():
@@ -64,6 +65,32 @@ class _DebugTransport(TransportBridge):
             for name in self._camera_names
         }
         return Observation(images=images, state_qpos=self._qpos.copy())
+
+    def acquire_collection_raw(self) -> RawCollectionSnapshot | None:
+        if self._shutdown.is_set():
+            return None
+        h = self._config.transport.image_height
+        w = self._config.transport.image_width
+        timestamp = float(self._raw_index)
+        self._raw_index += 1
+        images = {
+            name: np.random.randint(0, 256, (h, w, 3), dtype=np.uint8)
+            for name in self._camera_names
+        }
+        state = self._qpos.copy()
+
+        def decode_raw() -> CollectionRawBatch:
+            return CollectionRawBatch(
+                images={
+                    name: [CollectionRawSample(timestamp, image.copy())]
+                    for name, image in images.items()
+                },
+                vectors={
+                    "state_qpos": [CollectionRawSample(timestamp, state.copy())],
+                },
+            )
+
+        return RawCollectionSnapshot(timestamp=timestamp, decode_raw=decode_raw)
 
     def publish_action(self, action: np.ndarray, target: str = "real") -> None:
         self._qpos = np.asarray(action, dtype=np.float32).copy()

--- a/tests/integration/web/test_console_eval.py
+++ b/tests/integration/web/test_console_eval.py
@@ -124,3 +124,39 @@ def test_results_dedup_latest_episode_per_clip(tmp_path):
         assert len(recs) == 1  # one row per clip
         assert recs[0]["episode_index"] == 3  # latest episode wins
         assert recs[0]["score"] == 4
+
+
+def test_score_does_not_wait_for_async_save(tmp_path):
+    class _Logger:
+        def __init__(self) -> None:
+            self.patches = []
+
+        def wait_for_saves(self) -> bool:
+            raise AssertionError("score endpoint must not wait for background save")
+
+        def patch_episode_meta_by_clip(self, clip_id: str, **fields):
+            self.patches.append((clip_id, fields))
+            return 4
+
+    with _serve_eval_console(_eval_config(), str(tmp_path)) as h:
+        logger = _Logger()
+        h.runtime.episode_logger = logger
+
+        resp = h.post(
+            "/api/score",
+            {
+                "clip_id": "c1",
+                "prompt": "pick up the block",
+                "trial": 1,
+                "score": 2,
+                "max_score": 4,
+                "milestones": {"grasp": True},
+                "note": "ok",
+                "duration_ms": 123,
+            },
+        )
+
+        assert resp.status == 200
+        assert resp.json["episode_index"] == 4
+        assert logger.patches[0][0] == "c1"
+        assert logger.patches[0][1]["score"] == 2

--- a/tests/recorder/test_episode_logger.py
+++ b/tests/recorder/test_episode_logger.py
@@ -16,7 +16,13 @@ from core.config import ConfigDict
 from core.recorder import collection as collection_module
 from core.recorder import episode as episode_module
 from core.recorder.episode import EpisodeLogger, sanitize_path_component
-from core.types import CollectionRawBatch, CollectionRawSample, Observation, RawCollectionSnapshot
+from core.types import (
+    CollectionRawBatch,
+    CollectionRawImage,
+    CollectionRawSample,
+    Observation,
+    RawCollectionSnapshot,
+)
 from core.utils.lerobot import LeRobotDatasetIO
 from robots.base import (
     ActuatorGroup,
@@ -41,7 +47,13 @@ def _robot() -> Robot:
     )
 
 
-def _logger(log_dir, *, save_video: bool = False, fps: int = 30) -> EpisodeLogger:
+def _logger(
+    log_dir,
+    *,
+    save_video: bool = False,
+    fps: int = 30,
+    async_save: bool = False,
+) -> EpisodeLogger:
     return EpisodeLogger(
         log_dir,
         _robot(),
@@ -52,7 +64,7 @@ def _logger(log_dir, *, save_video: bool = False, fps: int = 30) -> EpisodeLogge
             action_key="action",
             video_keys={},
         ),
-        async_save=False,
+        async_save=async_save,
     )
 
 
@@ -485,6 +497,125 @@ def test_record_step_uses_observation_timestamp_when_present(tmp_path):
 
     table = pq.read_table(tmp_path / "data" / "chunk-000" / "episode_000000.parquet")
     np.testing.assert_allclose(table.column("capture_time").to_pylist(), [5.0, 5.1, 5.2])
+
+
+def test_raw_episode_snapshots_decode_on_async_save_worker(tmp_path):
+    logger = _logger(tmp_path, fps=10, async_save=True)
+    raw_decodes = 0
+    image_decodes = 0
+
+    def snapshot(timestamp: float, state: np.ndarray) -> RawCollectionSnapshot:
+        def decode_raw() -> CollectionRawBatch:
+            nonlocal raw_decodes
+            raw_decodes += 1
+
+            def decode_image() -> np.ndarray:
+                nonlocal image_decodes
+                image_decodes += 1
+                return np.zeros((2, 2, 3), dtype=np.uint8)
+
+            return CollectionRawBatch(
+                images={
+                    "cam_high": [
+                        CollectionRawSample(
+                            timestamp,
+                            CollectionRawImage(decode_image),
+                        ),
+                    ],
+                },
+                vectors={
+                    "state_qpos": [CollectionRawSample(timestamp, state.copy())],
+                },
+                start_time=timestamp,
+                end_time=timestamp,
+            )
+
+        return RawCollectionSnapshot(timestamp=timestamp, decode_raw=decode_raw)
+
+    logger.start_episode("t")
+    logger.ingest_raw_episode_snapshot(
+        snapshot(1.0, np.zeros(_DIM, dtype=np.float32)),
+        np.full(_DIM, 10.0, dtype=np.float32),
+    )
+    logger.ingest_raw_episode_snapshot(
+        snapshot(1.2, np.full(_DIM, 2.0, dtype=np.float32)),
+        np.full(_DIM, 12.0, dtype=np.float32),
+    )
+    logger._start_save_worker = lambda: None
+
+    assert logger.end_episode()
+    assert raw_decodes == 0
+    assert image_decodes == 0
+
+    logger._save_queue_worker()
+
+    assert raw_decodes == 2
+    assert image_decodes == 2
+    table = pq.read_table(tmp_path / "data" / "chunk-000" / "episode_000000.parquet")
+    np.testing.assert_allclose(table.column("timestamp").to_pylist(), [0.0, 0.1, 0.2])
+    np.testing.assert_allclose(table.column("capture_time").to_pylist(), [1.0, 1.1, 1.2])
+    np.testing.assert_allclose(
+        table.column("action").to_pylist(),
+        [
+            [10.0] * _DIM,
+            [11.0] * _DIM,
+            [12.0] * _DIM,
+        ],
+    )
+
+
+def test_pending_score_patch_applies_to_async_save_job(tmp_path):
+    logger = _logger(tmp_path, fps=10, async_save=True)
+
+    def snapshot(timestamp: float, state: np.ndarray) -> RawCollectionSnapshot:
+        def decode_raw() -> CollectionRawBatch:
+            return CollectionRawBatch(
+                images={
+                    "cam_high": [
+                        CollectionRawSample(
+                            timestamp,
+                            np.zeros((2, 2, 3), dtype=np.uint8),
+                        ),
+                    ],
+                },
+                vectors={
+                    "state_qpos": [CollectionRawSample(timestamp, state.copy())],
+                },
+            )
+
+        return RawCollectionSnapshot(timestamp=timestamp, decode_raw=decode_raw)
+
+    logger.start_episode("t")
+    logger.set_episode_meta(clip_id="c1", prompt="p", trial=1)
+    logger.ingest_raw_episode_snapshot(
+        snapshot(1.0, np.zeros(_DIM, dtype=np.float32)),
+        np.full(_DIM, 10.0, dtype=np.float32),
+    )
+    logger.ingest_raw_episode_snapshot(
+        snapshot(1.2, np.full(_DIM, 2.0, dtype=np.float32)),
+        np.full(_DIM, 12.0, dtype=np.float32),
+    )
+    logger._start_save_worker = lambda: None
+
+    assert logger.end_episode()
+    episode_index = logger.patch_episode_meta_by_clip(
+        "c1",
+        score=2,
+        max_score=4,
+        milestones={"grasp": True},
+        note="ok",
+    )
+
+    assert episode_index == 0
+
+    logger._save_queue_worker()
+
+    row = _read_jsonl(tmp_path / "meta" / "episodes.jsonl")[0]
+    assert row["clip_id"] == "c1"
+    assert row["score"] == 2
+    assert row["max_score"] == 4
+    assert row["milestones"] == {"grasp": True}
+    assert row["note"] == "ok"
 
 
 def test_collection_raw_batches_report_image_skew_qc(tmp_path):

--- a/tests/transport/test_base.py
+++ b/tests/transport/test_base.py
@@ -106,6 +106,24 @@ def test_raw_collection_snapshot_exposes_raw_stream_batch():
     np.testing.assert_allclose(batch.vectors["state_qpos:arm"][1].value, [2.0, 3.0])
 
 
+def test_raw_episode_snapshot_uses_live_streams_without_collection_schema():
+    image = np.zeros((4, 4, 3), dtype=np.uint8)
+    transport = _FakeRosCollectionTransport(image)
+    transport._config.collection.schema.columns = {}
+    transport._config.collection.schema.cameras = {}
+    transport._group_state_deques = {"arm": deque([transport._msg(1.0, [1.0, 2.0])])}
+    transport._camera_deques["front"].append(transport._msg(1.1))
+    transport._group_state_deques["arm"].append(transport._msg(1.1, [2.0, 3.0]))
+
+    snapshot = transport.acquire_collection_raw()
+    assert snapshot is not None
+    batch = snapshot.decode_raw()
+
+    assert [sample.timestamp for sample in batch.images["cam_high"]] == [1.0, 1.1]
+    assert [sample.timestamp for sample in batch.vectors["state_qpos:arm"]] == [1.0, 1.1]
+    np.testing.assert_allclose(batch.vectors["state_qpos:arm"][1].value, [2.0, 3.0])
+
+
 def test_raw_collection_snapshot_defers_image_decode_until_alignment():
     image = np.zeros((4, 4, 3), dtype=np.uint8)
     transport = _FakeRosCollectionTransport(image)

--- a/tools/run_r1lite_fake_e2e.py
+++ b/tools/run_r1lite_fake_e2e.py
@@ -1,0 +1,841 @@
+#!/usr/bin/env python3
+"""Run R1 Lite fake-node end-to-end checks against EVA's ROS2 path."""
+
+from __future__ import annotations
+
+import argparse
+import http.client
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, NamedTuple, Sequence
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROMPT = "pack up a smart phone"
+
+
+class E2EPaths(NamedTuple):
+    base_dir: Path
+    config_dir: Path
+    deploy_config: Path
+    rollout_hil_config: Path
+    hil_config: Path
+    collection_config: Path
+    collection_no_hil_config: Path
+    eval_config: Path
+    rollout_no_hil_dir: Path
+    rollout_hil_dir: Path
+    hil_dir: Path
+    collection_hil_dir: Path
+    collection_no_hil_dir: Path
+    eval_output_dir: Path
+
+    @property
+    def eval_dir(self) -> Path:
+        return self.eval_output_dir
+
+
+class ManagedProcess:
+    """Small subprocess wrapper that writes logs and stops the whole process group."""
+
+    def __init__(self, name: str, command: Sequence[str], env: dict[str, str], log_path: Path):
+        self.name = name
+        self.command = list(command)
+        self.log_path = log_path
+        self._log_file = log_path.open("w", encoding="utf-8")
+        self._proc = subprocess.Popen(
+            self.command,
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=self._log_file,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+
+    @property
+    def returncode(self) -> int | None:
+        return self._proc.poll()
+
+    def assert_running(self) -> None:
+        code = self.returncode
+        if code is not None:
+            raise RuntimeError(f"{self.name} exited with code {code}; log={self.log_path}")
+
+    def stop(self) -> None:
+        if self.returncode is None:
+            os.killpg(self._proc.pid, signal.SIGINT)
+            try:
+                self._proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                os.killpg(self._proc.pid, signal.SIGTERM)
+                try:
+                    self._proc.wait(timeout=3.0)
+                except subprocess.TimeoutExpired:
+                    os.killpg(self._proc.pid, signal.SIGKILL)
+                    self._proc.wait(timeout=3.0)
+        self._log_file.close()
+
+
+def e2e_env() -> dict[str, str]:
+    env = os.environ.copy()
+    root = str(REPO_ROOT)
+    env["PYTHONPATH"] = f"{root}:{root}/src:{env.get('PYTHONPATH', '')}"
+    for key in (
+        "http_proxy",
+        "https_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "all_proxy",
+        "ALL_PROXY",
+        "FASTRTPS_DEFAULT_PROFILES_FILE",
+        "ROS_DISCOVERY_SERVER",
+        "RMW_IMPLEMENTATION",
+    ):
+        env.pop(key, None)
+    env["ROS_LOCALHOST_ONLY"] = "1"
+    return env
+
+
+def write_e2e_configs(base_dir: Path, policy_port: int) -> E2EPaths:
+    base_dir = base_dir.resolve()
+    config_dir = base_dir / "configs"
+    rollout_no_hil_dir = base_dir / "rollout_no_hil"
+    rollout_hil_dir = base_dir / "rollout_hil"
+    hil_dir = base_dir / "hil"
+    collection_hil_dir = base_dir / "collection_hil"
+    collection_no_hil_dir = base_dir / "collection_no_hil"
+    eval_output_dir = base_dir / "eval"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    rollout_no_hil_dir.mkdir(parents=True, exist_ok=True)
+    rollout_hil_dir.mkdir(parents=True, exist_ok=True)
+    hil_dir.mkdir(parents=True, exist_ok=True)
+    collection_hil_dir.mkdir(parents=True, exist_ok=True)
+    collection_no_hil_dir.mkdir(parents=True, exist_ok=True)
+    eval_output_dir.mkdir(parents=True, exist_ok=True)
+
+    deploy_base = REPO_ROOT / "configs/01_deploy/r1lite/openpi_qpos.py"
+    collection_base = REPO_ROOT / "configs/02_collection/r1lite.py"
+    eval_base = REPO_ROOT / "configs/03_evaluation/r1lite_eval.py"
+
+    deploy_config = config_dir / "r1lite_fake_deploy.py"
+    deploy_config.write_text(
+        f"""_base_ = ['{deploy_base}']
+
+policy = dict(port={policy_port})
+
+rollout = dict(
+    storage=dict(
+        enabled=True,
+        log_dir='{rollout_no_hil_dir}',
+        fps=15,
+        save_queue_max=15,
+        async_save=False,
+        image_height=360,
+        image_width=640,
+    ),
+    intervention=dict(enabled=False, control_mode='relative'),
+)
+
+operator_control = dict(enabled=True, button_topic='/eva/operator_button')
+
+inference_cfg = dict(publish_rate=15, setup_warmup_chunks=1)
+""",
+        encoding="utf-8",
+    )
+
+    rollout_hil_config = config_dir / "r1lite_fake_rollout_hil.py"
+    rollout_hil_config.write_text(
+        f"""_base_ = ['{deploy_base}']
+
+policy = dict(port={policy_port})
+
+rollout = dict(
+    storage=dict(
+        enabled=True,
+        log_dir='{rollout_hil_dir}',
+        fps=15,
+        save_queue_max=15,
+        async_save=False,
+        image_height=360,
+        image_width=640,
+    ),
+    intervention=dict(enabled=True, control_mode='relative'),
+)
+
+operator_control = dict(enabled=True, button_topic='/eva/operator_button')
+
+inference_cfg = dict(publish_rate=15, setup_warmup_chunks=1)
+""",
+        encoding="utf-8",
+    )
+
+    hil_config = config_dir / "r1lite_fake_hil.py"
+    hil_config.write_text(
+        f"""_base_ = ['{rollout_hil_config}']
+
+rollout = dict(
+    storage=dict(
+        log_dir='{hil_dir}',
+    ),
+    intervention=dict(enabled=True, control_mode='relative'),
+)
+""",
+        encoding="utf-8",
+    )
+
+    collection_config = config_dir / "r1lite_fake_collection.py"
+    collection_config.write_text(
+        f"""_base_ = ['{collection_base}']
+
+policy = dict(port={policy_port})
+
+collection = dict(
+    storage=dict(
+        log_dir='{collection_hil_dir}',
+        fps=15,
+        save_queue_max=15,
+        image_height=360,
+        image_width=640,
+    ),
+)
+
+rollout = dict(
+    intervention=dict(enabled=True, control_mode='relative'),
+)
+
+inference_cfg = dict(publish_rate=15, setup_warmup_chunks=1)
+""",
+        encoding="utf-8",
+    )
+
+    collection_no_hil_config = config_dir / "r1lite_fake_collection_no_hil.py"
+    collection_no_hil_config.write_text(
+        f"""_base_ = ['{collection_config}']
+
+collection = dict(
+    storage=dict(
+        log_dir='{collection_no_hil_dir}',
+    ),
+)
+
+rollout = dict(
+    intervention=dict(enabled=False, control_mode='relative'),
+)
+""",
+        encoding="utf-8",
+    )
+
+    eval_config = config_dir / "r1lite_fake_eval.py"
+    eval_config.write_text(
+        f"""_base_ = ['{eval_base}']
+
+eval_cfg = dict(
+    output_dir='{eval_output_dir}',
+    storage=dict(
+        fps=15,
+        save_queue_max=15,
+        image_height=360,
+        image_width=640,
+    ),
+    trials_per_prompt=1,
+    cli_mode='real',
+    inference_strategy='sync',
+    reset_after_each_trial=False,
+    skip_warmup_after_first=True,
+    checkpoints=[
+        dict(
+            name='fake_policy',
+            config='{deploy_base}',
+            port={policy_port},
+        ),
+    ],
+    shuffle_ckpts=False,
+    shuffle_seed=42,
+    enable_ssh_forward=False,
+    tasks=[
+        dict(
+            prompt_en='{PROMPT}',
+            milestones=(('done', 'fake episode completed'),),
+        ),
+    ],
+)
+""",
+        encoding="utf-8",
+    )
+
+    return E2EPaths(
+        base_dir=base_dir,
+        config_dir=config_dir,
+        deploy_config=deploy_config,
+        rollout_hil_config=rollout_hil_config,
+        hil_config=hil_config,
+        collection_config=collection_config,
+        collection_no_hil_config=collection_no_hil_config,
+        eval_config=eval_config,
+        rollout_no_hil_dir=rollout_no_hil_dir,
+        rollout_hil_dir=rollout_hil_dir,
+        hil_dir=hil_dir,
+        collection_hil_dir=collection_hil_dir,
+        collection_no_hil_dir=collection_no_hil_dir,
+        eval_output_dir=eval_output_dir,
+    )
+
+
+def http_json(method: str, url: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=data,
+        method=method,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(request, timeout=5.0) as response:
+        body = response.read().decode("utf-8")
+    return json.loads(body) if body else {}
+
+
+def get_json(base_url: str, path: str) -> dict[str, Any]:
+    return http_json("GET", f"{base_url}{path}")
+
+
+def post_json(base_url: str, path: str, payload: dict[str, Any] | None = None) -> dict[str, Any]:
+    return http_json("POST", f"{base_url}{path}", payload or {})
+
+
+def wait_for_http(base_url: str, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            get_json(base_url, "/api/status")
+            return
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            json.JSONDecodeError,
+            http.client.RemoteDisconnected,
+        ):
+            time.sleep(0.2)
+    raise TimeoutError(f"EVA did not answer at {base_url}")
+
+
+def wait_for_fake_ui(fake_url: str, timeout_s: float) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            get_json(fake_url, "/api/state")
+            return
+        except (
+            urllib.error.URLError,
+            TimeoutError,
+            json.JSONDecodeError,
+            http.client.RemoteDisconnected,
+        ):
+            time.sleep(0.2)
+    raise TimeoutError(f"fake node UI did not answer at {fake_url}")
+
+
+def wait_status_value(
+    base_url: str,
+    key: str,
+    expected: Any,
+    timeout_s: float,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_s
+    last: dict[str, Any] = {}
+    while time.monotonic() < deadline:
+        last = get_json(base_url, "/api/status")
+        if last.get(key) == expected:
+            return last
+        time.sleep(0.2)
+    raise TimeoutError(f"status[{key!r}] did not become {expected!r}; last={last}")
+
+
+def poll_status_for(base_url: str, duration_s: float, interval_s: float = 0.5) -> None:
+    deadline = time.monotonic() + duration_s
+    while time.monotonic() < deadline:
+        get_json(base_url, "/api/status")
+        remaining = deadline - time.monotonic()
+        if remaining <= 0.0:
+            return
+        time.sleep(min(interval_s, remaining))
+
+
+def wait_for_file(path: Path, timeout_s: float) -> Path:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if path.exists():
+            return path
+        time.sleep(0.2)
+    raise TimeoutError(f"file not written: {path}")
+
+
+def wait_for_latest_parquet(root: Path, timeout_s: float) -> Path:
+    deadline = time.monotonic() + timeout_s
+    last: list[Path] = []
+    while time.monotonic() < deadline:
+        last = sorted(root.glob("**/data/chunk-000/episode_*.parquet"))
+        if last:
+            return last[-1]
+        time.sleep(0.3)
+    raise TimeoutError(f"no episode parquet under {root}; last={last}")
+
+
+def latest_episode_row(dataset_root: Path) -> dict[str, Any]:
+    candidates = sorted(dataset_root.glob("**/meta/episodes.jsonl"))
+    if not candidates:
+        raise FileNotFoundError(f"no episodes.jsonl under {dataset_root}")
+    path = candidates[-1]
+    rows = [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+    if not rows:
+        raise AssertionError(f"empty episodes.jsonl: {path}")
+    return rows[-1]
+
+
+def wait_latest_episode_row(dataset_root: Path, timeout_s: float) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_s
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            return latest_episode_row(dataset_root)
+        except (FileNotFoundError, AssertionError) as exc:
+            last_error = exc
+            time.sleep(0.2)
+    if last_error is not None:
+        raise last_error
+    raise TimeoutError(f"no episode metadata under {dataset_root}")
+
+
+def assert_fixed_clock(table: pa.Table, fps: int) -> None:
+    timestamps = np.asarray(table["timestamp"].to_pylist(), dtype=np.float64)
+    if timestamps.size < 2:
+        raise AssertionError("need at least two timestamps to validate fixed-clock output")
+    expected = 1.0 / float(fps)
+    diffs = np.diff(timestamps)
+    if not np.allclose(diffs, expected, atol=1e-6):
+        raise AssertionError(
+            f"timestamp is not fixed-clock: expected dt={expected}, "
+            f"min={float(diffs.min())}, max={float(diffs.max())}"
+        )
+
+
+def table_vector(table: pa.Table, column: str) -> np.ndarray:
+    return np.asarray(table[column].to_pylist(), dtype=np.float32)
+
+
+def assert_vector_varies(
+    values: np.ndarray,
+    *,
+    columns: Sequence[int],
+    label: str,
+    min_std: float = 1e-4,
+) -> None:
+    if values.ndim != 2:
+        raise AssertionError(f"{label} must be 2-D, got shape={values.shape}")
+    selected = values[:, list(columns)]
+    if float(selected.std()) <= min_std:
+        raise AssertionError(f"{label} did not vary in columns {tuple(columns)}")
+
+
+def drive_hil(fake_url: str, repeats: int, delay_s: float) -> None:
+    for _ in range(repeats):
+        post_json(fake_url, "/api/joint_delta", {"group": "left_arm", "index": 2, "delta": 0.03})
+        post_json(
+            fake_url,
+            "/api/joint_delta",
+            {"group": "right_arm", "index": 3, "delta": -0.02},
+        )
+        time.sleep(delay_s)
+
+
+def drive_motion_target(fake_url: str, repeats: int, delay_s: float) -> None:
+    for _ in range(repeats):
+        post_json(
+            fake_url,
+            "/api/command_delta",
+            {"group": "left_arm", "index": 2, "delta": 0.03},
+        )
+        post_json(
+            fake_url,
+            "/api/command_delta",
+            {"group": "right_arm", "index": 3, "delta": -0.02},
+        )
+        time.sleep(delay_s)
+
+
+def validate_rollout(dataset_root: Path) -> dict[str, Any]:
+    parquet = wait_for_latest_parquet(dataset_root, 30.0)
+    table = pq.read_table(parquet)
+    assert_fixed_clock(table, 15)
+    state = table_vector(table, "observations.state.qpos")
+    action = table_vector(table, "action")
+    if state.shape[1] != 14 or action.shape[1] != 14:
+        raise AssertionError(f"rollout qpos shape mismatch: state={state.shape} action={action.shape}")
+    assert_vector_varies(action, columns=(2, 10), label="rollout action")
+    return {"path": str(parquet), "rows": table.num_rows, "action_std": float(action.std())}
+
+
+def validate_collection(dataset_root: Path) -> dict[str, Any]:
+    parquet = wait_for_latest_parquet(dataset_root, 45.0)
+    table = pq.read_table(parquet)
+    row = wait_latest_episode_row(dataset_root, 30.0)
+    assert_fixed_clock(table, 15)
+    state = table_vector(table, "observations.state.qpos")
+    action = table_vector(table, "action.qpos")
+    if state.shape[1] != 14 or action.shape[1] != 14:
+        raise AssertionError(
+            f"collection qpos shape mismatch: state={state.shape} action={action.shape}"
+        )
+    if row.get("quality") != "green":
+        raise AssertionError(f"collection quality is {row.get('quality')}: {row.get('quality_issues')}")
+    assert_vector_varies(action, columns=(2, 10), label="collection action.qpos")
+    return {
+        "path": str(parquet),
+        "rows": table.num_rows,
+        "quality": row.get("quality"),
+        "image_skew": row.get("alignment_image_max_skew_sec"),
+        "action_std": float(action.std()),
+    }
+
+
+def validate_eval(paths: E2EPaths, clip_id: str) -> dict[str, Any]:
+    dataset_root = paths.eval_output_dir / "fake_policy" / "episodes"
+    parquet = wait_for_latest_parquet(dataset_root, 45.0)
+    table = pq.read_table(parquet)
+    row = wait_latest_episode_row(dataset_root, 30.0)
+    assert_fixed_clock(table, 15)
+    if row.get("clip_id") != clip_id:
+        raise AssertionError(f"eval clip_id mismatch: {row.get('clip_id')} != {clip_id}")
+    return {"path": str(parquet), "rows": table.num_rows, "clip_id": row.get("clip_id")}
+
+
+def start_fake_node(paths: E2EPaths, env: dict[str, str], ui_port: int) -> ManagedProcess:
+    env = dict(env, PUBLISH_RATE="30", UI_PORT=str(ui_port), IMAGE_HEIGHT="360", IMAGE_WIDTH="640")
+    return ManagedProcess(
+        "fake-node",
+        ["bash", "examples/hardware/r1_lite/run_fake_node.sh", "--no-open-ui"],
+        env,
+        paths.base_dir / "fake-node.log",
+    )
+
+
+def start_fake_policy(paths: E2EPaths, env: dict[str, str], policy_port: int) -> ManagedProcess:
+    return ManagedProcess(
+        "fake-policy",
+        [
+            sys.executable,
+            "examples/fake_policy/fake_policy_server.py",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(policy_port),
+            "--chunk-size",
+            "50",
+            "--action-dim",
+            "14",
+            "--action-mode",
+            "qpos",
+        ],
+        env,
+        paths.base_dir / "fake-policy.log",
+    )
+
+
+def start_eva(
+    paths: E2EPaths,
+    env: dict[str, str],
+    config_path: Path,
+    web_port: int,
+    name: str,
+) -> ManagedProcess:
+    return ManagedProcess(
+        name,
+        [sys.executable, "src/main.py", "--config", str(config_path), "--web-port", str(web_port)],
+        env,
+        paths.base_dir / f"{name}.log",
+    )
+
+
+def stop_process(proc: ManagedProcess | None) -> None:
+    if proc is not None:
+        proc.stop()
+
+
+def run_rollout(
+    paths: E2EPaths,
+    env: dict[str, str],
+    web_port: int,
+    fake_url: str,
+    *,
+    config_path: Path,
+    dataset_root: Path,
+    name: str,
+) -> dict[str, Any]:
+    proc = start_eva(paths, env, config_path, web_port, name)
+    eva_url = f"http://127.0.0.1:{web_port}"
+    try:
+        wait_for_http(eva_url, 30.0)
+        post_json(eva_url, "/api/connect")
+        post_json(eva_url, "/api/select_mode", {"mode": "real"})
+        post_json(eva_url, "/api/select_strategy", {"strategy": "sync"})
+        post_json(eva_url, "/api/select_task", {"task": PROMPT})
+        post_json(eva_url, "/api/setup")
+        wait_status_value(eva_url, "session_status", "ready", 45.0)
+        post_json(eva_url, "/api/run")
+        wait_status_value(eva_url, "session_status", "running", 15.0)
+        poll_status_for(eva_url, 4.0)
+        post_json(eva_url, "/api/rollout_stop")
+        wait_status_value(eva_url, "session_status", "ready", 15.0)
+        status = get_json(eva_url, "/api/status")
+        if not status.get("rollout", {}).get("save_ready"):
+            raise AssertionError(f"rollout is not save_ready after stop: {status.get('rollout')}")
+        post_json(eva_url, "/api/rollout_save")
+        return validate_rollout(dataset_root)
+    finally:
+        stop_process(proc)
+        _ = fake_url
+
+
+def run_collection(
+    paths: E2EPaths,
+    env: dict[str, str],
+    web_port: int,
+    fake_url: str,
+    *,
+    config_path: Path,
+    dataset_root: Path,
+    name: str,
+    command_source: str,
+) -> dict[str, Any]:
+    proc = start_eva(paths, env, config_path, web_port, name)
+    eva_url = f"http://127.0.0.1:{web_port}"
+    try:
+        wait_for_http(eva_url, 30.0)
+        post_json(eva_url, "/api/tab_switch", {"tab": "collect", "collect_teleop_armed": True})
+        time.sleep(1.0)
+        post_json(fake_url, "/api/operator", {"button": "x"})
+        wait_status_value(eva_url, "session_status", "running", 15.0)
+        if command_source == "hil":
+            drive_hil(fake_url, repeats=30, delay_s=0.1)
+        elif command_source == "motion_target":
+            drive_motion_target(fake_url, repeats=30, delay_s=0.1)
+        else:
+            raise ValueError(f"unsupported collection command_source {command_source!r}")
+        post_json(fake_url, "/api/gripper", {"side": "right", "command": "close"})
+        time.sleep(0.5)
+        post_json(fake_url, "/api/gripper", {"side": "right", "command": "open"})
+        time.sleep(0.5)
+        post_json(fake_url, "/api/operator", {"button": "y"})
+        wait_status_value(eva_url, "session_status", "ready", 15.0)
+        return validate_collection(dataset_root)
+    finally:
+        stop_process(proc)
+
+
+def run_hil_intervention(
+    paths: E2EPaths,
+    env: dict[str, str],
+    web_port: int,
+    fake_url: str,
+) -> dict[str, Any]:
+    proc = start_eva(paths, env, paths.hil_config, web_port, "eva-hil")
+    eva_url = f"http://127.0.0.1:{web_port}"
+    try:
+        wait_for_http(eva_url, 30.0)
+        post_json(eva_url, "/api/connect")
+        post_json(eva_url, "/api/select_mode", {"mode": "real"})
+        post_json(eva_url, "/api/select_strategy", {"strategy": "sync"})
+        post_json(eva_url, "/api/select_task", {"task": PROMPT})
+        post_json(eva_url, "/api/setup")
+        wait_status_value(eva_url, "session_status", "ready", 45.0)
+        post_json(eva_url, "/api/run")
+        wait_status_value(eva_url, "session_status", "running", 15.0)
+        poll_status_for(eva_url, 3.0)
+        post_json(fake_url, "/api/operator", {"button": "x"})
+        deadline = time.monotonic() + 15.0
+        while time.monotonic() < deadline:
+            status = get_json(eva_url, "/api/status")
+            if status.get("rollout_intervention_active"):
+                break
+            time.sleep(0.2)
+        else:
+            raise AssertionError("rollout intervention did not become active after fake X")
+        post_json(fake_url, "/api/sync_hil_to_feedback")
+        drive_hil(fake_url, repeats=20, delay_s=0.1)
+        post_json(fake_url, "/api/operator", {"button": "y"})
+        wait_status_value(eva_url, "session_status", "running", 30.0)
+        poll_status_for(eva_url, 2.0)
+        post_json(eva_url, "/api/rollout_stop")
+        wait_status_value(eva_url, "session_status", "ready", 15.0)
+        status = get_json(eva_url, "/api/status")
+        segments = int(status.get("rollout_intervention_segments") or 0)
+        if segments < 1:
+            raise AssertionError(f"no accepted intervention segment: {status}")
+        post_json(eva_url, "/api/rollout_save")
+        summary = validate_rollout(paths.hil_dir)
+        summary["segments"] = segments
+        return summary
+    finally:
+        stop_process(proc)
+
+
+def run_eval(paths: E2EPaths, env: dict[str, str], web_port: int) -> dict[str, Any]:
+    proc = start_eva(paths, env, paths.eval_config, web_port, "eva-eval")
+    eva_url = f"http://127.0.0.1:{web_port}"
+    clip_id = "fake-clip-001"
+    try:
+        wait_for_http(eva_url, 45.0)
+        post_json(eva_url, "/api/tab_switch", {"tab": "eval"})
+        post_json(eva_url, "/api/eval_start", {"clip_id": clip_id, "prompt": PROMPT, "trial": 1})
+        wait_status_value(eva_url, "session_status", "running", 45.0)
+        poll_status_for(eva_url, 5.0)
+        post_json(eva_url, "/api/eval_stop")
+        wait_status_value(eva_url, "session_status", "ready", 30.0)
+        return validate_eval(paths, clip_id)
+    finally:
+        stop_process(proc)
+
+
+def run_all(args: argparse.Namespace) -> dict[str, Any]:
+    paths = write_e2e_configs(Path(args.base_dir), args.policy_port)
+    env = e2e_env()
+    fake_url = f"http://127.0.0.1:{args.fake_ui_port}"
+    fake_node = start_fake_node(paths, env, args.fake_ui_port)
+    fake_policy = start_fake_policy(paths, env, args.policy_port)
+    summary: dict[str, Any] = {"artifacts": str(paths.base_dir)}
+    try:
+        wait_for_fake_ui(fake_url, 30.0)
+        fake_node.assert_running()
+        fake_policy.assert_running()
+        if not args.only or args.only == "rollout":
+            summary["rollout_no_hil"] = run_rollout(
+                paths,
+                env,
+                args.web_port,
+                fake_url,
+                config_path=paths.deploy_config,
+                dataset_root=paths.rollout_no_hil_dir,
+                name="eva-rollout-no-hil",
+            )
+            summary["rollout_hil"] = run_rollout(
+                paths,
+                env,
+                args.web_port,
+                fake_url,
+                config_path=paths.rollout_hil_config,
+                dataset_root=paths.rollout_hil_dir,
+                name="eva-rollout-hil",
+            )
+        if args.only == "rollout_no_hil":
+            summary["rollout_no_hil"] = run_rollout(
+                paths,
+                env,
+                args.web_port,
+                fake_url,
+                config_path=paths.deploy_config,
+                dataset_root=paths.rollout_no_hil_dir,
+                name="eva-rollout-no-hil",
+            )
+        if args.only == "rollout_hil":
+            summary["rollout_hil"] = run_rollout(
+                paths,
+                env,
+                args.web_port,
+                fake_url,
+                config_path=paths.rollout_hil_config,
+                dataset_root=paths.rollout_hil_dir,
+                name="eva-rollout-hil",
+            )
+        if not args.only or args.only == "collect":
+            summary["collect_hil"] = run_collection(
+                paths,
+                env,
+                args.web_port,
+                fake_url,
+                config_path=paths.collection_config,
+                dataset_root=paths.collection_hil_dir,
+                name="eva-collection-hil",
+                command_source="hil",
+            )
+            summary["collect_no_hil"] = run_collection(
+                paths,
+                env,
+                args.web_port,
+                fake_url,
+                config_path=paths.collection_no_hil_config,
+                dataset_root=paths.collection_no_hil_dir,
+                name="eva-collection-no-hil",
+                command_source="motion_target",
+            )
+        if args.only == "collect_hil":
+            summary["collect_hil"] = run_collection(
+                paths,
+                env,
+                args.web_port,
+                fake_url,
+                config_path=paths.collection_config,
+                dataset_root=paths.collection_hil_dir,
+                name="eva-collection-hil",
+                command_source="hil",
+            )
+        if args.only == "collect_no_hil":
+            summary["collect_no_hil"] = run_collection(
+                paths,
+                env,
+                args.web_port,
+                fake_url,
+                config_path=paths.collection_no_hil_config,
+                dataset_root=paths.collection_no_hil_dir,
+                name="eva-collection-no-hil",
+                command_source="motion_target",
+            )
+        if not args.only or args.only == "hil":
+            summary["hil"] = run_hil_intervention(paths, env, args.web_port, fake_url)
+        if not args.only or args.only == "eval":
+            summary["eval"] = run_eval(paths, env, args.web_port)
+        return summary
+    finally:
+        stop_process(fake_policy)
+        stop_process(fake_node)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-dir", default="/tmp/eva-r1lite-fake-e2e")
+    parser.add_argument("--web-port", type=int, default=18080)
+    parser.add_argument("--policy-port", type=int, default=19000)
+    parser.add_argument("--fake-ui-port", type=int, default=18765)
+    parser.add_argument(
+        "--only",
+        choices=(
+            "rollout",
+            "rollout_no_hil",
+            "rollout_hil",
+            "collect",
+            "collect_hil",
+            "collect_no_hil",
+            "hil",
+            "eval",
+        ),
+        default="",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    summary = run_all(parse_args())
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Route eval/rollout capture through raw snapshots and async save workers, matching collection.
- Patch queued eval score metadata before the save worker writes meta.
- Add raw ROS episode stream fallback and regression coverage for collect/eval/rollout saving.

## Test Plan
- [x] source .venv/bin/activate && pytest -q
- [x] git diff --check
