### PR TITLE
ci: enforce Ruff formatting

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,35 @@
+name: Format check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: format-check-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ruff:
+    name: Ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run Ruff lint checks
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version-file: pyproject.toml
+          args: check --output-format=github
+
+      - name: Check Ruff formatting
+        run: ruff format --check --diff .

--- a/.github/workflows/format-fix.yml
+++ b/.github/workflows/format-fix.yml
@@ -1,0 +1,67 @@
+name: Format fix
+run-name: Format ${{ inputs.branch }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Existing branch to format
+        required: true
+        default: main
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: format-fix-${{ inputs.branch }}
+  cancel-in-progress: false
+
+jobs:
+  ruff:
+    name: Apply Ruff fixes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check out target branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ inputs.branch }}
+
+      - name: Validate target branch
+        env:
+          TARGET_BRANCH: ${{ inputs.branch }}
+        run: |
+          git check-ref-format --branch "$TARGET_BRANCH"
+          git ls-remote --exit-code --heads origin "refs/heads/$TARGET_BRANCH"
+
+      - name: Apply Ruff lint fixes
+        uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version-file: pyproject.toml
+          args: check --fix --output-format=github
+
+      - name: Apply Ruff formatting
+        run: ruff format .
+
+      - name: Verify corrected files
+        run: |
+          ruff check --output-format=github .
+          ruff format --check .
+
+      - name: Commit and push corrections
+        env:
+          TARGET_BRANCH: ${{ inputs.branch }}
+        run: |
+          if git diff --quiet; then
+            echo "No formatting corrections were needed."
+            exit 0
+          fi
+
+          git diff --check
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add --update
+          git commit -m "style: apply Ruff formatting"
+          git push origin "HEAD:refs/heads/$TARGET_BRANCH"

--- a/configs/00_openloop/arx_r5_openloop.py
+++ b/configs/00_openloop/arx_r5_openloop.py
@@ -1,22 +1,22 @@
 """ARX R5: open-loop dataset replay."""
 
-_base_ = ['../00_base/defaults.py']
+_base_ = ["../00_base/defaults.py"]
 
 robot = dict(
-    type='arx_r5',
+    type="arx_r5",
     gripper_threshold=None,
 )
 
 transport = dict(
-    type='dataset',
+    type="dataset",
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
     dataset_keys=dict(
-        state_key='observation.qpos',
+        state_key="observation.qpos",
         video_keys=dict(
-            cam_high='observation.images.cam_high',
-            cam_left_wrist='observation.images.cam_left_wrist',
-            cam_right_wrist='observation.images.cam_right_wrist',
+            cam_high="observation.images.cam_high",
+            cam_left_wrist="observation.images.cam_left_wrist",
+            cam_right_wrist="observation.images.cam_right_wrist",
         ),
     ),
 )
@@ -28,5 +28,5 @@ policy = dict(
 inference_cfg = dict(
     publish_rate=15,
     setup_warmup_chunks=0,
-    debug_tasks=['pick up the block and place it on the plate'],
+    debug_tasks=["pick up the block and place it on the plate"],
 )

--- a/configs/00_openloop/dual_agilex_piper_openloop.py
+++ b/configs/00_openloop/dual_agilex_piper_openloop.py
@@ -1,6 +1,6 @@
 """Dual Piper: open-loop dataset replay."""
 
-_base_ = ['../00_base/defaults.py']
+_base_ = ["../00_base/defaults.py"]
 
 robot = dict(
     gripper_threshold=None,
@@ -8,14 +8,14 @@ robot = dict(
 )
 
 transport = dict(
-    type='dataset',
-    dataset_dir='examples/agilex_dataset',
+    type="dataset",
+    dataset_dir="examples/agilex_dataset",
     dataset_keys=dict(
-        state_key='observation.qpos',
+        state_key="observation.qpos",
         video_keys=dict(
-            cam_high='observation.images.cam_high',
-            cam_left_wrist='observation.images.cam_left_wrist',
-            cam_right_wrist='observation.images.cam_right_wrist',
+            cam_high="observation.images.cam_high",
+            cam_left_wrist="observation.images.cam_left_wrist",
+            cam_right_wrist="observation.images.cam_right_wrist",
         ),
     ),
 )
@@ -26,5 +26,5 @@ policy = dict(
 
 inference_cfg = dict(
     setup_warmup_chunks=0,
-    debug_tasks=['pick up the orange block and place it on the green plate'],
+    debug_tasks=["pick up the orange block and place it on the green plate"],
 )

--- a/configs/00_openloop/dual_franka_openloop.py
+++ b/configs/00_openloop/dual_franka_openloop.py
@@ -1,24 +1,24 @@
 """Dual Franka: open-loop dataset replay."""
 
-_base_ = ['../00_base/defaults.py']
+_base_ = ["../00_base/defaults.py"]
 
 robot = dict(
-    type='dual_franka',
+    type="dual_franka",
     gripper_threshold=None,
 )
 
 transport = dict(
-    type='dataset',
-    dataset_dir='datasets/sft/real_robot/tong_franka/push_black_block_gripper_open',
+    type="dataset",
+    dataset_dir="datasets/sft/real_robot/tong_franka/push_black_block_gripper_open",
     resize_pad=False,
-    image_layout='hwc',
-    disabled_cameras=['cam_left_wrist'],
-    disabled_groups=['left_arm'],
+    image_layout="hwc",
+    disabled_cameras=["cam_left_wrist"],
+    disabled_groups=["left_arm"],
     dataset_keys=dict(
-        state_key='observation.state',
+        state_key="observation.state",
         video_keys=dict(
-            cam_high='observation.images.topcam',
-            cam_right_wrist='observation.images.wristcam',
+            cam_high="observation.images.topcam",
+            cam_right_wrist="observation.images.wristcam",
         ),
     ),
 )
@@ -29,5 +29,5 @@ policy = dict(
 
 inference_cfg = dict(
     setup_warmup_chunks=0,
-    debug_tasks=['push black block'],
+    debug_tasks=["push black block"],
 )

--- a/configs/00_openloop/r1lite_openloop.py
+++ b/configs/00_openloop/r1lite_openloop.py
@@ -1,25 +1,25 @@
 """R1 Lite: open-loop dataset replay."""
 
-_base_ = ['../00_base/defaults.py']
+_base_ = ["../00_base/defaults.py"]
 
 robot = dict(
-    type='r1_lite',
+    type="r1_lite",
     gripper_threshold=None,
     gripper_open=0.0,
     gripper_close=1.0,
 )
 
 transport = dict(
-    type='dataset',
-    dataset_dir='datasets/r1_lite',
+    type="dataset",
+    dataset_dir="datasets/r1_lite",
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
     dataset_keys=dict(
-        state_key='observation.qpos',
+        state_key="observation.qpos",
         video_keys=dict(
-            cam_high='observation.images.cam_high',
-            cam_left_wrist='observation.images.cam_left_wrist',
-            cam_right_wrist='observation.images.cam_right_wrist',
+            cam_high="observation.images.cam_high",
+            cam_left_wrist="observation.images.cam_left_wrist",
+            cam_right_wrist="observation.images.cam_right_wrist",
         ),
     ),
 )
@@ -31,5 +31,5 @@ policy = dict(
 inference_cfg = dict(
     publish_rate=15,
     setup_warmup_chunks=0,
-    debug_tasks=['placeholder task — replace with the real task prompt'],
+    debug_tasks=["placeholder task — replace with the real task prompt"],
 )

--- a/configs/00_openloop/ur5e_openloop.py
+++ b/configs/00_openloop/ur5e_openloop.py
@@ -1,20 +1,20 @@
 """UR5e: open-loop dataset replay."""
 
-_base_ = ['../00_base/defaults.py']
+_base_ = ["../00_base/defaults.py"]
 
 robot = dict(
-    type='ur5e',
+    type="ur5e",
 )
 
 transport = dict(
-    type='dataset',
+    type="dataset",
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
     dataset_keys=dict(
-        state_key='observation.qpos',
+        state_key="observation.qpos",
         video_keys=dict(
-            cam_high='observation.images.cam_high',
-            cam_wrist='observation.images.cam_wrist',
+            cam_high="observation.images.cam_high",
+            cam_wrist="observation.images.cam_wrist",
         ),
     ),
 )
@@ -26,5 +26,5 @@ policy = dict(
 inference_cfg = dict(
     publish_rate=25,
     setup_warmup_chunks=0,
-    debug_tasks=['Put the apples in the white basket'],
+    debug_tasks=["Put the apples in the white basket"],
 )

--- a/configs/01_deploy/agibot_g2/_base.py
+++ b/configs/01_deploy/agibot_g2/_base.py
@@ -1,40 +1,40 @@
 """AgiBot G2: shared deploy settings for openpi (eef / qpos)."""
 
-_base_ = ['../../00_base/defaults.py']
+_base_ = ["../../00_base/defaults.py"]
 
 robot = dict(
-    type='agibot_g2',
+    type="agibot_g2",
     gripper_threshold=-0.4,
     gripper_open=0.0,
     gripper_close=-0.785,
 )
 
 transport = dict(
-    type='zmq',
+    type="zmq",
 )
 
 policy = dict(
-    type='openpi_rtc',
+    type="openpi_rtc",
     backend_options=dict(latency_k=4),
 )
 
 inference_cfg = dict(
     debug_tasks=[
-        'Put the pen into the pen holder.',
-        'Close the laptop.',
-        'Put the tissue into the trash bin.',
-        'Place the mouse on the right side of the laptop.',
-        'Straighten the colored pencil box.',
+        "Put the pen into the pen holder.",
+        "Close the laptop.",
+        "Put the tissue into the trash bin.",
+        "Place the mouse on the right side of the laptop.",
+        "Straighten the colored pencil box.",
     ],
 )
 
 inference_strategies = {
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=4,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=4,
         ),

--- a/configs/01_deploy/agibot_g2/openpi_eef.py
+++ b/configs/01_deploy/agibot_g2/openpi_eef.py
@@ -1,9 +1,9 @@
 """AgiBot G2: openpi policy deploy, EEF-pose action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 inference_cfg = dict(
     action_space=dict(
-        type='EEFPose',
+        type="EEFPose",
     ),
 )

--- a/configs/01_deploy/agibot_g2/openpi_qpos.py
+++ b/configs/01_deploy/agibot_g2/openpi_qpos.py
@@ -1,4 +1,3 @@
 """AgiBot G2: openpi policy deploy, qpos action space."""
 
-_base_ = ['_base.py']
-
+_base_ = ["_base.py"]

--- a/configs/01_deploy/arx_r5/_base.py
+++ b/configs/01_deploy/arx_r5/_base.py
@@ -1,43 +1,43 @@
 """ARX R5: shared deploy settings for openpi (eef / qpos)."""
 
-_base_ = ['../../00_base/defaults.py']
+_base_ = ["../../00_base/defaults.py"]
 
 robot = dict(
-    type='arx_r5',
+    type="arx_r5",
     gripper_threshold=None,
 )
 
 transport = dict(
-    type='zmq',
+    type="zmq",
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
 )
 
-policy = dict(type='openpi')
+policy = dict(type="openpi")
 
 rollout = dict(
     storage=dict(
         enabled=True,
-        log_dir='work_dirs/rollout/arx_r5',
+        log_dir="work_dirs/rollout/arx_r5",
         fps=30,
         save_queue_max=15,
         async_save=True,
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )
 
 inference_strategies = {
-    'sync': dict(
+    "sync": dict(
         args=dict(
             execute_horizon=30,
         ),
     ),
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=8,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=10,
         ),

--- a/configs/01_deploy/arx_r5/openpi_eef.py
+++ b/configs/01_deploy/arx_r5/openpi_eef.py
@@ -1,24 +1,24 @@
 """ARX R5: openpi policy deploy, EEF-pose action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 inference_cfg = dict(
     obs_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     action_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     publish_rate=15,
     debug_tasks=[
-        'pick up the mango and place it on the plate',
-        'pick up the orange',
-        'pick up the block and place it on the plate',
+        "pick up the mango and place it on the plate",
+        "pick up the orange",
+        "pick up the block and place it on the plate",
     ],
 )

--- a/configs/01_deploy/arx_r5/openpi_qpos.py
+++ b/configs/01_deploy/arx_r5/openpi_qpos.py
@@ -1,16 +1,16 @@
 """ARX R5: openpi policy deploy, qpos action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 inference_cfg = dict(
     inference_rate=15,
     publish_rate=40,
     debug_tasks=[
-        'pick up the mango and place it on the plate',
-        'pick up the block and place it on the plate',
-        'play the table tennis',
-        'play the table tennis with strength',
-        'play the table tennis with strength 0622',
-        'pick up the orange',
+        "pick up the mango and place it on the plate",
+        "pick up the block and place it on the plate",
+        "play the table tennis",
+        "play the table tennis with strength",
+        "play the table tennis with strength 0622",
+        "pick up the orange",
     ],
 )

--- a/configs/01_deploy/arx_r5/table_tennis.py
+++ b/configs/01_deploy/arx_r5/table_tennis.py
@@ -1,12 +1,12 @@
 """ARX R5: table-tennis deploy task preset."""
 
-_base_ = ['openpi_qpos.py']
+_base_ = ["openpi_qpos.py"]
 
 inference_cfg = dict(
     inference_rate=3,
     publish_rate=30,
     debug_tasks=[
-        'play the table tennis',
+        "play the table tennis",
     ],
 )
 

--- a/configs/01_deploy/dual_agilex_piper/_base.py
+++ b/configs/01_deploy/dual_agilex_piper/_base.py
@@ -1,6 +1,6 @@
 """Dual Piper: shared deploy settings for openpi (eef / qpos)."""
 
-_base_ = ['../../00_base/defaults.py']
+_base_ = ["../../00_base/defaults.py"]
 
 robot = dict(
     gripper_threshold=None,
@@ -8,33 +8,33 @@ robot = dict(
 )
 
 transport = dict(
-    type='ros1',
+    type="ros1",
     image_height=224,
     image_width=224,
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
     convert_bgr_to_rgb=False,
-    ssh=dict(host='<remote-host>', user='<remote-user>', port=8000),
+    ssh=dict(host="<remote-host>", user="<remote-user>", port=8000),
     topics=dict(
         camera_topics=dict(
-            front='/camera_f/color/image_raw',
-            left_wrist='/camera_l/color/image_raw',
-            right_wrist='/camera_r/color/image_raw',
+            front="/camera_f/color/image_raw",
+            left_wrist="/camera_l/color/image_raw",
+            right_wrist="/camera_r/color/image_raw",
         ),
         group_topics=dict(
             left_arm=dict(
-                state_topic='/puppet/joint_left',
-                command_topic='/puppet/master_joint_left',
-                eef_state_topic='/puppet/end_pose_left',
-                sim_command_topic='/sim_joint_left',
-                hil_input_topic='/eva/hil/input_joint_state_arm_left',
+                state_topic="/puppet/joint_left",
+                command_topic="/puppet/master_joint_left",
+                eef_state_topic="/puppet/end_pose_left",
+                sim_command_topic="/sim_joint_left",
+                hil_input_topic="/eva/hil/input_joint_state_arm_left",
             ),
             right_arm=dict(
-                state_topic='/puppet/joint_right',
-                command_topic='/puppet/master_joint_right',
-                eef_state_topic='/puppet/end_pose_right',
-                sim_command_topic='/sim_joint_right',
-                hil_input_topic='/eva/hil/input_joint_state_arm_right',
+                state_topic="/puppet/joint_right",
+                command_topic="/puppet/master_joint_right",
+                eef_state_topic="/puppet/end_pose_right",
+                sim_command_topic="/sim_joint_right",
+                hil_input_topic="/eva/hil/input_joint_state_arm_right",
             ),
         ),
     ),
@@ -43,10 +43,10 @@ transport = dict(
 rollout = dict(
     storage=dict(
         enabled=True,
-        log_dir='work_dirs/rollout/dual_agilex_piper',
+        log_dir="work_dirs/rollout/dual_agilex_piper",
         fps=30,
         save_queue_max=15,
         async_save=True,
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )

--- a/configs/01_deploy/dual_agilex_piper/openpi_eef.py
+++ b/configs/01_deploy/dual_agilex_piper/openpi_eef.py
@@ -1,42 +1,42 @@
 """Dual Piper: openpi policy deploy, EEF-pose action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 policy = dict(
-    type='openpi',
+    type="openpi",
     backend_options=dict(latency_k=8),
 )
 
 inference_cfg = dict(
     obs_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     action_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     debug_tasks=[
-        'pick up letter blocks and place them to spell MEI, the order is: first M, then E, then I',
+        "pick up letter blocks and place them to spell MEI, the order is: first M, then E, then I",
     ],
 )
 
 inference_strategies = {
-    'sync': dict(
+    "sync": dict(
         args=dict(
             execute_horizon=50,
         ),
     ),
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=8,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=8,
         ),

--- a/configs/01_deploy/dual_agilex_piper/openpi_qpos.py
+++ b/configs/01_deploy/dual_agilex_piper/openpi_qpos.py
@@ -1,48 +1,48 @@
 """Dual Piper: openpi policy deploy, qpos action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 policy = dict(
-    type='openpi_rtc',
+    type="openpi_rtc",
     backend_options=dict(latency_k=4),
 )
 
 inference_cfg = dict(
     debug_tasks=[
-        'pick up the yellow spoon and place it on the green plate',
-        'pick up the mango and place it on the green plate',
-        'pick up the light blue fork and place it on the green plate',
-        'pick up the green knife and place it on the green plate',
-        'pick up the green block and place it on the green plate',
-        'pick up the orange block and place it on the green plate',
-        'pick up the green block and place it on the green plate',
-        'pick up the yellow spoon and place it on the green plate',
-        'pick up the gray cup and place it on the green plate',
-        'pick up the light blue fork and place it on the green plate',
-        'pick up the orange block and place it on the green plate',
-        'pick up the yellow cup and place it on the green plate',
-        'pick up the light blue spoon and place it on the green plate',
-        'pick up the green cup and place it on the green plate',
-        'pick up the red block and place it on the green plate',
-        'pick up the lemon and place it on the green plate',
-        'pick up the gray knife and place it on the green plate',
-        'pick up the blue cup and place it on the green plate',
-        'pick up the green fork and place it on the green plate',
-        'pick up the banana and place it on the green plate',
-        'pick up the blue block and place it on the green plate',
-        'pick up the yellow cup and place it on the green plate',
-        'pick up the green mango and place it on the green plate',
-        'pick up the green knife and place it on the green plate',
+        "pick up the yellow spoon and place it on the green plate",
+        "pick up the mango and place it on the green plate",
+        "pick up the light blue fork and place it on the green plate",
+        "pick up the green knife and place it on the green plate",
+        "pick up the green block and place it on the green plate",
+        "pick up the orange block and place it on the green plate",
+        "pick up the green block and place it on the green plate",
+        "pick up the yellow spoon and place it on the green plate",
+        "pick up the gray cup and place it on the green plate",
+        "pick up the light blue fork and place it on the green plate",
+        "pick up the orange block and place it on the green plate",
+        "pick up the yellow cup and place it on the green plate",
+        "pick up the light blue spoon and place it on the green plate",
+        "pick up the green cup and place it on the green plate",
+        "pick up the red block and place it on the green plate",
+        "pick up the lemon and place it on the green plate",
+        "pick up the gray knife and place it on the green plate",
+        "pick up the blue cup and place it on the green plate",
+        "pick up the green fork and place it on the green plate",
+        "pick up the banana and place it on the green plate",
+        "pick up the blue block and place it on the green plate",
+        "pick up the yellow cup and place it on the green plate",
+        "pick up the green mango and place it on the green plate",
+        "pick up the green knife and place it on the green plate",
     ],
 )
 
 inference_strategies = {
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=4,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=4,
         ),

--- a/configs/01_deploy/dual_franka/_base.py
+++ b/configs/01_deploy/dual_franka/_base.py
@@ -1,36 +1,36 @@
 """Dual Franka: shared deploy settings for openpi (eef / qpos)."""
 
-_base_ = ['../../00_base/defaults.py']
+_base_ = ["../../00_base/defaults.py"]
 
 robot = dict(
-    type='dual_franka',
+    type="dual_franka",
     gripper_threshold=None,
 )
 
 transport = dict(
-    type='zmq',
+    type="zmq",
     resize_pad=False,
-    image_layout='hwc',
-    disabled_cameras=['cam_left_wrist'],
+    image_layout="hwc",
+    disabled_cameras=["cam_left_wrist"],
 )
 
 policy = dict(
-    type='openpi_rtc',
+    type="openpi_rtc",
     backend_options=dict(latency_k=10),
 )
 
 inference_strategies = {
-    'sync': dict(
+    "sync": dict(
         args=dict(
             execute_horizon=50,
         ),
     ),
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=4,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=10,
         ),

--- a/configs/01_deploy/dual_franka/openpi_eef.py
+++ b/configs/01_deploy/dual_franka/openpi_eef.py
@@ -1,19 +1,19 @@
 """Dual Franka: openpi policy deploy, EEF-pose action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 inference_cfg = dict(
     obs_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     action_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
-    debug_tasks=['placeholder task — replace with the real EEF task prompt'],
+    debug_tasks=["placeholder task — replace with the real EEF task prompt"],
 )

--- a/configs/01_deploy/dual_franka/openpi_qpos.py
+++ b/configs/01_deploy/dual_franka/openpi_qpos.py
@@ -1,7 +1,7 @@
 """Dual Franka: openpi policy deploy, qpos action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 inference_cfg = dict(
-    debug_tasks=['push black block'],
+    debug_tasks=["push black block"],
 )

--- a/configs/01_deploy/r1lite/_base.py
+++ b/configs/01_deploy/r1lite/_base.py
@@ -1,37 +1,37 @@
 """R1 Lite: shared deploy settings across openpi / eva, eef / qpos."""
 
-_base_ = ['../../00_base/defaults.py']
+_base_ = ["../../00_base/defaults.py"]
 
 robot = dict(
-    type='r1_lite',
-    eef_reference_frame='torso_link3',
+    type="r1_lite",
+    eef_reference_frame="torso_link3",
     gripper_open=100.0,
 )
 
 transport = dict(
-    type='ros2',
+    type="ros2",
     topics=dict(
         camera_topics=dict(
-            head='/hdas/camera_head/right_raw/image_raw_color/compressed',
-            left_wrist='/hdas/camera_wrist_left/color/image_raw/compressed',
-            right_wrist='/hdas/camera_wrist_right/color/image_raw/compressed',
+            head="/hdas/camera_head/right_raw/image_raw_color/compressed",
+            left_wrist="/hdas/camera_wrist_left/color/image_raw/compressed",
+            right_wrist="/hdas/camera_wrist_right/color/image_raw/compressed",
         ),
         group_topics=dict(
             left_arm=dict(
-                state_topic='/hdas/feedback_arm_left',
-                command_topic='/motion_target/target_joint_state_arm_left',
-                eef_state_topic='/relaxed_ik/motion_control/pose_ee_arm_left',
-                gripper_state_topic='/hdas/feedback_gripper_left',
-                gripper_command_topic='/motion_target/target_position_gripper_left',
-                hil_input_topic='/eva/hil/input_joint_state_arm_left',
+                state_topic="/hdas/feedback_arm_left",
+                command_topic="/motion_target/target_joint_state_arm_left",
+                eef_state_topic="/relaxed_ik/motion_control/pose_ee_arm_left",
+                gripper_state_topic="/hdas/feedback_gripper_left",
+                gripper_command_topic="/motion_target/target_position_gripper_left",
+                hil_input_topic="/eva/hil/input_joint_state_arm_left",
             ),
             right_arm=dict(
-                state_topic='/hdas/feedback_arm_right',
-                command_topic='/motion_target/target_joint_state_arm_right',
-                eef_state_topic='/relaxed_ik/motion_control/pose_ee_arm_right',
-                gripper_state_topic='/hdas/feedback_gripper_right',
-                gripper_command_topic='/motion_target/target_position_gripper_right',
-                hil_input_topic='/eva/hil/input_joint_state_arm_right',
+                state_topic="/hdas/feedback_arm_right",
+                command_topic="/motion_target/target_joint_state_arm_right",
+                eef_state_topic="/relaxed_ik/motion_control/pose_ee_arm_right",
+                gripper_state_topic="/hdas/feedback_gripper_right",
+                gripper_command_topic="/motion_target/target_position_gripper_right",
+                hil_input_topic="/eva/hil/input_joint_state_arm_right",
             ),
         ),
     ),
@@ -39,27 +39,27 @@ transport = dict(
 
 collection = dict(
     storage=dict(
-        log_dir='work_dirs/collection/r1lite',
+        log_dir="work_dirs/collection/r1lite",
         fps=15,
         save_queue_max=15,
     ),
     schema=dict(
-        robot_type='r1_lite',
+        robot_type="r1_lite",
         min_episode_frames=10,
         arms=dict(
-            left_arm='left',
-            right_arm='right',
+            left_arm="left",
+            right_arm="right",
         ),
         cameras=dict(
-            cam_high='observation.images.cam_high',
-            cam_left_wrist='observation.images.cam_left_wrist',
-            cam_right_wrist='observation.images.cam_right_wrist',
+            cam_high="observation.images.cam_high",
+            cam_left_wrist="observation.images.cam_left_wrist",
+            cam_right_wrist="observation.images.cam_right_wrist",
         ),
         columns=dict(
-            qpos='observations.state.qpos',
-            eef='observations.state.eef',
-            action_qpos='action.qpos',
-            action_eef='action.eef',
+            qpos="observations.state.qpos",
+            eef="observations.state.eef",
+            action_qpos="action.qpos",
+            action_eef="action.eef",
         ),
     ),
     transport=dict(
@@ -67,24 +67,24 @@ collection = dict(
             max_frame_skew_sec=0.3,
             groups=dict(
                 left_arm=dict(
-                    qpos_topic='/hdas/feedback_arm_left',
-                    qpos_gripper_topic='/hdas/feedback_gripper_left',
-                    eef_topic='/relaxed_ik/motion_control/pose_ee_arm_left',
-                    action_qpos_topic='/motion_target/target_joint_state_arm_left',
-                    action_qpos_gripper_source='operator',
+                    qpos_topic="/hdas/feedback_arm_left",
+                    qpos_gripper_topic="/hdas/feedback_gripper_left",
+                    eef_topic="/relaxed_ik/motion_control/pose_ee_arm_left",
+                    action_qpos_topic="/motion_target/target_joint_state_arm_left",
+                    action_qpos_gripper_source="operator",
                     action_qpos_gripper_topic=None,
                     action_qpos_gripper_binary=True,
-                    action_eef_topic='/relaxed_ik/motion_control/pose_ee_arm_left',
+                    action_eef_topic="/relaxed_ik/motion_control/pose_ee_arm_left",
                 ),
                 right_arm=dict(
-                    qpos_topic='/hdas/feedback_arm_right',
-                    qpos_gripper_topic='/hdas/feedback_gripper_right',
-                    eef_topic='/relaxed_ik/motion_control/pose_ee_arm_right',
-                    action_qpos_topic='/motion_target/target_joint_state_arm_right',
-                    action_qpos_gripper_source='operator',
+                    qpos_topic="/hdas/feedback_arm_right",
+                    qpos_gripper_topic="/hdas/feedback_gripper_right",
+                    eef_topic="/relaxed_ik/motion_control/pose_ee_arm_right",
+                    action_qpos_topic="/motion_target/target_joint_state_arm_right",
+                    action_qpos_gripper_source="operator",
                     action_qpos_gripper_topic=None,
                     action_qpos_gripper_binary=True,
-                    action_eef_topic='/relaxed_ik/motion_control/pose_ee_arm_right',
+                    action_eef_topic="/relaxed_ik/motion_control/pose_ee_arm_right",
                 ),
             ),
         ),
@@ -94,17 +94,17 @@ collection = dict(
 rollout = dict(
     storage=dict(
         enabled=True,
-        log_dir='work_dirs/rollout/r1lite',
+        log_dir="work_dirs/rollout/r1lite",
         fps=15,
         save_queue_max=15,
         async_save=True,
         image_height=360,
         image_width=640,
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )
 
 operator_control = dict(
     enabled=True,
-    action_topic='/eva/operator_action',
+    action_topic="/eva/operator_action",
 )

--- a/configs/01_deploy/r1lite/eva_base.py
+++ b/configs/01_deploy/r1lite/eva_base.py
@@ -1,8 +1,8 @@
 """R1 Lite: shared eva deploy settings (eef / qpos)."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 transport = dict(
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
 )

--- a/configs/01_deploy/r1lite/eva_eef.py
+++ b/configs/01_deploy/r1lite/eva_eef.py
@@ -1,9 +1,9 @@
 """R1 Lite: eva policy deploy, EEF-pose action space."""
 
-_base_ = ['eva_base.py']
+_base_ = ["eva_base.py"]
 
 policy = dict(
-    type='openpi_rtc',
+    type="openpi_rtc",
     backend_options=dict(latency_k=8),
 )
 
@@ -13,33 +13,33 @@ robot = dict(
 
 inference_cfg = dict(
     obs_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     action_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     publish_rate=15,
-    debug_tasks=['placeholder task — replace with the real EEF task prompt'],
+    debug_tasks=["placeholder task — replace with the real EEF task prompt"],
 )
 
 inference_strategies = {
-    'sync': dict(
+    "sync": dict(
         args=dict(
             execute_horizon=50,
         ),
     ),
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=8,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=8,
         ),

--- a/configs/01_deploy/r1lite/eva_qpos.py
+++ b/configs/01_deploy/r1lite/eva_qpos.py
@@ -1,29 +1,29 @@
 """R1 Lite: eva policy deploy, qpos action space."""
 
-_base_ = ['eva_base.py']
+_base_ = ["eva_base.py"]
 
 policy = dict(
-    type='openpi_rtc',
+    type="openpi_rtc",
     backend_options=dict(latency_k=10),
 )
 
 inference_cfg = dict(
     publish_rate=15,
-    debug_tasks=['placeholder task — replace with the real task prompt'],
+    debug_tasks=["placeholder task — replace with the real task prompt"],
 )
 
 inference_strategies = {
-    'sync': dict(
+    "sync": dict(
         args=dict(
             execute_horizon=50,
         ),
     ),
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=4,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=10,
         ),

--- a/configs/01_deploy/r1lite/openpi_base.py
+++ b/configs/01_deploy/r1lite/openpi_base.py
@@ -1,4 +1,3 @@
 """R1 Lite: shared openpi deploy settings (eef / qpos)."""
 
-_base_ = ['_base.py']
-
+_base_ = ["_base.py"]

--- a/configs/01_deploy/r1lite/openpi_eef.py
+++ b/configs/01_deploy/r1lite/openpi_eef.py
@@ -1,9 +1,9 @@
 """R1 Lite: openpi policy deploy, EEF-pose action space."""
 
-_base_ = ['openpi_base.py']
+_base_ = ["openpi_base.py"]
 
 policy = dict(
-    type='openpi_rtc',
+    type="openpi_rtc",
     backend_options=dict(latency_k=8),
 )
 
@@ -13,28 +13,28 @@ robot = dict(
 
 inference_cfg = dict(
     obs_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     action_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=2,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     publish_rate=15,
-    debug_tasks=['placeholder task — replace with the real EEF task prompt'],
+    debug_tasks=["placeholder task — replace with the real EEF task prompt"],
 )
 
 inference_strategies = {
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=8,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=8,
         ),

--- a/configs/01_deploy/r1lite/openpi_qpos.py
+++ b/configs/01_deploy/r1lite/openpi_qpos.py
@@ -1,15 +1,15 @@
 """R1 Lite: openpi policy deploy, qpos action space."""
 
-_base_ = ['openpi_base.py']
+_base_ = ["openpi_base.py"]
 
 policy = dict(
-    type='openpi',
+    type="openpi",
     backend_options=dict(latency_k=4),
 )
 
 transport = dict(
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
 )
 
 robot = dict(
@@ -18,21 +18,21 @@ robot = dict(
 
 inference_cfg = dict(
     publish_rate=30,
-    debug_tasks=['placeholder task — replace with the real task prompt'],
+    debug_tasks=["placeholder task — replace with the real task prompt"],
 )
 
 inference_strategies = {
-    'sync': dict(
+    "sync": dict(
         args=dict(
             execute_horizon=50,
         ),
     ),
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=4,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=4,
         ),

--- a/configs/01_deploy/ur5e/_base.py
+++ b/configs/01_deploy/ur5e/_base.py
@@ -1,46 +1,46 @@
 """UR5e: shared deploy settings for openpi (eef / qpos)."""
 
-_base_ = ['../../00_base/defaults.py']
+_base_ = ["../../00_base/defaults.py"]
 
 robot = dict(
-    type='ur5e',
+    type="ur5e",
 )
 
 transport = dict(
-    type='zmq',
+    type="zmq",
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
 )
 
 collection = dict(
     storage=dict(
-        log_dir='work_dirs/collection/ur5e',
+        log_dir="work_dirs/collection/ur5e",
         fps=20,
         save_queue_max=15,
     ),
     schema=dict(
-        robot_type='ur5e',
+        robot_type="ur5e",
         min_episode_frames=10,
         arms=dict(
-            arm='arm',
+            arm="arm",
         ),
         cameras=dict(
-            cam_high='observation.images.cam_high',
-            cam_wrist='observation.images.cam_wrist',
+            cam_high="observation.images.cam_high",
+            cam_wrist="observation.images.cam_wrist",
         ),
         columns=dict(
-            qpos='observations.state.qpos',
-            eef='observations.state.eef',
-            action_qpos='action.qpos',
-            action_eef='action.eef',
+            qpos="observations.state.qpos",
+            eef="observations.state.eef",
+            action_qpos="action.qpos",
+            action_eef="action.eef",
         ),
     ),
     teleop=dict(
-        type='ur5e_master_arm',
-        port='/dev/ttyACM0',
+        type="ur5e_master_arm",
+        port="/dev/ttyACM0",
         joint_coef=[1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
         gripper=dict(
-            source='analog',
+            source="analog",
         ),
     ),
 )
@@ -48,10 +48,10 @@ collection = dict(
 rollout = dict(
     storage=dict(
         enabled=True,
-        log_dir='work_dirs/rollout/ur5e',
+        log_dir="work_dirs/rollout/ur5e",
         fps=20,
         save_queue_max=15,
         async_save=True,
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )

--- a/configs/01_deploy/ur5e/openpi_eef.py
+++ b/configs/01_deploy/ur5e/openpi_eef.py
@@ -1,36 +1,36 @@
 """UR5e: openpi policy deploy, EEF-pose action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 policy = dict(
-    type='openpi_rtc',
+    type="openpi_rtc",
     backend_options=dict(latency_k=4),
 )
 
 inference_cfg = dict(
     obs_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=1,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     action_space=dict(
-        type='EEFPose',
+        type="EEFPose",
         n_arms=1,
-        rotation='quat',
+        rotation="quat",
         include_gripper=True,
     ),
     publish_rate=25,
-    debug_tasks=['placeholder task — replace with the real EEF task prompt'],
+    debug_tasks=["placeholder task — replace with the real EEF task prompt"],
 )
 
 inference_strategies = {
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=4,
         ),
     ),
-    'rtc': dict(
+    "rtc": dict(
         args=dict(
             latency_k=4,
         ),

--- a/configs/01_deploy/ur5e/openpi_qpos.py
+++ b/configs/01_deploy/ur5e/openpi_qpos.py
@@ -1,24 +1,24 @@
 """UR5e: openpi policy deploy, qpos action space."""
 
-_base_ = ['_base.py']
+_base_ = ["_base.py"]
 
 policy = dict(
-    type='openpi_rtc',
+    type="openpi_rtc",
     backend_options=dict(latency_k=4),
 )
 
 inference_cfg = dict(
     publish_rate=20,
-    debug_tasks=['Put the apples in the white basket'],
+    debug_tasks=["Put the apples in the white basket"],
 )
 
 inference_strategies = {
-    'sync': dict(
+    "sync": dict(
         args=dict(
             sync_wait_ignore_gripper=True,
         ),
     ),
-    'async': dict(
+    "async": dict(
         args=dict(
             latency_k=4,
         ),

--- a/configs/02_collection/agibot_g2.py
+++ b/configs/02_collection/agibot_g2.py
@@ -1,31 +1,31 @@
 """AgiBot G2: teleop data collection (schema)."""
 
-_base_ = ['../01_deploy/agibot_g2/_base.py']
+_base_ = ["../01_deploy/agibot_g2/_base.py"]
 
 collection = dict(
     storage=dict(
-        log_dir='work_dirs/collection/agibot_g2',
+        log_dir="work_dirs/collection/agibot_g2",
         fps=30,
         save_queue_max=15,
     ),
     schema=dict(
-        robot_type='agibot_g2',
+        robot_type="agibot_g2",
         min_episode_frames=10,
         arms=dict(
-            left_arm='left',
-            right_arm='right',
+            left_arm="left",
+            right_arm="right",
         ),
         cameras=dict(
-            top_head='observation.images.cam_high',
-            hand_left='observation.images.cam_left_wrist',
-            hand_right='observation.images.cam_right_wrist',
+            top_head="observation.images.cam_high",
+            hand_left="observation.images.cam_left_wrist",
+            hand_right="observation.images.cam_right_wrist",
         ),
         columns=dict(
-            qpos='observations.state.qpos',
-            eef='observations.state.eef',
-            action_qpos='action.qpos',
-            action_eef='action.eef',
+            qpos="observations.state.qpos",
+            eef="observations.state.eef",
+            action_qpos="action.qpos",
+            action_eef="action.eef",
         ),
     ),
-    tasks=['pick up the apple'],
+    tasks=["pick up the apple"],
 )

--- a/configs/02_collection/arx_r5.py
+++ b/configs/02_collection/arx_r5.py
@@ -1,30 +1,30 @@
 """ARX R5: teleop data collection (schema + tasks)."""
 
-_base_ = ['../01_deploy/arx_r5/_base.py']
+_base_ = ["../01_deploy/arx_r5/_base.py"]
 
 collection = dict(
     storage=dict(
-        log_dir='work_dirs/collection/arx_r5/',
+        log_dir="work_dirs/collection/arx_r5/",
         fps=30,
         save_queue_max=15,
     ),
     schema=dict(
-        robot_type='arx_r5',
+        robot_type="arx_r5",
         arms=dict(
-            left_arm='left',
-            right_arm='right',
+            left_arm="left",
+            right_arm="right",
         ),
         cameras=dict(
-            cam_high='observation.images.cam_high',
-            cam_left_wrist='observation.images.cam_left_wrist',
-            cam_right_wrist='observation.images.cam_right_wrist',
+            cam_high="observation.images.cam_high",
+            cam_left_wrist="observation.images.cam_left_wrist",
+            cam_right_wrist="observation.images.cam_right_wrist",
         ),
         columns=dict(
-            qpos='observations.state.qpos',
-            eef='observations.state.eef',
-            action_qpos='action.qpos',
-            action_eef='action.eef',
+            qpos="observations.state.qpos",
+            eef="observations.state.eef",
+            action_qpos="action.qpos",
+            action_eef="action.eef",
         ),
     ),
-    tasks=['pick up the apple','pick up the orange'],
+    tasks=["pick up the apple", "pick up the orange"],
 )

--- a/configs/02_collection/dual_agilex_piper.py
+++ b/configs/02_collection/dual_agilex_piper.py
@@ -1,49 +1,49 @@
 """Dual Piper: teleop data collection (schema + collection topics)."""
 
-_base_ = ['../01_deploy/dual_agilex_piper/_base.py']
+_base_ = ["../01_deploy/dual_agilex_piper/_base.py"]
 
 collection = dict(
     storage=dict(
-        log_dir='work_dirs/collection/dual_agilex_piper',
+        log_dir="work_dirs/collection/dual_agilex_piper",
         fps=30,
         save_queue_max=15,
     ),
     schema=dict(
-        robot_type='agilex_piper',
+        robot_type="agilex_piper",
         min_episode_frames=10,
         arms=dict(
-            left_arm='left',
-            right_arm='right',
+            left_arm="left",
+            right_arm="right",
         ),
         cameras=dict(
-            cam_high='observation.images.cam_high',
-            cam_left_wrist='observation.images.cam_left_wrist',
-            cam_right_wrist='observation.images.cam_right_wrist',
+            cam_high="observation.images.cam_high",
+            cam_left_wrist="observation.images.cam_left_wrist",
+            cam_right_wrist="observation.images.cam_right_wrist",
         ),
         columns=dict(
-            qpos='observations.state.qpos',
-            eef='observations.state.eef',
-            action_qpos='action.qpos',
-            action_eef='action.eef',
+            qpos="observations.state.qpos",
+            eef="observations.state.eef",
+            action_qpos="action.qpos",
+            action_eef="action.eef",
         ),
     ),
     transport=dict(
         ros1=dict(
             groups=dict(
                 left_arm=dict(
-                    qpos_topic='/puppet/joint_left',
-                    eef_topic='/puppet/end_pose_left',
-                    action_qpos_topic='/puppet/master_joint_left',
-                    action_eef_topic='/puppet/end_pose_left',
+                    qpos_topic="/puppet/joint_left",
+                    eef_topic="/puppet/end_pose_left",
+                    action_qpos_topic="/puppet/master_joint_left",
+                    action_eef_topic="/puppet/end_pose_left",
                 ),
                 right_arm=dict(
-                    qpos_topic='/puppet/joint_right',
-                    eef_topic='/puppet/end_pose_right',
-                    action_qpos_topic='/puppet/master_joint_right',
-                    action_eef_topic='/puppet/end_pose_right',
+                    qpos_topic="/puppet/joint_right",
+                    eef_topic="/puppet/end_pose_right",
+                    action_qpos_topic="/puppet/master_joint_right",
+                    action_eef_topic="/puppet/end_pose_right",
                 ),
             ),
         ),
     ),
-    tasks=['pick up the apple'],
+    tasks=["pick up the apple"],
 )

--- a/configs/02_collection/dual_franka.py
+++ b/configs/02_collection/dual_franka.py
@@ -1,31 +1,31 @@
 """Dual Franka: teleop data collection (schema)."""
 
-_base_ = ['../01_deploy/dual_franka/_base.py']
+_base_ = ["../01_deploy/dual_franka/_base.py"]
 
 collection = dict(
     storage=dict(
-        log_dir='work_dirs/collection/dual_franka',
+        log_dir="work_dirs/collection/dual_franka",
         fps=30,
         save_queue_max=15,
     ),
     schema=dict(
-        robot_type='dual_franka',
+        robot_type="dual_franka",
         min_episode_frames=10,
         arms=dict(
-            left_arm='left',
-            right_arm='right',
+            left_arm="left",
+            right_arm="right",
         ),
         cameras=dict(
-            cam_high='observation.images.cam_high',
-            cam_left_wrist='observation.images.cam_left_wrist',
-            cam_right_wrist='observation.images.cam_right_wrist',
+            cam_high="observation.images.cam_high",
+            cam_left_wrist="observation.images.cam_left_wrist",
+            cam_right_wrist="observation.images.cam_right_wrist",
         ),
         columns=dict(
-            qpos='observations.state.qpos',
-            eef='observations.state.eef',
-            action_qpos='action.qpos',
-            action_eef='action.eef',
+            qpos="observations.state.qpos",
+            eef="observations.state.eef",
+            action_qpos="action.qpos",
+            action_eef="action.eef",
         ),
     ),
-    tasks=['pick up the apple'],
+    tasks=["pick up the apple"],
 )

--- a/configs/02_collection/r1lite.py
+++ b/configs/02_collection/r1lite.py
@@ -1,10 +1,10 @@
 """R1 Lite: teleop data collection over ROS2."""
 
-_base_ = ['../01_deploy/r1lite/_base.py']
+_base_ = ["../01_deploy/r1lite/_base.py"]
 
 transport = dict(
     resize_pad=False,
-    image_layout='hwc',
+    image_layout="hwc",
 )
 
 collection = dict(

--- a/configs/02_collection/ur5e.py
+++ b/configs/02_collection/ur5e.py
@@ -1,37 +1,37 @@
 """UR5e: teleop data collection (schema + teleop)."""
 
-_base_ = ['../01_deploy/ur5e/_base.py']
+_base_ = ["../01_deploy/ur5e/_base.py"]
 
 collection = dict(
     storage=dict(
-        log_dir='work_dirs/collection/ur5e',
+        log_dir="work_dirs/collection/ur5e",
         fps=20,
         save_queue_max=15,
     ),
     schema=dict(
-        robot_type='ur5e',
+        robot_type="ur5e",
         min_episode_frames=10,
         arms=dict(
-            arm='arm',
+            arm="arm",
         ),
         cameras=dict(
-            cam_high='observation.images.cam_high',
-            cam_wrist='observation.images.cam_wrist',
+            cam_high="observation.images.cam_high",
+            cam_wrist="observation.images.cam_wrist",
         ),
         columns=dict(
-            qpos='observations.state.qpos',
-            eef='observations.state.eef',
-            action_qpos='action.qpos',
-            action_eef='action.eef',
+            qpos="observations.state.qpos",
+            eef="observations.state.eef",
+            action_qpos="action.qpos",
+            action_eef="action.eef",
         ),
     ),
     teleop=dict(
-        type='ur5e_master_arm',
-        port='/dev/ttyACM0',
+        type="ur5e_master_arm",
+        port="/dev/ttyACM0",
         joint_coef=[1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
         gripper=dict(
-            source='analog',
+            source="analog",
         ),
     ),
-    tasks=['pick up the apple'],
+    tasks=["pick up the apple"],
 )

--- a/configs/03_evaluation/arx_r5_eval.py
+++ b/configs/03_evaluation/arx_r5_eval.py
@@ -1,6 +1,6 @@
 """ARX R5: eval checkpoint sweep."""
 
-_base_ = ['../01_deploy/arx_r5/_base.py']
+_base_ = ["../01_deploy/arx_r5/_base.py"]
 
 eval_cfg = dict(
     storage=dict(
@@ -8,19 +8,19 @@ eval_cfg = dict(
         save_queue_max=15,
     ),
     trials_per_prompt=5,
-    cli_mode='real',
-    inference_strategy='async',
+    cli_mode="real",
+    inference_strategy="async",
     reset_after_each_trial=False,
     skip_warmup_after_first=True,
     checkpoints=[
         dict(
-            name='arx_r5_openpi_modified',
-            config='../01_deploy/arx_r5/openpi_qpos.py',
+            name="arx_r5_openpi_modified",
+            config="../01_deploy/arx_r5/openpi_qpos.py",
             port=9000,
         ),
         dict(
-            name='arx_r5_openpi_baseline',
-            config='../01_deploy/arx_r5/openpi_qpos.py',
+            name="arx_r5_openpi_baseline",
+            config="../01_deploy/arx_r5/openpi_qpos.py",
             port=9000,
         ),
     ],
@@ -37,19 +37,19 @@ eval_cfg = dict(
     # ),
     tasks=[
         dict(
-            prompt_en='pick up the apple',
+            prompt_en="pick up the apple",
             milestones=(
-                ('approach', 'approach the apple'),
-                ('pick', 'pick up the apple'),
-                ('place', 'place the apple into the plate'),
+                ("approach", "approach the apple"),
+                ("pick", "pick up the apple"),
+                ("place", "place the apple into the plate"),
             ),
         ),
         dict(
-            prompt_en='pick up the orange',
+            prompt_en="pick up the orange",
             milestones=(
-                ('approach', 'approach the orange'),
-                ('pick', 'pick up the orange'),
-                ('place', 'place the orange into the plate'),
+                ("approach", "approach the orange"),
+                ("pick", "pick up the orange"),
+                ("place", "place the orange into the plate"),
             ),
         ),
     ],

--- a/configs/03_evaluation/dual_agilex_piper_eval.py
+++ b/configs/03_evaluation/dual_agilex_piper_eval.py
@@ -1,6 +1,6 @@
 """Dual Piper: openpi qpos eval (checkpoints + SSH-forwarded remote endpoint)."""
 
-_base_ = ['../01_deploy/dual_agilex_piper/openpi_qpos.py']
+_base_ = ["../01_deploy/dual_agilex_piper/openpi_qpos.py"]
 
 eval_cfg = dict(
     storage=dict(
@@ -8,14 +8,14 @@ eval_cfg = dict(
         save_queue_max=15,
     ),
     trials_per_prompt=5,
-    cli_mode='real',
-    inference_strategy='async',
+    cli_mode="real",
+    inference_strategy="async",
     reset_after_each_trial=False,
     skip_warmup_after_first=True,
     checkpoints=[
         dict(
-            name='qwen3vl_mlp_oft_xpred_qpos-agilex-ood-eval_qpos-agilex-midtrain_from_mid_train_539_step30000',
-            config='../01_deploy/dual_agilex_piper/openpi_qpos.py',
+            name="qwen3vl_mlp_oft_xpred_qpos-agilex-ood-eval_qpos-agilex-midtrain_from_mid_train_539_step30000",
+            config="../01_deploy/dual_agilex_piper/openpi_qpos.py",
             port=9000,
         ),
     ],
@@ -25,18 +25,18 @@ eval_cfg = dict(
     # To forward each checkpoint port to a remote inference server, fill in your
     # own endpoint below and set enable_ssh_forward=True.
     ssh=dict(
-        host='<remote-host>',
-        user='<remote-user>',
+        host="<remote-host>",
+        user="<remote-user>",
         port=8000,
-        remote_sync_dir='<remote-sync-dir>',
+        remote_sync_dir="<remote-sync-dir>",
     ),
     tasks=[
         dict(
-            prompt_en='pick the apple',
+            prompt_en="pick the apple",
             milestones=(
-                ('approach', 'approach apple'),
-                ('grasp', 'grasp apple'),
-                ('lift', 'lift off table'),
+                ("approach", "approach apple"),
+                ("grasp", "grasp apple"),
+                ("lift", "lift off table"),
             ),
         ),
     ],

--- a/configs/03_evaluation/r1lite_eval.py
+++ b/configs/03_evaluation/r1lite_eval.py
@@ -1,6 +1,6 @@
 """R1 Lite: openpi qpos eval."""
 
-_base_ = ['../01_deploy/r1lite/openpi_qpos.py']
+_base_ = ["../01_deploy/r1lite/openpi_qpos.py"]
 
 eval_cfg = dict(
     storage=dict(
@@ -8,14 +8,14 @@ eval_cfg = dict(
         save_queue_max=15,
     ),
     trials_per_prompt=5,
-    cli_mode='real',
-    inference_strategy='rtc',
+    cli_mode="real",
+    inference_strategy="rtc",
     reset_after_each_trial=False,
     skip_warmup_after_first=True,
     checkpoints=[
         dict(
-            name='r1lite_openpi_qpos_baseline',
-            config='../01_deploy/r1lite/openpi_qpos.py',
+            name="r1lite_openpi_qpos_baseline",
+            config="../01_deploy/r1lite/openpi_qpos.py",
             port=9000,
         ),
     ],
@@ -24,8 +24,8 @@ eval_cfg = dict(
     enable_ssh_forward=False,
     tasks=[
         dict(
-            prompt_en='placeholder task — replace with the real task prompt',
-            milestones=(('complete', 'complete the task'),),
+            prompt_en="placeholder task — replace with the real task prompt",
+            milestones=(("complete", "complete the task"),),
         ),
     ],
 )

--- a/configs/03_evaluation/ur5e_eval.py
+++ b/configs/03_evaluation/ur5e_eval.py
@@ -1,6 +1,6 @@
 """UR5e: eval checkpoint sweep."""
 
-_base_ = ['../01_deploy/ur5e/openpi_qpos.py']
+_base_ = ["../01_deploy/ur5e/openpi_qpos.py"]
 
 eval_cfg = dict(
     storage=dict(
@@ -8,14 +8,14 @@ eval_cfg = dict(
         save_queue_max=15,
     ),
     trials_per_prompt=5,
-    cli_mode='real',
-    inference_strategy='async',
+    cli_mode="real",
+    inference_strategy="async",
     reset_after_each_trial=False,
     skip_warmup_after_first=True,
     checkpoints=[
         dict(
-            name='ur5e_openpi_qpos_baseline',
-            config='../01_deploy/ur5e/openpi_qpos.py',
+            name="ur5e_openpi_qpos_baseline",
+            config="../01_deploy/ur5e/openpi_qpos.py",
             port=9000,
         ),
     ],
@@ -24,11 +24,11 @@ eval_cfg = dict(
     enable_ssh_forward=False,
     tasks=[
         dict(
-            prompt_en='pick the apple',
+            prompt_en="pick the apple",
             milestones=(
-                ('approach', 'approach apple'),
-                ('grasp', 'grasp apple'),
-                ('lift', 'lift off table'),
+                ("approach", "approach apple"),
+                ("grasp", "grasp apple"),
+                ("lift", "lift off table"),
             ),
         ),
     ],

--- a/configs/04_rl/agibot_g2_rl.py
+++ b/configs/04_rl/agibot_g2_rl.py
@@ -1,36 +1,36 @@
 """AgiBot G2 RL workspace with independent policy and critic selection."""
 
-_base_ = ['../01_deploy/agibot_g2/openpi_qpos.py']
+_base_ = ["../01_deploy/agibot_g2/openpi_qpos.py"]
 
 rl_cfg = dict(
-    cli_mode='real',
-    inference_strategy='async',
-    tasks=['placeholder task — replace with the real RL task prompt'],
+    cli_mode="real",
+    inference_strategy="async",
+    tasks=["placeholder task — replace with the real RL task prompt"],
     policies=[
         dict(
-            name='agibot_g2_openpi_qpos',
-            config='../01_deploy/agibot_g2/openpi_qpos.py',
-            host='127.0.0.1',
+            name="agibot_g2_openpi_qpos",
+            config="../01_deploy/agibot_g2/openpi_qpos.py",
+            host="127.0.0.1",
             port=9000,
         ),
     ],
     critics=[
         dict(
-            name='agibot_g2_critic',
-            type='websocket',
-            host='127.0.0.1',
+            name="agibot_g2_critic",
+            type="websocket",
+            host="127.0.0.1",
             port=9100,
             backend_options={},
         ),
     ],
     data=dict(
-        format='lerobot',
+        format="lerobot",
         storage=dict(
-            log_dir='work_dirs/rl/agibot_g2',
+            log_dir="work_dirs/rl/agibot_g2",
             fps=30,
             save_queue_max=15,
             async_save=True,
         ),
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )

--- a/configs/04_rl/arx_r5_rl.py
+++ b/configs/04_rl/arx_r5_rl.py
@@ -1,36 +1,36 @@
 """ARX R5 RL workspace with independent policy and critic selection."""
 
-_base_ = ['../01_deploy/arx_r5/openpi_qpos.py']
+_base_ = ["../01_deploy/arx_r5/openpi_qpos.py"]
 
 rl_cfg = dict(
-    cli_mode='real',
-    inference_strategy='async',
-    tasks=['placeholder task — replace with the real RL task prompt'],
+    cli_mode="real",
+    inference_strategy="async",
+    tasks=["placeholder task — replace with the real RL task prompt"],
     policies=[
         dict(
-            name='arx_r5_openpi_qpos',
-            config='../01_deploy/arx_r5/openpi_qpos.py',
-            host='127.0.0.1',
+            name="arx_r5_openpi_qpos",
+            config="../01_deploy/arx_r5/openpi_qpos.py",
+            host="127.0.0.1",
             port=9000,
         ),
     ],
     critics=[
         dict(
-            name='arx_r5_critic',
-            type='websocket',
-            host='127.0.0.1',
+            name="arx_r5_critic",
+            type="websocket",
+            host="127.0.0.1",
             port=9100,
             backend_options={},
         ),
     ],
     data=dict(
-        format='lerobot',
+        format="lerobot",
         storage=dict(
-            log_dir='work_dirs/rl/arx_r5',
+            log_dir="work_dirs/rl/arx_r5",
             fps=30,
             save_queue_max=15,
             async_save=True,
         ),
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )

--- a/configs/04_rl/dual_agilex_piper_rl.py
+++ b/configs/04_rl/dual_agilex_piper_rl.py
@@ -1,36 +1,36 @@
 """Dual Piper RL workspace with independent policy and critic selection."""
 
-_base_ = ['../01_deploy/dual_agilex_piper/openpi_qpos.py']
+_base_ = ["../01_deploy/dual_agilex_piper/openpi_qpos.py"]
 
 rl_cfg = dict(
-    cli_mode='real',
-    inference_strategy='async',
-    tasks=['placeholder task — replace with the real RL task prompt'],
+    cli_mode="real",
+    inference_strategy="async",
+    tasks=["placeholder task — replace with the real RL task prompt"],
     policies=[
         dict(
-            name='dual_agilex_piper_openpi_qpos',
-            config='../01_deploy/dual_agilex_piper/openpi_qpos.py',
-            host='127.0.0.1',
+            name="dual_agilex_piper_openpi_qpos",
+            config="../01_deploy/dual_agilex_piper/openpi_qpos.py",
+            host="127.0.0.1",
             port=9000,
         ),
     ],
     critics=[
         dict(
-            name='dual_agilex_piper_critic',
-            type='websocket',
-            host='127.0.0.1',
+            name="dual_agilex_piper_critic",
+            type="websocket",
+            host="127.0.0.1",
             port=9100,
             backend_options={},
         ),
     ],
     data=dict(
-        format='lerobot',
+        format="lerobot",
         storage=dict(
-            log_dir='work_dirs/rl/dual_agilex_piper',
+            log_dir="work_dirs/rl/dual_agilex_piper",
             fps=30,
             save_queue_max=15,
             async_save=True,
         ),
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )

--- a/configs/04_rl/dual_franka_rl.py
+++ b/configs/04_rl/dual_franka_rl.py
@@ -1,36 +1,36 @@
 """Dual Franka RL workspace with independent policy and critic selection."""
 
-_base_ = ['../01_deploy/dual_franka/openpi_qpos.py']
+_base_ = ["../01_deploy/dual_franka/openpi_qpos.py"]
 
 rl_cfg = dict(
-    cli_mode='real',
-    inference_strategy='async',
-    tasks=['placeholder task — replace with the real RL task prompt'],
+    cli_mode="real",
+    inference_strategy="async",
+    tasks=["placeholder task — replace with the real RL task prompt"],
     policies=[
         dict(
-            name='dual_franka_openpi_qpos',
-            config='../01_deploy/dual_franka/openpi_qpos.py',
-            host='127.0.0.1',
+            name="dual_franka_openpi_qpos",
+            config="../01_deploy/dual_franka/openpi_qpos.py",
+            host="127.0.0.1",
             port=9000,
         ),
     ],
     critics=[
         dict(
-            name='dual_franka_critic',
-            type='websocket',
-            host='127.0.0.1',
+            name="dual_franka_critic",
+            type="websocket",
+            host="127.0.0.1",
             port=9100,
             backend_options={},
         ),
     ],
     data=dict(
-        format='lerobot',
+        format="lerobot",
         storage=dict(
-            log_dir='work_dirs/rl/dual_franka',
+            log_dir="work_dirs/rl/dual_franka",
             fps=30,
             save_queue_max=15,
             async_save=True,
         ),
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )

--- a/configs/04_rl/r1lite_rl.py
+++ b/configs/04_rl/r1lite_rl.py
@@ -1,32 +1,32 @@
 """R1 Lite RL workspace with independent policy and critic selection."""
 
-_base_ = ['../01_deploy/r1lite/openpi_qpos.py']
+_base_ = ["../01_deploy/r1lite/openpi_qpos.py"]
 
 rl_cfg = dict(
-    cli_mode='real',
-    inference_strategy='async',
-    tasks=['placeholder task — replace with the real RL task prompt'],
+    cli_mode="real",
+    inference_strategy="async",
+    tasks=["placeholder task — replace with the real RL task prompt"],
     policies=[
         dict(
-            name='r1lite_openpi_qpos',
-            config='../01_deploy/r1lite/openpi_qpos.py',
-            host='127.0.0.1',
+            name="r1lite_openpi_qpos",
+            config="../01_deploy/r1lite/openpi_qpos.py",
+            host="127.0.0.1",
             port=9000,
         ),
     ],
     critics=[
         dict(
-            name='r1lite_critic',
-            type='websocket',
-            host='127.0.0.1',
+            name="r1lite_critic",
+            type="websocket",
+            host="127.0.0.1",
             port=9100,
             backend_options={},
         ),
     ],
     data=dict(
-        format='lerobot',
+        format="lerobot",
         storage=dict(
-            log_dir='work_dirs/rl/r1lite',
+            log_dir="work_dirs/rl/r1lite",
             fps=15,
             save_queue_max=15,
             async_save=True,
@@ -34,5 +34,5 @@ rl_cfg = dict(
             image_width=640,
         ),
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )

--- a/configs/04_rl/ur5e_rl.py
+++ b/configs/04_rl/ur5e_rl.py
@@ -1,36 +1,36 @@
 """UR5e RL workspace with independent policy and critic selection."""
 
-_base_ = ['../01_deploy/ur5e/openpi_qpos.py']
+_base_ = ["../01_deploy/ur5e/openpi_qpos.py"]
 
 rl_cfg = dict(
-    cli_mode='real',
-    inference_strategy='async',
-    tasks=['placeholder task — replace with the real RL task prompt'],
+    cli_mode="real",
+    inference_strategy="async",
+    tasks=["placeholder task — replace with the real RL task prompt"],
     policies=[
         dict(
-            name='ur5e_openpi_qpos',
-            config='../01_deploy/ur5e/openpi_qpos.py',
-            host='127.0.0.1',
+            name="ur5e_openpi_qpos",
+            config="../01_deploy/ur5e/openpi_qpos.py",
+            host="127.0.0.1",
             port=9000,
         ),
     ],
     critics=[
         dict(
-            name='ur5e_critic',
-            type='websocket',
-            host='127.0.0.1',
+            name="ur5e_critic",
+            type="websocket",
+            host="127.0.0.1",
             port=9100,
             backend_options={},
         ),
     ],
     data=dict(
-        format='lerobot',
+        format="lerobot",
         storage=dict(
-            log_dir='work_dirs/rl/ur5e',
+            log_dir="work_dirs/rl/ur5e",
             fps=20,
             save_queue_max=15,
             async_save=True,
         ),
     ),
-    intervention=dict(control_mode='relative'),
+    intervention=dict(control_mode="relative"),
 )

--- a/examples/hardware/fake_common.py
+++ b/examples/hardware/fake_common.py
@@ -167,8 +167,7 @@ class FakeRobotNode:
 
     def _zero_eef_by_group(self) -> dict[str, np.ndarray]:
         return {
-            group.name: np.zeros(_EEF_DOF, dtype=np.float32)
-            for group in self._robot.arm_groups
+            group.name: np.zeros(_EEF_DOF, dtype=np.float32) for group in self._robot.arm_groups
         }
 
     def _read_images(self) -> dict[str, np.ndarray]:
@@ -328,9 +327,7 @@ class FakeRobotNode:
         # recording starts; COLLECT only additionally reports it as action_qpos.
         if self._hil_active:
             if self._hil_mode == "relative":
-                self._qpos = self._hil_robot_anchor + (
-                    self._hil_input - self._hil_input_anchor
-                )
+                self._qpos = self._hil_robot_anchor + (self._hil_input - self._hil_input_anchor)
             else:
                 self._qpos = self._hil_input.copy()
             action_qpos = self._qpos.copy()

--- a/examples/hardware/ur5e/node.py
+++ b/examples/hardware/ur5e/node.py
@@ -72,9 +72,7 @@ class Ur5eZmqNode:
         self._action_sub.setsockopt(zmq.RCVTIMEO, 0)
         self._robot = Ur5eRobot(config)
         robot = ROBOT_REGISTRY.build("ur5e")
-        self._fk_solver = robot.build_kinematics(
-            initial_qpos_groups=robot.initial_qpos_by_group()
-        )
+        self._fk_solver = robot.build_kinematics(initial_qpos_groups=robot.initial_qpos_by_group())
         self._captures = open_cameras(config.cameras)
         self._collection_active = False
         self._hil_active = False

--- a/src/core/app/cli.py
+++ b/src/core/app/cli.py
@@ -150,9 +150,7 @@ def _resolve_task(arg: str, config: ConfigDict) -> str | None:
     return arg
 
 
-def _dispatch(
-    line: str, config: ConfigDict, runtime: RuntimeState, session: SessionState
-) -> None:
+def _dispatch(line: str, config: ConfigDict, runtime: RuntimeState, session: SessionState) -> None:
     """Map one CLI line to a queued command or an inline print."""
     parts = line.split(maxsplit=1)
     verb = parts[0].lower()

--- a/src/core/app/console/server.py
+++ b/src/core/app/console/server.py
@@ -560,8 +560,7 @@ def _serialize_rl(ctx: ConsoleContext) -> dict:
         "inference_strategy": str(rl_cfg.inference_strategy),
         "tasks": [str(task) for task in rl_cfg.tasks],
         "policies": [
-            {"slot": slot, "name": str(model.name)}
-            for slot, model in enumerate(rl_cfg.policies)
+            {"slot": slot, "name": str(model.name)} for slot, model in enumerate(rl_cfg.policies)
         ],
         "critics": [
             {"slot": slot, "name": str(model.name), "type": str(model.type)}
@@ -1804,9 +1803,7 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         if transform_range is not None:
             start, count = transform_range
         raw = (
-            preview.transforms_blob(ep, start=start, count=count)
-            if (preview and ep >= 0)
-            else None
+            preview.transforms_blob(ep, start=start, count=count) if (preview and ep >= 0) else None
         )
         if raw is None:
             self._send_json(404, {"available": False})
@@ -2350,6 +2347,7 @@ class ConsoleRequestHandler(BaseHTTPRequestHandler):
         side = str(body.get("side", "") or "")
         arg = f"{action}:{side}" if side in ("l", "r") else action
         self._enqueue_ok(f"web:init_gripper:{arg}")
+
 
 # Exact-path GET routes (prefix routes — camera/assets/meshes — are handled inline in
 # do_GET because they own a path subtree). Values are unbound handler methods.

--- a/src/core/app/handlers/io.py
+++ b/src/core/app/handlers/io.py
@@ -218,8 +218,8 @@ def normalize_policy_action_chunk(
     """
     if not resolve_policy_action_mode(config, runtime, response=response).is_eef():
         return action_chunk
-    canonical_eef_chunk = (
-        config.inference_cfg.action_space.normalize_chunk_to_canonical(action_chunk)
+    canonical_eef_chunk = config.inference_cfg.action_space.normalize_chunk_to_canonical(
+        action_chunk
     )
     ik_solver = ensure_ik_solver(config, runtime)
     seed_qpos = runtime.transport.get_latest_qpos()
@@ -295,9 +295,7 @@ def _replay_action_at(config: ConfigDict, runtime: RuntimeState, index: int) -> 
     action_chunk = normalize_action_chunk(raw_action)
     replay_mode = _resolve_replay_action_mode(config, runtime)
     if isinstance(replay_mode, EEFPose):
-        action_chunk = _fill_missing_replay_eef_gripper(
-            runtime, replay_mode, action_chunk, index
-        )
+        action_chunk = _fill_missing_replay_eef_gripper(runtime, replay_mode, action_chunk, index)
         canonical_eef_chunk = replay_mode.normalize_chunk_to_canonical(action_chunk)
         ik_solver = ensure_ik_solver(config, runtime)
         seed_qpos = _replay_qpos_at(runtime, index) if index == 0 else None
@@ -400,9 +398,7 @@ def fetch_action_chunk(
     raise SystemExit(0)
 
 
-def _loop_observation(
-    config: ConfigDict, runtime: RuntimeState, prompt: str
-) -> dict | None:
+def _loop_observation(config: ConfigDict, runtime: RuntimeState, prompt: str) -> dict | None:
     """Build a policy observation from the latest frame; None if none is available."""
     frame = runtime.transport.get_frame()
     if frame is None:
@@ -465,11 +461,7 @@ def run_warmup_and_start(config: ConfigDict, runtime: RuntimeState, session: Ses
 
     warmup_n = max(1, config.inference_cfg.setup_warmup_chunks)
 
-    skip_warmup = (
-        config.eval
-        and config.eval.skip_warmup_after_first
-        and runtime._eval_warmup_done
-    )
+    skip_warmup = config.eval and config.eval.skip_warmup_after_first and runtime._eval_warmup_done
 
     if runtime.infer_strategy is not None:
         runtime.infer_strategy.reset()
@@ -774,6 +766,7 @@ def _build_replay_dataset_config(
     only the dataset-relevant fields so the source decodes the right columns/videos.
     """
     import copy
+
     new_config = copy.deepcopy(config)
     new_config.transport.dataset_dir = dataset_dir
     new_config.transport.episode_id = episode_id

--- a/src/core/app/handlers/recording.py
+++ b/src/core/app/handlers/recording.py
@@ -295,10 +295,7 @@ def mark_rollout_save_ready(runtime: RuntimeState, reason: str) -> None:
         logger_obj.active_frame_count
         + len(runtime.rollout_policy_actions)
         + runtime.rollout_raw_snapshots.qsize()
-        + sum(
-            len(segment.frames)
-            for segment in runtime.rollout_intervention_segments
-        )
+        + sum(len(segment.frames) for segment in runtime.rollout_intervention_segments)
     )
     if buffered_frames <= 0:
         logger_obj.cancel_episode("empty rollout")

--- a/src/core/app/run.py
+++ b/src/core/app/run.py
@@ -1209,9 +1209,7 @@ def run(
         channel_cfg = config.get("control_channel") or {}
         if not channel_cfg.get("enabled", False):
             # Headless with no channel would be uncontrollable — force it on.
-            config.control_channel = ConfigDict(
-                {**dict(channel_cfg), "enabled": True}
-            )
+            config.control_channel = ConfigDict({**dict(channel_cfg), "enabled": True})
         maybe_start_control_channel(config, runtime)
         ch = config.control_channel
         disp_host = "127.0.0.1" if ch.get("host") == "0.0.0.0" else ch.get("host", "127.0.0.1")
@@ -1289,10 +1287,7 @@ def run(
                 and session.status is SessionStatus.RUNNING
             ):
                 running_tick = time.monotonic()
-                if (
-                    last_running_tick is not None
-                    and running_tick - last_running_tick >= 0.1
-                ):
+                if last_running_tick is not None and running_tick - last_running_tick >= 0.1:
                     logger.warning(
                         "[CONTROL_TIMING] stage=main_loop_gap duration_ms=%.1f step=%d",
                         (running_tick - last_running_tick) * 1000.0,

--- a/src/core/app/state.py
+++ b/src/core/app/state.py
@@ -286,8 +286,8 @@ class RuntimeState:
     rl_pending_critic_observation: dict | None = None
     rl_pending_critic_action: np.ndarray | None = None
     rl_pending_critic_timestamp: float | None = None
-    rl_live_samples: list[tuple[float, np.ndarray, np.ndarray, str, int]] = (
-        dataclasses.field(default_factory=list)
+    rl_live_samples: list[tuple[float, np.ndarray, np.ndarray, str, int]] = dataclasses.field(
+        default_factory=list
     )
     rl_replay_source: DatasetTransport | None = None
     rl_replay_sources: list[DatasetTransport] = dataclasses.field(default_factory=list)

--- a/src/core/cfg/_utils.py
+++ b/src/core/cfg/_utils.py
@@ -192,8 +192,7 @@ def digit_version(version_str: str, length: int = 4):
         if version.pre:
             if version.pre[0] not in mapping:
                 warnings.warn(
-                    f"unknown prerelease version {version.pre[0]}, "
-                    "version checking may go wrong",
+                    f"unknown prerelease version {version.pre[0]}, version checking may go wrong",
                     stacklevel=2,
                 )
             else:
@@ -280,8 +279,7 @@ def get_installed_path(package: str) -> str:
                 # `get_installed_path` cannot get the installed path of
                 # namespace packages
                 raise RuntimeError(
-                    f"{package} is a namespace package, "
-                    "which is invalid for `get_install_path`"
+                    f"{package} is a namespace package, which is invalid for `get_install_path`"
                 )
         else:
             raise PackageNotFoundError(f"Package {package} is not installed")
@@ -292,5 +290,3 @@ def get_installed_path(package: str) -> str:
         return possible_path
     else:
         return osp.join(location, package2module(package))
-
-

--- a/src/core/cfg/config.py
+++ b/src/core/cfg/config.py
@@ -59,6 +59,7 @@ logger = logging.getLogger(__name__)
 
 # ===== from lazy.py =====
 
+
 class LazyObject:
     """LazyObject is used to lazily initialize the imported module during
     parsing the configuration file.
@@ -287,6 +288,7 @@ class LazyAttr:
     def __setstate__(self, state: dict[str, Any]) -> None:
         self.__dict__ = state
 
+
 # ===== from fileio_shim.py =====
 
 try:
@@ -335,6 +337,7 @@ def dump(obj: Any, file: str | Path | None = None, file_format: str | None = Non
         else:
             json.dump(obj, f, default=str)
     return None
+
 
 # ===== from config_utils.py =====
 
@@ -673,9 +676,7 @@ class ImportTransformer(ast.NodeTransformer):
                 # case2:
                 # from eva.engine.model import BaseModel
                 # BaseModel = LazyObject('engine.model', 'BaseModel')
-                code = (
-                    f'{alias_node.name} = LazyObject("{module}", "{alias_node.name}", "{self.filename}, line {lineno}")'  # noqa: E501
-                )
+                code = f'{alias_node.name} = LazyObject("{module}", "{alias_node.name}", "{self.filename}, line {lineno}")'  # noqa: E501
                 self.imported_obj.add(alias_node.name)
             try:
                 nodes.append(ast.parse(code).body[0])  # type: ignore
@@ -775,6 +776,7 @@ def _gather_abs_import_lazyobj(tree: ast.Module, filename: str | None = None):
         new_body.insert(0, lazy_module_assign.body[0])
     tree.body = new_body
     return tree, abs_imported
+
 
 # ===== Config + ConfigDict =====
 
@@ -2401,7 +2403,7 @@ class Config:
         )
 
     @staticmethod
-    def diff(cfg1: str  | Config, cfg2: str  | Config) -> str:
+    def diff(cfg1: str | Config, cfg2: str | Config) -> str:
         if isinstance(cfg1, str):
             cfg1 = Config.fromfile(cfg1)
 

--- a/src/core/cfg/registry.py
+++ b/src/core/cfg/registry.py
@@ -136,7 +136,8 @@ class ManagerMixin(metaclass=ManagerMeta):
             warnings.warn(
                 f"{cls} instance named of {name} has been created, "
                 "the method `get_instance` should not accept any other "
-                "arguments", stacklevel=2
+                "arguments",
+                stacklevel=2,
             )
         # Get latest instantiated instance or root instance.
         _release_lock()
@@ -193,7 +194,9 @@ class ManagerMixin(metaclass=ManagerMeta):
         """
         return self._instance_name
 
+
 # ===== from default_scope.py =====
+
 
 class DefaultScope(ManagerMixin):
     """Scope of current task used to reset the current registry, which can be
@@ -280,7 +283,9 @@ class DefaultScope(ManagerMixin):
             finally:
                 cls._instance_dict = tmp
 
+
 # ===== Registry =====
+
 
 class Registry:
     """A registry to map strings to classes or functions.
@@ -827,9 +832,9 @@ class Registry:
 
         assert isinstance(registry, Registry)
         assert registry.scope is not None
-        assert (
-            registry.scope not in self.children
-        ), f"scope {registry.scope} exists in {self.name} registry"
+        assert registry.scope not in self.children, (
+            f"scope {registry.scope} exists in {self.name} registry"
+        )
         self.children[registry.scope] = registry
 
     def _register_module(
@@ -860,8 +865,7 @@ class Registry:
             if not force and name in self._module_dict:
                 existed_module = self.module_dict[name]
                 raise KeyError(
-                    f"{name} is already registered in {self.name} "
-                    f"at {existed_module.__module__}"
+                    f"{name} is already registered in {self.name} at {existed_module.__module__}"
                 )
             self._module_dict[name] = module
 
@@ -880,7 +884,6 @@ class Registry:
             return obj
 
         return decorator
-
 
     def available(self) -> list[str]:
         """Return the sorted list of registered keys (legacy api)."""
@@ -928,8 +931,7 @@ class Registry:
         # raise the error ahead of time
         if not (name is None or isinstance(name, str) or is_seq_of(name, str)):
             raise TypeError(
-                f"name must be None, an instance of str, or a sequence of str, "
-                f"but got {type(name)}"
+                f"name must be None, an instance of str, or a sequence of str, but got {type(name)}"
             )
 
         # use it as a normal method: x.register_module(module=SomeClass)
@@ -943,6 +945,7 @@ class Registry:
             return module
 
         return _register
+
 
 # ===== from build_functions.py =====
 

--- a/src/core/recorder/collection.py
+++ b/src/core/recorder/collection.py
@@ -146,9 +146,7 @@ class CollectionEpisodeWriter:
             raise ValueError("collection frame missing timestamp or state_qpos")
         with self._state_lock:
             frame_index = len(self._records)
-            images = {
-                key: np.asarray(value) for key, value in frame.images.items()
-            }
+            images = {key: np.asarray(value) for key, value in frame.images.items()}
             vectors = {
                 field: (
                     None
@@ -317,8 +315,7 @@ class CollectionEpisodeWriter:
         self._alignment_report = None
         self._max_capture_time = None
         logger.info(
-            "collection end_episode queued raw=%s raw_snapshots=%d: package=%.1fms "
-            "total=%.1fms",
+            "collection end_episode queued raw=%s raw_snapshots=%d: package=%.1fms total=%.1fms",
             has_raw,
             len(raw_snapshots),
             (package_done - started) * 1000.0,
@@ -413,9 +410,7 @@ class CollectionEpisodeWriter:
                     "alignment_grid_end": self._alignment_report.grid_end,
                     "alignment_image_skew_tolerance_sec": self._image_skew_tolerance_sec(),
                     "alignment_image_max_skew_sec": self._alignment_report.image_max_skew,
-                    "alignment_image_stream_stats": (
-                        self._alignment_report.image_stream_stats
-                    ),
+                    "alignment_image_stream_stats": (self._alignment_report.image_stream_stats),
                 }
             )
         if job.episode_meta:
@@ -442,9 +437,7 @@ class CollectionEpisodeWriter:
     def _alignment_failure_detail(self) -> str:
         issues = []
         if self._alignment_report is not None:
-            issues = [
-                f"{issue.code}: {issue.detail}" for issue in self._alignment_report.issues
-            ]
+            issues = [f"{issue.code}: {issue.detail}" for issue in self._alignment_report.issues]
         issue_text = "; ".join(issues) if issues else "none"
         return (
             "collection episode produced 0 frames; "
@@ -673,9 +666,7 @@ class CollectionEpisodeWriter:
         if not episodes or not stats_rows:
             return None
 
-        stats_by_episode = {
-            int(row["episode_index"]): row.get("stats", {}) for row in stats_rows
-        }
+        stats_by_episode = {int(row["episode_index"]): row.get("stats", {}) for row in stats_rows}
         episode_indices = {int(row["episode_index"]) for row in episodes}
         if set(stats_by_episode) != episode_indices:
             return None
@@ -683,8 +674,7 @@ class CollectionEpisodeWriter:
         stats: dict[str, Any] = {}
         for output_key in self._schema.columns.values():
             combined = self._combine_episode_stats(
-                stats_by_episode[int(row["episode_index"])].get(output_key)
-                for row in episodes
+                stats_by_episode[int(row["episode_index"])].get(output_key) for row in episodes
             )
             if combined is None:
                 return None

--- a/src/core/recorder/collection_alignment.py
+++ b/src/core/recorder/collection_alignment.py
@@ -107,9 +107,7 @@ def align_collection_samples(
     image_series: dict[str, list[CollectionRawSample]] = {
         key: _sorted_samples(batch.images.get(key, [])) for key in required_images
     }
-    vector_series = {
-        field: _vector_components(batch, field, robot) for field in required_vectors
-    }
+    vector_series = {field: _vector_components(batch, field, robot) for field in required_vectors}
     issues: list[AlignmentIssue] = []
     coverage_starts: list[float] = []
     coverage_ends: list[float] = []
@@ -337,10 +335,7 @@ def _stream_stats(
     count = len(samples)
     start_time = samples[0].timestamp
     end_time = samples[-1].timestamp
-    gaps = [
-        samples[index].timestamp - samples[index - 1].timestamp
-        for index in range(1, count)
-    ]
+    gaps = [samples[index].timestamp - samples[index - 1].timestamp for index in range(1, count)]
     duration = end_time - start_time
     estimated_hz = None
     if count > 1 and duration > 0.0:
@@ -403,9 +398,7 @@ def _vector_components(
         gripper_samples = None
         default_gripper = None
         if field in {"state_qpos", "action_qpos"}:
-            samples, gripper_samples = _split_group_gripper_samples(
-                batch, field, group, samples
-            )
+            samples, gripper_samples = _split_group_gripper_samples(batch, field, group, samples)
             if group.gripper_index is not None:
                 default_gripper = _initial_gripper_value(robot, group)
         components.append(

--- a/src/core/recorder/episode.py
+++ b/src/core/recorder/episode.py
@@ -87,6 +87,7 @@ def _release_failed_save_payload(job: SaveJob) -> None:
     job.raw_video_samples = None
     job.intervention_segments = []
 
+
 # Observation vector fields (everything except timestamp/images) recorded per collection frame.
 _COLLECTION_VECTOR_FIELDS = (
     "state_qpos",
@@ -415,9 +416,7 @@ class EpisodeLogger:
                 self._raw_episode_batch.vectors.setdefault("state_eef", []).append(
                     CollectionRawSample(timestamp, np.asarray(state_eef, dtype=np.float32).copy())
                 )
-            self._raw_episode_frame_labels.append(
-                RawEpisodeFrameLabel(timestamp, False, -1)
-            )
+            self._raw_episode_frame_labels.append(RawEpisodeFrameLabel(timestamp, False, -1))
             self._extend_raw_episode_time_bounds(
                 self._raw_episode_batch,
                 self._raw_episode_batch.vectors["action_qpos"][-1:],
@@ -657,9 +656,7 @@ class EpisodeLogger:
         raw_snapshots = [
             RawEpisodeSnapshot(
                 snapshot=sample.snapshot,
-                action_qpos=None
-                if sample.action_qpos is None
-                else sample.action_qpos.copy(),
+                action_qpos=None if sample.action_qpos is None else sample.action_qpos.copy(),
                 intervention=sample.intervention,
                 segment_index=sample.segment_index,
             )
@@ -1030,8 +1027,7 @@ class EpisodeLogger:
                 (
                     index
                     for index, interval in enumerate(ranges)
-                    if float(interval["start_time"]) < timestamp
-                    < float(interval["end_time"])
+                    if float(interval["start_time"]) < timestamp < float(interval["end_time"])
                 ),
                 None,
             )
@@ -1454,9 +1450,7 @@ class EpisodeLogger:
             )
             path.parent.mkdir(parents=True, exist_ok=True)
             encoded = [
-                sample.value.encoded
-                if isinstance(sample.value, CollectionRawImage)
-                else None
+                sample.value.encoded if isinstance(sample.value, CollectionRawImage) else None
                 for sample in samples
             ]
             if self._convert_bgr_to_rgb and all(payload is not None for payload in encoded):
@@ -1825,9 +1819,7 @@ class EpisodeLogger:
 
     def _save_job_summary(self, job: SaveJob) -> dict[str, Any]:
         row = job.collection_episode_row or {}
-        quality_issues, quality_issue_count = summarize_quality_issues(
-            row.get("quality_issues")
-        )
+        quality_issues, quality_issue_count = summarize_quality_issues(row.get("quality_issues"))
         payload = job.raw_episode_payload
         pending_length = 0
         if payload is not None:

--- a/src/core/registry.py
+++ b/src/core/registry.py
@@ -63,7 +63,6 @@ class Registry(_BaseRegistry, Generic[T]):
         return decorator
 
 
-
 ROBOT_REGISTRY: Registry[Robot] = Registry("robot")
 TRANSPORT_REGISTRY: Registry[TransportBridge] = Registry("transport")
 STRATEGY_REGISTRY: Registry[BaseInferStrategy] = Registry("strategy")

--- a/src/core/utils/ssh_forward.py
+++ b/src/core/utils/ssh_forward.py
@@ -72,9 +72,7 @@ def _kill(pid: int, sig: int) -> None:
 
 
 @FUNCTIONS.register("ssh_forward")
-def start_ssh_forward(
-    ssh: dict, ports: list[int]
-) -> subprocess.Popen[bytes] | None:
+def start_ssh_forward(ssh: dict, ports: list[int]) -> subprocess.Popen[bytes] | None:
     """Start one multiplexed `ssh -fN -L` forwarding each port 1:1 to remote localhost.
 
     Args:

--- a/src/critic_client/base.py
+++ b/src/critic_client/base.py
@@ -51,9 +51,7 @@ class MockCriticClient(CriticClient):
     """Deterministic scalar critic used by unit tests and offline demos."""
 
     @classmethod
-    def from_config(
-        cls, config: ConfigDict, ctx: CriticBuildContext
-    ) -> MockCriticClient:
+    def from_config(cls, config: ConfigDict, ctx: CriticBuildContext) -> MockCriticClient:
         _ = config, ctx
         return cls()
 

--- a/src/critic_client/websocket.py
+++ b/src/critic_client/websocket.py
@@ -36,17 +36,13 @@ class WebSocketCriticClient(CriticClient):
         client: tuple[Any, dict] | None = None,
     ) -> None:
         if client is None:
-            self._ws, self._metadata = self._connect(
-                host, port, retry_until_connected, max_retries
-            )
+            self._ws, self._metadata = self._connect(host, port, retry_until_connected, max_retries)
         else:
             self._ws, self._metadata = client
         self._packer = msgpack_numpy.Packer()
 
     @classmethod
-    def from_config(
-        cls, config: ConfigDict, ctx: CriticBuildContext
-    ) -> WebSocketCriticClient:
+    def from_config(cls, config: ConfigDict, ctx: CriticBuildContext) -> WebSocketCriticClient:
         return cls(
             str(config.host),
             int(config.port),

--- a/src/policy_client/gr00t.py
+++ b/src/policy_client/gr00t.py
@@ -174,5 +174,3 @@ class Gr00tPolicyClient(PolicyClient):
     def reset(self) -> None:
         """Call the server's ``reset`` endpoint to clear its per-episode state."""
         self._call("reset", {"options": None})
-
-

--- a/src/policy_client/openpi.py
+++ b/src/policy_client/openpi.py
@@ -118,9 +118,7 @@ class RtcOpenPiPolicyClient(OpenPiPolicyClient):
         retry_until_connected: bool = True,
         client: tuple[websockets.sync.client.ClientConnection, dict] | None = None,
     ) -> None:
-        super().__init__(
-            host, port, retry_until_connected=retry_until_connected, client=client
-        )
+        super().__init__(host, port, retry_until_connected=retry_until_connected, client=client)
         self._latency_k = latency_k
         self._active_response: dict | None = None
         self._lock = threading.Lock()

--- a/src/robots/kinematics/pyroki.py
+++ b/src/robots/kinematics/pyroki.py
@@ -114,9 +114,7 @@ def _solve_frame_jax(
         pk.costs.pose_cost_analytic_jac(
             robot,
             joint_var,
-            jaxlie.SE3.from_rotation_and_translation(
-                jaxlie.SO3(target_wxyz), target_pos
-            ),
+            jaxlie.SE3.from_rotation_and_translation(jaxlie.SO3(target_wxyz), target_pos),
             target_link_index,
             pos_weight=pos_weight,
             ori_weight=ori_weight,
@@ -127,9 +125,7 @@ def _solve_frame_jax(
     ]
 
     @jaxls.Cost.factory(name="limit_velocity")
-    def limit_velocity_cost(
-        vals: jaxls.VarValues, var: jaxls.Var[jax.Array]
-    ) -> jax.Array:
+    def limit_velocity_cost(vals: jaxls.VarValues, var: jaxls.Var[jax.Array]) -> jax.Array:
         joint_vel = (vals[var] - prev_cfg) / dt
         residual = jnp.maximum(0.0, jnp.abs(joint_vel) - robot.joints.velocity_limits)
         return (residual * vel_weight).flatten()
@@ -373,13 +369,16 @@ class PyrokiSingleArm:
                 )
             )
             _logger.info(
-                "ik frame %d/%d solved in %.1f ms", t + 1, n_frames,
+                "ik frame %d/%d solved in %.1f ms",
+                t + 1,
+                n_frames,
                 (time.perf_counter() - t0) * 1e3,
             )
             sol[t] = cfg
             prev_cfg = cfg
         _logger.info(
-            "ik chunk: %d frames in %.1f ms", n_frames,
+            "ik chunk: %d frames in %.1f ms",
+            n_frames,
             (time.perf_counter() - t_start) * 1e3,
         )
         return sol[:, self._arm_cols]

--- a/src/robots/kinematics/solver.py
+++ b/src/robots/kinematics/solver.py
@@ -145,7 +145,10 @@ class DualArmChunkSolver:
             if pos_err >= self._position_tolerance:
                 _logger.warning(
                     "%s frame %d tracking pos err %.4f >= tol %.4f",
-                    label, t, pos_err, self._position_tolerance,
+                    label,
+                    t,
+                    pos_err,
+                    self._position_tolerance,
                 )
 
     def solve_chunk(self, chunk: np.ndarray, seed_qpos: np.ndarray | None = None) -> np.ndarray:
@@ -317,7 +320,9 @@ class SingleArmChunkSolver:
                 if pos_err >= self._position_tolerance:
                     _logger.warning(
                         "frame %d tracking pos err %.4f >= tol %.4f",
-                        t, pos_err, self._position_tolerance,
+                        t,
+                        pos_err,
+                        self._position_tolerance,
                     )
             solved = np.concatenate([arm_traj, eef_primary[:, 7:8]], axis=1)
             self._seed_qpos = solved[-1].astype(np.float64).copy()

--- a/src/robots/zoo/agibot_g2/__init__.py
+++ b/src/robots/zoo/agibot_g2/__init__.py
@@ -69,8 +69,11 @@ class AgibotKinematicsSolver(PyrokiDualArm):
 
         def make_arm(arm_index: int) -> PyrokiSingleArm:
             return PyrokiSingleArm(
-                urdf, arm_joints[arm_index], eef_links[arm_index],
-                reference_frame=frame_name, fixed_joints=fixed,
+                urdf,
+                arm_joints[arm_index],
+                eef_links[arm_index],
+                reference_frame=frame_name,
+                fixed_joints=fixed,
             )
 
         super().__init__(
@@ -109,10 +112,30 @@ class AgibotG2(Robot):
     RIGHT_GROUP = (*RIGHT_ARM, "idx81_gripper_r_outer_joint1")
     EEF_LINKS = ("gripper_l_center_link", "gripper_r_center_link")
     INITIAL_QPOS = (
-        0.739033, -0.717023, -1.524419, -1.537612, 0.27811, -0.925845, -0.839257, -0.785,
-        -0.739033, -0.717023, 1.524419, -1.537612, -0.27811, -0.925845, 0.839257, -0.785,
-        0.0, 0.0, 0.11464,
-        -0.83423, 1.2172, 0.10025, 0.0, 0.0,
+        0.739033,
+        -0.717023,
+        -1.524419,
+        -1.537612,
+        0.27811,
+        -0.925845,
+        -0.839257,
+        -0.785,
+        -0.739033,
+        -0.717023,
+        1.524419,
+        -1.537612,
+        -0.27811,
+        -0.925845,
+        0.839257,
+        -0.785,
+        0.0,
+        0.0,
+        0.11464,
+        -0.83423,
+        1.2172,
+        0.10025,
+        0.0,
+        0.0,
     )
     # One gripper scalar -> its 8 driven finger joints (visualization only; IK freezes grippers).
     GRIPPER_COUPLING = (1.0, 0.1, 0.25, -0.7, -1.0, 0.1, -0.25, 0.7)

--- a/src/robots/zoo/agilex_piper/__init__.py
+++ b/src/robots/zoo/agilex_piper/__init__.py
@@ -67,12 +67,22 @@ class AgilexPiper(Robot):
             vis_config=RobotVisConfig(
                 parts=(
                     VisPart.from_segments(
-                        "left_arm", self.URDF, (-0.25, 0.0, 0.0), (0.7071068, 0.0, 0.0, 0.7071068),
-                        0, 7, self.GRIPPER_SEGMENTS,
+                        "left_arm",
+                        self.URDF,
+                        (-0.25, 0.0, 0.0),
+                        (0.7071068, 0.0, 0.0, 0.7071068),
+                        0,
+                        7,
+                        self.GRIPPER_SEGMENTS,
                     ),
                     VisPart.from_segments(
-                        "right_arm", self.URDF, (0.25, 0.0, 0.0), (0.7071068, 0.0, 0.0, 0.7071068),
-                        7, 7, self.GRIPPER_SEGMENTS,
+                        "right_arm",
+                        self.URDF,
+                        (0.25, 0.0, 0.0),
+                        (0.7071068, 0.0, 0.0, 0.7071068),
+                        7,
+                        7,
+                        self.GRIPPER_SEGMENTS,
                     ),
                 )
             ),

--- a/src/robots/zoo/arx_r5/__init__.py
+++ b/src/robots/zoo/arx_r5/__init__.py
@@ -63,12 +63,22 @@ class ArxR5(Robot):
             vis_config=RobotVisConfig(
                 parts=(
                     VisPart.from_segments(
-                        "left_arm", self.URDF, (-0.25, 0.0, 0.0), (0.7071068, 0.0, 0.0, 0.7071068),
-                        0, 7, self.GRIPPER_SEGMENTS,
+                        "left_arm",
+                        self.URDF,
+                        (-0.25, 0.0, 0.0),
+                        (0.7071068, 0.0, 0.0, 0.7071068),
+                        0,
+                        7,
+                        self.GRIPPER_SEGMENTS,
                     ),
                     VisPart.from_segments(
-                        "right_arm", self.URDF, (0.25, 0.0, 0.0), (0.7071068, 0.0, 0.0, 0.7071068),
-                        7, 7, self.GRIPPER_SEGMENTS,
+                        "right_arm",
+                        self.URDF,
+                        (0.25, 0.0, 0.0),
+                        (0.7071068, 0.0, 0.0, 0.7071068),
+                        7,
+                        7,
+                        self.GRIPPER_SEGMENTS,
                     ),
                 )
             ),

--- a/src/robots/zoo/dual_franka/__init__.py
+++ b/src/robots/zoo/dual_franka/__init__.py
@@ -136,14 +136,22 @@ class DualFranka(Robot):
             vis_config=RobotVisConfig(
                 parts=(
                     VisPart.from_segments(
-                        "left_arm", self.URDF, (0.036395, 0.050681, 0.0508858),
+                        "left_arm",
+                        self.URDF,
+                        (0.036395, 0.050681, 0.0508858),
                         (0.865806672, -0.436878319, 0.022287915, -0.242939065),
-                        0, 8, self.GRIPPER_SEGMENTS,
+                        0,
+                        8,
+                        self.GRIPPER_SEGMENTS,
                     ),
                     VisPart.from_segments(
-                        "right_arm", self.URDF, (0.036395, -0.050681, 0.0508858),
+                        "right_arm",
+                        self.URDF,
+                        (0.036395, -0.050681, 0.0508858),
                         (0.865806672, 0.436878319, 0.022287915, 0.242939065),
-                        8, 8, self.GRIPPER_SEGMENTS,
+                        8,
+                        8,
+                        self.GRIPPER_SEGMENTS,
                     ),
                 )
             ),

--- a/src/robots/zoo/r1_lite/__init__.py
+++ b/src/robots/zoo/r1_lite/__init__.py
@@ -60,8 +60,11 @@ class R1LiteKinematicsSolver(PyrokiDualArm):
     ) -> None:
         def make_arm(arm: int) -> PyrokiSingleArm:
             return PyrokiSingleArm(
-                urdf, arm_joints[arm], eef_links[arm],
-                reference_frame=reference_frame, fixed_joints=fixed_joints,
+                urdf,
+                arm_joints[arm],
+                eef_links[arm],
+                reference_frame=reference_frame,
+                fixed_joints=fixed_joints,
             )
 
         super().__init__(
@@ -79,11 +82,7 @@ class R1Lite(Robot):
     """R1 Lite: dual 6-DoF arm + gripper on a fixed torso, 14-D action."""
 
     URDF = (
-        Path(__file__).resolve().parent
-        / "assets"
-        / "r1lite_description"
-        / "urdf"
-        / "r1lite.urdf"
+        Path(__file__).resolve().parent / "assets" / "r1lite_description" / "urdf" / "r1lite.urdf"
     )
     ARM_JOINTS = {
         0: [f"left_arm_joint{i}" for i in range(1, 7)],
@@ -97,11 +96,11 @@ class R1Lite(Robot):
     SUPPORTED_FRAMES = ("base_link", "torso_link3")
     # 14-D qpos -> 25-D URDF cfg in joint order; whole body as one part.
     VIS_SEGMENTS = [
-        {"fixed": [0, 0, 0, 0, 0, 0]},                # wheels / steer
-        {"fixed": [-0.657, 1.516, 0.845]},           # torso (held fixed)
-        {"copy": [0, 6]},                            # left arm joint1..6
+        {"fixed": [0, 0, 0, 0, 0, 0]},  # wheels / steer
+        {"fixed": [-0.657, 1.516, 0.845]},  # torso (held fixed)
+        {"copy": [0, 6]},  # left arm joint1..6
         {"gripper": 6, "range": [0.0, 100.0], "stroke": 0.035, "fingers": [1, -1]},
-        {"copy": [7, 13]},                           # right arm joint1..6
+        {"copy": [7, 13]},  # right arm joint1..6
         {"gripper": 13, "range": [0.0, 100.0], "stroke": 0.035, "fingers": [1, -1]},
     ]
 
@@ -113,8 +112,7 @@ class R1Lite(Robot):
                 ActuatorGroup("right_arm", 7, self.RIGHT_JOINTS, gripper_index=6),
             ),
             initial_qpos=np.array(
-                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0,
-                 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 100.0],
                 dtype=np.float32,
             ),
             observation_schema=ObservationSchema(
@@ -150,6 +148,10 @@ class R1Lite(Robot):
             allowed = ", ".join(self.SUPPORTED_FRAMES)
             raise ValueError(f"Unsupported R1 Lite reference frame {frame!r}; expected: {allowed}")
         return R1LiteKinematicsSolver(
-            urdf=self.URDF, arm_joints=self.ARM_JOINTS, eef_links=self.EEF_LINKS,
-            fixed_joints=self.FIXED_JOINTS, reference_frame=frame, **kwargs,
+            urdf=self.URDF,
+            arm_joints=self.ARM_JOINTS,
+            eef_links=self.EEF_LINKS,
+            fixed_joints=self.FIXED_JOINTS,
+            reference_frame=frame,
+            **kwargs,
         )

--- a/src/robots/zoo/ur5e/__init__.py
+++ b/src/robots/zoo/ur5e/__init__.py
@@ -35,12 +35,21 @@ class UR5e(Robot):
 
     URDF = Path(__file__).resolve().parent / "assets" / "ur5e_description" / "urdf" / "ur5e.urdf"
     ARM_JOINTS = (
-        "shoulder_pan_joint", "shoulder_lift_joint", "elbow_joint",
-        "wrist_1_joint", "wrist_2_joint", "wrist_3_joint",
+        "shoulder_pan_joint",
+        "shoulder_lift_joint",
+        "elbow_joint",
+        "wrist_1_joint",
+        "wrist_2_joint",
+        "wrist_3_joint",
     )
     INITIAL_QPOS = (
-        -3.3475797812091272, -1.2882714432528992, 1.4286816755877894,
-        1.5116821962543945, 1.6023021936416626, -0.21513206163515264, 1.0,
+        -3.3475797812091272,
+        -1.2882714432528992,
+        1.4286816755877894,
+        1.5116821962543945,
+        1.6023021936416626,
+        -0.21513206163515264,
+        1.0,
     )
 
     def __init__(self) -> None:
@@ -60,7 +69,12 @@ class UR5e(Robot):
             vis_config=RobotVisConfig(
                 parts=(
                     VisPart.from_segments(
-                        "arm", self.URDF, (0.0, 0.0, 0.0), (1.0, 0.0, 0.0, 0.0), 0, 7,
+                        "arm",
+                        self.URDF,
+                        (0.0, 0.0, 0.0),
+                        (1.0, 0.0, 0.0, 0.0),
+                        0,
+                        7,
                         [
                             {"copy": [0, 6]},
                             {

--- a/src/strategy/action_buffer.py
+++ b/src/strategy/action_buffer.py
@@ -84,12 +84,8 @@ class StreamActionBuffer:
             if overlap_len == 1:
                 old_weights = np.ones((1, 1), dtype=np.float32)
             else:
-                old_weights = np.linspace(
-                    1.0, 0.0, overlap_len, dtype=np.float32
-                )[:, np.newaxis]
-            smoothed = old[:overlap_len] * old_weights + new[:overlap_len] * (
-                1.0 - old_weights
-            )
+                old_weights = np.linspace(1.0, 0.0, overlap_len, dtype=np.float32)[:, np.newaxis]
+            smoothed = old[:overlap_len] * old_weights + new[:overlap_len] * (1.0 - old_weights)
             combined = np.concatenate((smoothed, new[overlap_len:]), axis=0)
             prepared_chunk = deque(row.copy() for row in combined)
             with self._lock:

--- a/src/transport/base.py
+++ b/src/transport/base.py
@@ -565,9 +565,7 @@ class _RosTransportBase(TransportBridge):
             return None
         return min(self._stamp_to_sec(deque[-1]) for deque in required)
 
-    def _gather_collection_columns(
-        self, frame_time: float
-    ) -> tuple[np.ndarray | None, ...] | None:
+    def _gather_collection_columns(self, frame_time: float) -> tuple[np.ndarray | None, ...] | None:
         """Gather the configured collection column vectors at ``frame_time``.
 
         Returns:
@@ -809,9 +807,7 @@ class _RosTransportBase(TransportBridge):
             for kind, field, source_name, _source, deque in streams:
                 key = f"{kind}:{field}:{source_name}"
                 last_stamp = cursors.get(key)
-                fresh, first_stamp, latest = self._collection_fresh_messages(
-                    deque, last_stamp
-                )
+                fresh, first_stamp, latest = self._collection_fresh_messages(deque, last_stamp)
                 if not fresh:
                     continue
                 new_messages[key] = fresh

--- a/src/transport/ros1.py
+++ b/src/transport/ros1.py
@@ -343,9 +343,7 @@ class Ros1Transport(_RosTransportBase):
         """Create a deque for ``group_name`` and subscribe ``topic`` into it."""
         deque: collections.deque = collections.deque()
         deques[group_name] = deque
-        self._register_subscriber(
-            topic, msg_type, lambda msg, d=deque: self._append_msg(d, msg)
-        )
+        self._register_subscriber(topic, msg_type, lambda msg, d=deque: self._append_msg(d, msg))
 
     def close(self) -> None:
         """Unregister all subscribers and publishers and drop publisher handles."""

--- a/src/transport/ros2.py
+++ b/src/transport/ros2.py
@@ -275,9 +275,7 @@ class Ros2Transport(_RosTransportBase):
             gripper = self._last_group_gripper_commands.get(group.name)
             if gripper is None:
                 gripper = float(state[group.gripper_index])
-            action_parts.append(
-                np.insert(command, group.gripper_index, gripper).astype(np.float32)
-            )
+            action_parts.append(np.insert(command, group.gripper_index, gripper).astype(np.float32))
         state_qpos = np.concatenate(state_parts).astype(np.float32)
         return Observation(
             images={},
@@ -296,9 +294,7 @@ class Ros2Transport(_RosTransportBase):
         self._image_rate.mark(camera_name)
         with self._deque_guard():
             targets = (
-                (live_deque, collection_deque)
-                if self._collection_capture_active
-                else (live_deque,)
+                (live_deque, collection_deque) if self._collection_capture_active else (live_deque,)
             )
             for target in targets:
                 if len(target) >= _COLLECTION_DEQUE_MAX:

--- a/src/transport/utils.py
+++ b/src/transport/utils.py
@@ -50,9 +50,7 @@ class ImageRateTracker:
     def mark(self, key: str, timestamp: float | None = None) -> None:
         stamp = time.monotonic() if timestamp is None else float(timestamp)
         with self._lock:
-            stamps = self._stamps.setdefault(
-                key, collections.deque(maxlen=self._sample_limit)
-            )
+            stamps = self._stamps.setdefault(key, collections.deque(maxlen=self._sample_limit))
             if stamps and stamp <= stamps[-1]:
                 return
             stamps.append(stamp)

--- a/tests/app/test_control_channel.py
+++ b/tests/app/test_control_channel.py
@@ -23,13 +23,11 @@ def test_catalog_is_json_ready_and_exposes_rl_templates() -> None:
     entries = control_command_catalog()
     assert all(set(entry) == {"verb", "command", "controls"} for entry in entries)
     assert any(
-        entry["verb"] == "rl_select_critic"
-        and entry["command"] == "web:rl_select_critic:{slot}"
+        entry["verb"] == "rl_select_critic" and entry["command"] == "web:rl_select_critic:{slot}"
         for entry in entries
     )
     assert any(
-        entry["verb"] == "gripper"
-        and entry["command"] == "web:gripper:{side}:{state}:{lock}"
+        entry["verb"] == "gripper" and entry["command"] == "web:gripper:{side}:{state}:{lock}"
         for entry in entries
     )
 

--- a/tests/comms/test_wire.py
+++ b/tests/comms/test_wire.py
@@ -342,9 +342,7 @@ def test_zmq_clear_collection_backlog_drops_raw_queue_and_returns_cutoff(monkeyp
     reader = object.__new__(_ObservationReader)
     reader._zmq = types.SimpleNamespace(NOBLOCK=object(), Again=_Again)
     reader._sub = _Sub()
-    reader._collection_queue = collections.deque(
-        [WireObservation(t=6.0, images={}, state={})]
-    )
+    reader._collection_queue = collections.deque([WireObservation(t=6.0, images={}, state={})])
     reader._raw_collection_queue = collections.deque(
         [pack_observation(WireObservation(t=6.5, images={}, state={}))]
     )

--- a/tests/config/test_control_state.py
+++ b/tests/config/test_control_state.py
@@ -46,12 +46,18 @@ def test_recording_space_follows_action_space_not_observation_space():
     qpos = ConfigDict(is_eef=lambda: False)
     eef = ConfigDict(is_eef=lambda: True)
 
-    assert recording._recording_space(
-        ConfigDict(inference_cfg=ConfigDict(obs_space=eef, action_space=qpos))
-    ) == "qpos"
-    assert recording._recording_space(
-        ConfigDict(inference_cfg=ConfigDict(obs_space=qpos, action_space=eef))
-    ) == "eef"
+    assert (
+        recording._recording_space(
+            ConfigDict(inference_cfg=ConfigDict(obs_space=eef, action_space=qpos))
+        )
+        == "qpos"
+    )
+    assert (
+        recording._recording_space(
+            ConfigDict(inference_cfg=ConfigDict(obs_space=qpos, action_space=eef))
+        )
+        == "eef"
+    )
 
 
 def test_gripper_command_records_collection_action_target():
@@ -289,7 +295,6 @@ class _ResettableStrategy:
 
 class _BufferedBackgroundStrategy(_ResettableStrategy):
     runs_background_loop = True
-
 
 
 def _robot() -> Robot:

--- a/tests/hardware/test_r1lite_fake_e2e_harness.py
+++ b/tests/hardware/test_r1lite_fake_e2e_harness.py
@@ -59,16 +59,15 @@ def test_rl_browser_harness_covers_episode_switch_and_sync_metrics():
     source = HARNESS_PATH.read_text()
 
     assert (
-        'document.querySelectorAll("#rl-save-tiles .collect-tile.replayable").length >= 2'
-        in source
+        'document.querySelectorAll("#rl-save-tiles .collect-tile.replayable").length >= 2' in source
     )
-    assert '#rl-save-tiles .collect-tile.replayable:nth-of-type(1)' in source
-    assert '#rl-save-tiles .collect-tile.replayable:nth-of-type(2)' in source
-    assert 'window.__evaReplaySync' in source
-    assert 'maxReadyVideos' in source
-    assert 'maxCameraSkewSec' in source
-    assert 'maxUrdfFrameSkew' in source
-    assert 'maxFrameGapMs' in source
+    assert "#rl-save-tiles .collect-tile.replayable:nth-of-type(1)" in source
+    assert "#rl-save-tiles .collect-tile.replayable:nth-of-type(2)" in source
+    assert "window.__evaReplaySync" in source
+    assert "maxReadyVideos" in source
+    assert "maxCameraSkewSec" in source
+    assert "maxUrdfFrameSkew" in source
+    assert "maxFrameGapMs" in source
 
 
 def test_assert_fixed_clock_accepts_exact_grid_and_rejects_jitter():

--- a/tests/integration/web/test_console_rl.py
+++ b/tests/integration/web/test_console_rl.py
@@ -454,9 +454,7 @@ def test_rl_replay_switch_closes_previous_source(console, tmp_path, monkeypatch)
     assert console.runtime.rl_replay_sources == [sources[1]]
 
 
-def test_rl_replay_switch_waits_for_active_critic_frame_builder(
-    console, tmp_path, monkeypatch
-):
+def test_rl_replay_switch_waits_for_active_critic_frame_builder(console, tmp_path, monkeypatch):
     _configure_rl(console, tmp_path)
     console.do("/api/tab_switch", {"tab": "rl"})
     read_started = threading.Event()

--- a/tests/integration/web/test_console_static.py
+++ b/tests/integration/web/test_console_static.py
@@ -135,8 +135,10 @@ def test_rl_policy_selection_waits_for_backend_confirmation_before_auto_setup():
     assert "rlPendingPolicy = policy.value;" in html
     assert 'else if (rlPendingPolicy == null) {\n    S.rlPolicy = "";' in html
     assert "const selectionConfirmed = status.selected_task === S.rlTask" in html
-    assert "if (selectionConfirmed && !setup && !setupBusy && !setupError) scheduleRlSetup();" in html
-    assert 'status.is_setup_done || status.setup_stage' in html
+    assert (
+        "if (selectionConfirmed && !setup && !setupBusy && !setupError) scheduleRlSetup();" in html
+    )
+    assert "status.is_setup_done || status.setup_stage" in html
 
 
 def test_rl_tab_does_not_force_generic_sim_mode_before_rl_setup():
@@ -160,9 +162,9 @@ def test_rl_save_gives_immediate_feedback_and_blocks_duplicate_actions_until_set
 
     assert "let rlSaveSetupPending = false;" in html
     assert 'setupMsg.textContent = "SAVE · QUEUING DATA…";' in html
-    assert 'intervention || rlSaveSetupPending;' in html
-    assert 'if (rlSaveSetupPending) return;' in html
-    assert 'rlSaveSetupPending = true;\n  renderRlStatus(S.STATUS || {});' in html
+    assert "intervention || rlSaveSetupPending;" in html
+    assert "if (rlSaveSetupPending) return;" in html
+    assert "rlSaveSetupPending = true;\n  renderRlStatus(S.STATUS || {});" in html
 
 
 def test_telemetry_bar_renders_image_hz_metric():
@@ -264,7 +266,10 @@ def test_collect_review_uses_shared_local_replay_engine():
     assert "replayTransformsUrl = `/api/review_transforms?${params.toString()}`;" in html
     assert "const videosReady = waitForStageVideosReady();" in html
     assert "const transformsReady = loadReplayTransformChunk(" in html
-    assert "const [videosOk, transformsOk] = await Promise.all([videosReady, transformsReady]);" in html
+    assert (
+        "const [videosOk, transformsOk] = await Promise.all([videosReady, transformsReady]);"
+        in html
+    )
     assert "await waitForStageVideosPainted();" in html
     assert "seekReplay(0);" in html
     assert "replayPlay();" in html
@@ -348,8 +353,13 @@ def test_review_episode_gates_playback_on_all_videos_and_first_transform_chunk()
     local_body = html[local_start : html.index("function replayApplyTransformFrame", local_start)]
     assert "const videosReady = waitForStageVideosReady();" in local_body
     assert "const transformsReady = loadReplayTransformChunk(" in local_body
-    assert "const [videosOk, transformsOk] = await Promise.all([videosReady, transformsReady]);" in local_body
-    assert local_body.index("await waitForStageVideosPainted();") < local_body.index("replayPlay();")
+    assert (
+        "const [videosOk, transformsOk] = await Promise.all([videosReady, transformsReady]);"
+        in local_body
+    )
+    assert local_body.index("await waitForStageVideosPainted();") < local_body.index(
+        "replayPlay();"
+    )
     assert local_body.index("seekReplay(0);") < local_body.index("replayPlay();")
 
     rollout_start = html.index("async function reviewRolloutEpisode(item)")
@@ -541,7 +551,10 @@ def test_replay_load_mounts_videos_from_load_response_without_status_poll():
     confirm_start = html.index("const confirm = async () => {")
     confirm_body = html[confirm_start : html.index("// QC deep-link", confirm_start)]
 
-    assert 'import { maybeSyncReplayPlayer, loadMountedReplaySeries, replayStop } from "./replay.js";' in html
+    assert (
+        'import { maybeSyncReplayPlayer, loadMountedReplaySeries, replayStop } from "./replay.js";'
+        in html
+    )
     assert "const hasInspectedDir = replayInspectedDir === dir;" in confirm_body
     assert "const loadKeys = hasInspectedDir" in confirm_body
     assert "const loadVideoKeys = hasInspectedDir ? S.replayVideoKeys : {};" in confirm_body
@@ -1097,22 +1110,22 @@ def test_rl_workspace_has_eval_style_workflow_and_hides_data_config():
     assert "let rlCriticPendingFrame = null;" in html
     assert "function flushRlCriticQueue()" in html
     assert "if (generation === rlCriticGeneration) flushRlCriticQueue();" in html
-    assert '!rollout.save_ready || intervention' in html
-    assert '!rollout.save_ready || !hasFrames' not in html
+    assert "!rollout.save_ready || intervention" in html
+    assert "!rollout.save_ready || !hasFrames" not in html
     assert 'id="rl-save-count"' in html
     assert 'id="rl-save-expand"' in html
     assert 'id="rl-save-list"' in html
-    assert 'rl-save-tiles .collect-tile::after' not in html
-    assert 'CRITIC · OPTIONAL' in html
-    assert 'Select task and Policy; Critic is optional' in html
+    assert "rl-save-tiles .collect-tile::after" not in html
+    assert "CRITIC · OPTIONAL" in html
+    assert "Select task and Policy; Critic is optional" in html
     assert 'const selected = !!S.rlTask && S.rlPolicy !== "";' in html
-    assert 'ROBOT + POLICY READY · CRITIC OPTIONAL' in html
-    assert 'const setupError = status.last_error || status.policy_error;' in html
-    assert 'POLICY OFFLINE · SETUP REQUIRED' in html
+    assert "ROBOT + POLICY READY · CRITIC OPTIONAL" in html
+    assert "const setupError = status.last_error || status.policy_error;" in html
+    assert "POLICY OFFLINE · SETUP REQUIRED" in html
     assert 'retry.style.display = setupError && !setup ? "" : "none";' in html
-    assert 'Select <b>task and Policy</b>' in html
-    assert 'SETUP starts <b>automatically</b>' in html
-    assert 'Select <b>task, Policy, and Critic</b>' not in html
+    assert "Select <b>task and Policy</b>" in html
+    assert "SETUP starts <b>automatically</b>" in html
+    assert "Select <b>task, Policy, and Critic</b>" not in html
     assert 'LIVE.replayOwner !== "rl" || !S.STATUS.rl?.critic_connected' in html
     assert 'id="rl-auto-setup-msg"' in html
     assert 'id="rl-panel-data" data-st="done" hidden' in html
@@ -1120,7 +1133,7 @@ def test_rl_workspace_has_eval_style_workflow_and_hides_data_config():
     assert ".rl-source-value::before" in html
     assert "#rl-stage-col {\n    min-height: 0; overflow: hidden;" in html
     assert "#view-rl .stage.rl-replay .stage-charts" in html
-    assert 'scheduleRlSetup();' in html
+    assert "scheduleRlSetup();" in html
     assert 'else S.rlCritic = "";' in html
     assert 'criticChoice.style.display = setup ? "" : "none";' in html
     assert 'stage.classList.toggle("rl-critic-active", !!S.rlCritic && !!rl.active);' in html
@@ -1137,8 +1150,8 @@ def test_rl_stage_has_prominent_critic_curve_and_control_source_legend():
     assert 'openChartModal("c")' in html
     assert 'class="control-legend"' in html
     assert 'class="critic-source-legend"' in html
-    assert 'LIVE.criticSource' in html
-    assert 'drawSourceBands(ctx, ts, source' in html
+    assert "LIVE.criticSource" in html
+    assert "drawSourceBands(ctx, ts, source" in html
     assert 'data-source="intervention"' in html
     assert "--policy:   #2563EB" in html
     assert "--intervention: #FF4D00" in html
@@ -1150,8 +1163,8 @@ def test_rl_saved_episode_click_switches_replay_immediately_and_latest_wins():
     assert "let replayRequestId = 0;" in html
     assert "function selectSavedEpisode(item, items)" in html
     assert "replaySelectedEpisode();" in html
-    assert "if (LIVE.replayMode && LIVE.replayOwner === \"rl\") exitReplayMode();" in html
-    assert "requestId !== replayRequestId || S.ACTIVE_TAB !== \"rl\"" in html
+    assert 'if (LIVE.replayMode && LIVE.replayOwner === "rl") exitReplayMode();' in html
+    assert 'requestId !== replayRequestId || S.ACTIVE_TAB !== "rl"' in html
     assert "if (replayVideoAbortController) replayVideoAbortController.abort();" in html
     assert "replayVideoAbortController = new AbortController();" in html
     assert "async function loadReplaySeries()" in html
@@ -1208,10 +1221,10 @@ def test_live_charts_bound_draw_work_to_canvas_resolution():
     assert 'criticCursor, ["#E8590C"]' in html
     assert "criticGeneration" in html
     assert "if (criticGeneration !== LIVE.criticGeneration) return;" in html
-    assert 'ctx.fillText(`${(elapsed * ratio).toFixed(1)}s`' in html
+    assert "ctx.fillText(`${(elapsed * ratio).toFixed(1)}s`" in html
     assert ".stage-critic {\n    display: none; flex: 0 0 190px; min-height: 190px;\n  }" in html
     assert ".stage.rl-live .stage-charts" in html
-    assert "stage.classList.toggle(\"rl-live\"" in html
+    assert 'stage.classList.toggle("rl-live"' in html
 
 
 def test_replay_charts_use_series_dimension_names():

--- a/tests/integration/web/test_replay_runtime.py
+++ b/tests/integration/web/test_replay_runtime.py
@@ -421,9 +421,7 @@ def test_replay_load_resolves_relative_collection_qpos_dataset(tmp_path, monkeyp
     np.testing.assert_allclose(runtime.replay_source.get_scene_qpos(1), state[1])
 
 
-def test_replay_load_reuses_transport_trajectory_without_second_parquet_read(
-    tmp_path, monkeypatch
-):
+def test_replay_load_reuses_transport_trajectory_without_second_parquet_read(tmp_path, monkeypatch):
     dataset_dir = tmp_path / "dataset"
     meta_dir = dataset_dir / "meta"
     data_dir = dataset_dir / "data" / "chunk-000"
@@ -501,9 +499,7 @@ def test_eef_replay_fills_missing_action_gripper_when_mode_is_eef(monkeypatch):
             _ = initial_qpos_groups, dt
             self.chunks = []
 
-        def solve_chunk(
-            self, chunk: np.ndarray, seed_qpos: np.ndarray | None = None
-        ) -> np.ndarray:
+        def solve_chunk(self, chunk: np.ndarray, seed_qpos: np.ndarray | None = None) -> np.ndarray:
             _ = seed_qpos
             self.chunks.append(np.asarray(chunk, dtype=np.float32).copy())
             return np.zeros((1, 7), dtype=np.float32)
@@ -512,14 +508,10 @@ def test_eef_replay_fills_missing_action_gripper_when_mode_is_eef(monkeypatch):
         robot=ROBOT_REGISTRY.build("ur5e"),
         transport=_FakeTransport(),
     )
-    monkeypatch.setattr(
-        runtime.robot, "build_kinematics", lambda **kw: _FakeUr5eSolver(**kw)
-    )
+    monkeypatch.setattr(runtime.robot, "build_kinematics", lambda **kw: _FakeUr5eSolver(**kw))
     runtime.replay_source = cast(
         DatasetTransport,
-        _ReplaySource(
-            np.asarray([[0.1, -0.2, 0.3, -1.0, 0.5, 1.2, 0.75]], dtype=np.float32)
-        ),
+        _ReplaySource(np.asarray([[0.1, -0.2, 0.3, -1.0, 0.5, 1.2, 0.75]], dtype=np.float32)),
     )
     runtime.replay_trajectory = np.asarray(
         [[0.4, 0.5, 0.6, 1.0, 0.0, 0.0, 0.0]],
@@ -549,9 +541,7 @@ def test_eef_replay_with_joint_config_fills_gripper_and_solves_ik(monkeypatch):
             _ = initial_qpos_groups, dt
             self.chunks = []
 
-        def solve_chunk(
-            self, chunk: np.ndarray, seed_qpos: np.ndarray | None = None
-        ) -> np.ndarray:
+        def solve_chunk(self, chunk: np.ndarray, seed_qpos: np.ndarray | None = None) -> np.ndarray:
             _ = seed_qpos
             self.chunks.append(np.asarray(chunk, dtype=np.float32).copy())
             return np.zeros((1, 7), dtype=np.float32)
@@ -560,14 +550,10 @@ def test_eef_replay_with_joint_config_fills_gripper_and_solves_ik(monkeypatch):
         robot=ROBOT_REGISTRY.build("ur5e"),
         transport=_FakeTransport(),
     )
-    monkeypatch.setattr(
-        runtime.robot, "build_kinematics", lambda **kw: _FakeUr5eSolver(**kw)
-    )
+    monkeypatch.setattr(runtime.robot, "build_kinematics", lambda **kw: _FakeUr5eSolver(**kw))
     runtime.replay_source = cast(
         DatasetTransport,
-        _ReplaySource(
-            np.asarray([[0.1, -0.2, 0.3, -1.0, 0.5, 1.2, 0.75]], dtype=np.float32)
-        ),
+        _ReplaySource(np.asarray([[0.1, -0.2, 0.3, -1.0, 0.5, 1.2, 0.75]], dtype=np.float32)),
     )
     runtime.replay_trajectory = np.asarray(
         [[0.4, 0.5, 0.6, 1.0, 0.0, 0.0, 0.0]],

--- a/tests/manual/replay_perf_probe.py
+++ b/tests/manual/replay_perf_probe.py
@@ -875,7 +875,7 @@ def summarize(name: str, data: dict[str, Any]) -> dict[str, Any]:
         for marker in (video.get("playing"), video.get("play"))
         if marker is not None
     ]
-    stable_start = (min(play_markers) if play_markers else data.get("playCommand"))
+    stable_start = min(play_markers) if play_markers else data.get("playCommand")
     stable_start = None if stable_start is None else float(stable_start) + 250.0
     stable_waiting = sum(
         sum(1 for row in video["waiting"] if stable_start is not None and row[0] >= stable_start)
@@ -885,6 +885,7 @@ def summarize(name: str, data: dict[str, Any]) -> dict[str, Any]:
         sum(1 for row in video["stalled"] if stable_start is not None and row[0] >= stable_start)
         for video in videos
     )
+
     def percentile(values: list[float], ratio: float) -> float | None:
         if not values:
             return None
@@ -914,14 +915,8 @@ def summarize(name: str, data: dict[str, Any]) -> dict[str, Any]:
         ]
         for v in videos
     }
-    media_p95 = {
-        key: percentile(values, 0.95)
-        for key, values in media_intervals.items()
-    }
-    media_max = {
-        key: max(values) if values else None
-        for key, values in media_intervals.items()
-    }
+    media_p95 = {key: percentile(values, 0.95) for key, values in media_intervals.items()}
+    media_max = {key: max(values) if values else None for key, values in media_intervals.items()}
     long_tasks = [
         float(row.get("duration", 0))
         for row in data.get("longTasks") or []
@@ -960,9 +955,7 @@ def summarize(name: str, data: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def capture_measurement(
-    cdp: Cdp, name: str, timeout: float, play_seconds: float
-) -> dict[str, Any]:
+def capture_measurement(cdp: Cdp, name: str, timeout: float, play_seconds: float) -> dict[str, Any]:
     try:
         wait_for(cdp, VIDEOS_VISIBLE_READY_EXPR, timeout)
         if play_seconds > 0:
@@ -1120,9 +1113,7 @@ def main() -> None:
                 target = select_clickable_tile(cdp, "#rollout-save-queue-tiles", i)
                 human_click_target_and_start_probe(cdp, target, f"debug-tile-{i}")
                 summaries.append(
-                    capture_measurement(
-                        cdp, f"debug-{i}", args.visible_timeout, args.play_seconds
-                    )
+                    capture_measurement(cdp, f"debug-{i}", args.visible_timeout, args.play_seconds)
                 )
 
         if args.rl_count > 0:
@@ -1145,16 +1136,12 @@ def main() -> None:
                 wait_for(cdp, ".rv-task .rv-node-head", 5)
                 human_click(cdp, ".rv-task .rv-node-head")
                 wait_for(cdp, RESULT_TRIAL_READY_EXPR, 5)
-                target = select_clickable_tile(
-                    cdp, ".rv-trials", i, ".eval-trial.scored"
-                )
+                target = select_clickable_tile(cdp, ".rv-trials", i, ".eval-trial.scored")
                 human_click_target_and_start_probe(cdp, target, f"result-trial-{i}")
                 wait_for(cdp, RESULT_POP_READY_EXPR, 10)
                 human_click(cdp, "#tp-play")
                 summaries.append(
-                    capture_measurement(
-                        cdp, f"result-{i}", args.visible_timeout, args.play_seconds
-                    )
+                    capture_measurement(cdp, f"result-{i}", args.visible_timeout, args.play_seconds)
                 )
 
         if args.rapid_switches:

--- a/tests/manual/verify_async_save_perf.py
+++ b/tests/manual/verify_async_save_perf.py
@@ -90,9 +90,7 @@ class R1LiteFakeDataset:
                     CollectionRawSample(
                         timestamp,
                         CollectionRawImage(
-                            lambda key=camera_key, index=frame_index: self._camera_frame(
-                                key, index
-                            )
+                            lambda key=camera_key, index=frame_index: self._camera_frame(key, index)
                         ),
                     )
                 ]

--- a/tests/manual/viser_track_chunk.py
+++ b/tests/manual/viser_track_chunk.py
@@ -125,9 +125,7 @@ def main() -> None:
     parts = robot.vis_config.parts
     n_arms = _arm_eef_width(seed_eef.shape[0])
     if len(parts) < n_arms:
-        raise SystemExit(
-            f"{len(parts)} vis parts but solver reports {n_arms} arms; mismatch."
-        )
+        raise SystemExit(f"{len(parts)} vis parts but solver reports {n_arms} arms; mismatch.")
 
     server = viser.ViserServer(port=args.port)
     server.scene.set_up_direction("+z")
@@ -232,9 +230,7 @@ def main() -> None:
             tgt = chunk[:, i * 8 : i * 8 + 7]
             got = fk[:, i * 8 : i * 8 + 7]
             pos_err = np.linalg.norm(tgt[:, :3] - got[:, :3], axis=1)
-            ori_err = np.array(
-                [_quat_angle_deg(tgt[t, 3:7], got[t, 3:7]) for t in range(len(tgt))]
-            )
+            ori_err = np.array([_quat_angle_deg(tgt[t, 3:7], got[t, 3:7]) for t in range(len(tgt))])
             max_pos_mm = max(max_pos_mm, float(pos_err.max() * 1000.0))
             max_ori_deg = max(max_ori_deg, float(ori_err.max()))
             print(

--- a/tests/recorder/test_episode_logger.py
+++ b/tests/recorder/test_episode_logger.py
@@ -607,9 +607,7 @@ def test_raw_episode_action_column_follows_recording_space(tmp_path):
 
     assert qpos_logger.end_episode()
 
-    qpos_table = pq.read_table(
-        tmp_path / "qpos" / "data" / "chunk-000" / "episode_000000.parquet"
-    )
+    qpos_table = pq.read_table(tmp_path / "qpos" / "data" / "chunk-000" / "episode_000000.parquet")
     assert "action.qpos" in qpos_table.column_names
     assert "action" not in qpos_table.column_names
 
@@ -630,9 +628,7 @@ def test_raw_episode_action_column_follows_recording_space(tmp_path):
 
     assert eef_logger.end_episode()
 
-    eef_table = pq.read_table(
-        tmp_path / "eef" / "data" / "chunk-000" / "episode_000000.parquet"
-    )
+    eef_table = pq.read_table(tmp_path / "eef" / "data" / "chunk-000" / "episode_000000.parquet")
     assert "action.eef" in eef_table.column_names
     np.testing.assert_allclose(eef_table.column("action.eef").to_pylist(), [action_eef] * 2)
 
@@ -671,9 +667,7 @@ def test_raw_episode_video_writer_holds_only_one_decoded_image(tmp_path, monkeyp
     logger = _logger(tmp_path, fps=10, async_save=True)
 
     def snapshot(timestamp: float, value: int) -> RawCollectionSnapshot:
-        image = CollectionRawImage(
-            lambda value=value: np.full((2, 2, 3), value, dtype=np.uint8)
-        )
+        image = CollectionRawImage(lambda value=value: np.full((2, 2, 3), value, dtype=np.uint8))
         raw_images.append(image)
 
         def decode_raw() -> CollectionRawBatch:

--- a/tests/recorder/test_lerobot_meta.py
+++ b/tests/recorder/test_lerobot_meta.py
@@ -8,9 +8,7 @@ def test_quality_issue_status_summary_preserves_codes_and_exact_counts() -> None
         {"severity": "red", "code": "image_skew_exceeded", "detail": f"frame {i}"}
         for i in range(396)
     ]
-    issues.append(
-        {"severity": "red", "code": "frame_count_mismatch", "detail": "camera short"}
-    )
+    issues.append({"severity": "red", "code": "frame_count_mismatch", "detail": "camera short"})
 
     summaries, count = summarize_quality_issues(issues)
 

--- a/tests/strategy/test_strategy_build.py
+++ b/tests/strategy/test_strategy_build.py
@@ -43,9 +43,7 @@ def test_build_sync_basic():
 
 
 def test_build_sync_ignore_gripper_wait_flag():
-    strategy = _build(
-        {"type": "BaseInferStrategy", "args": {"sync_wait_ignore_gripper": True}}
-    )
+    strategy = _build({"type": "BaseInferStrategy", "args": {"sync_wait_ignore_gripper": True}})
     assert strategy.sync_wait_ignore_gripper is True
 
 

--- a/tests/transport/test_base.py
+++ b/tests/transport/test_base.py
@@ -195,9 +195,7 @@ def test_acquire_collection_raw_scans_only_messages_after_cursor():
 def test_acquire_collection_raw_blocks_concurrent_deque_append_during_scan():
     image = np.zeros((4, 4, 3), dtype=np.uint8)
     transport = _FakeRosCollectionTransport(image)
-    transport._camera_deques["front"] = deque(
-        [transport._msg(float(i)) for i in range(10)]
-    )
+    transport._camera_deques["front"] = deque([transport._msg(float(i)) for i in range(10)])
     transport._collection_qpos_deques["arm"] = deque(
         [transport._msg(float(i), [float(i), float(i + 1)]) for i in range(10)]
     )
@@ -257,9 +255,7 @@ def test_ros_camera_append_updates_image_min_hz():
     transport._append_camera_msg(
         "front", transport._camera_deques["front"], transport._msg(1.0), 0.0
     )
-    transport._append_camera_msg(
-        "left", transport._camera_deques["left"], transport._msg(1.0), 0.0
-    )
+    transport._append_camera_msg("left", transport._camera_deques["left"], transport._msg(1.0), 0.0)
     transport._append_camera_msg(
         "front", transport._camera_deques["front"], transport._msg(1.1), 0.05
     )

--- a/tests/transport/test_ros1.py
+++ b/tests/transport/test_ros1.py
@@ -138,9 +138,7 @@ def test_ros1_hil_relative_relay_reorders_named_input(monkeypatch):
         observation_schema=ObservationSchema(cameras=(), state_composition=("arm",)),
     )
     transport = ros1.Ros1Transport(config, robot)
-    transport._group_state_deques["arm"].append(
-        types.SimpleNamespace(position=[10.0, 20.0])
-    )
+    transport._group_state_deques["arm"].append(types.SimpleNamespace(position=[10.0, 20.0]))
     assert transport.start_hil_control("relative").active is True
     callback = _subscription_callback(fake_rospy, "/hil_input")
 

--- a/tests/transport/test_ros2.py
+++ b/tests/transport/test_ros2.py
@@ -461,9 +461,7 @@ def test_ros2_hil_relay_restamps_commands_with_local_clock(monkeypatch):
     transport = ros2.Ros2Transport(config, robot)
     transport.set_hil_relay_enabled(True)
     transport.set_hil_control_mode("relative")
-    transport._group_state_deques["left_arm"].append(
-        _stamped_msg(100, [10, 20, 30, 40, 50, 60])
-    )
+    transport._group_state_deques["left_arm"].append(_stamped_msg(100, [10, 20, 30, 40, 50, 60]))
     callback = _subscription_callback(node, "/eva/hil/input_joint_state_arm_left")
 
     node.clock_stamp = types.SimpleNamespace(sec=100, nanosec=123)
@@ -496,9 +494,7 @@ def test_ros2_collection_action_qpos_subscribes_motion_target_when_hil_enabled(m
     config = load_config(_R1LITE_COLLECTION)
     robot = ROBOT_REGISTRY.build(config.robot.type)
     transport = ros2.Ros2Transport(config, robot)
-    action_callback = _subscription_callback(
-        node, "/motion_target/target_joint_state_arm_left"
-    )
+    action_callback = _subscription_callback(node, "/motion_target/target_joint_state_arm_left")
 
     action_callback(_stamped_msg(2, [1, 2, 3, 4, 5, 6]))
 
@@ -816,9 +812,7 @@ def test_ros2_collection_joint_vector_merges_configured_gripper_topics(monkeypat
     robot = ROBOT_REGISTRY.build(config.robot.type)
     transport = ros2.Ros2Transport(config, robot)
     transport._collection_qpos_deques["left_arm"].append(_stamped_msg(1, [0, 1, 2, 3, 4, 5]))
-    transport._collection_qpos_deques["right_arm"].append(
-        _stamped_msg(1, [10, 11, 12, 13, 14, 15])
-    )
+    transport._collection_qpos_deques["right_arm"].append(_stamped_msg(1, [10, 11, 12, 13, 14, 15]))
     transport._collection_qpos_gripper_deques["left_arm"].append(_stamped_msg(1, [42]))
     transport._collection_qpos_gripper_deques["right_arm"].append(_stamped_msg(1, [43]))
 
@@ -850,9 +844,7 @@ def test_ros2_collection_action_gripper_snaps_to_robot_open_close(monkeypatch):
     config = load_config(_R1LITE_COLLECTION)
     robot = ROBOT_REGISTRY.build(config.robot.type)
     transport = ros2.Ros2Transport(config, robot)
-    transport._collection_action_qpos_deques["left_arm"].append(
-        _stamped_msg(1, [0, 1, 2, 3, 4, 5])
-    )
+    transport._collection_action_qpos_deques["left_arm"].append(_stamped_msg(1, [0, 1, 2, 3, 4, 5]))
     transport._collection_action_qpos_deques["right_arm"].append(
         _stamped_msg(1, [10, 11, 12, 13, 14, 15])
     )
@@ -896,9 +888,7 @@ def test_ros2_collection_raw_batch_merges_gripper_topics(monkeypatch):
     for camera in transport._collection_camera_specs():
         transport._collection_camera_deques[camera.name].append(_compressed_msg(1, b"jpeg"))
     transport._collection_qpos_deques["left_arm"].append(_stamped_msg(1, [0, 1, 2, 3, 4, 5]))
-    transport._collection_qpos_deques["right_arm"].append(
-        _stamped_msg(1, [10, 11, 12, 13, 14, 15])
-    )
+    transport._collection_qpos_deques["right_arm"].append(_stamped_msg(1, [10, 11, 12, 13, 14, 15]))
     transport._collection_qpos_gripper_deques["left_arm"].append(_stamped_msg(1, [42]))
     transport._collection_qpos_gripper_deques["right_arm"].append(_stamped_msg(1, [43]))
 
@@ -1166,9 +1156,7 @@ def test_ros2_collection_raw_action_qpos_is_complete_from_seeded_gripper(monkeyp
     for camera in transport._collection_camera_specs():
         transport._collection_camera_deques[camera.name].append(_compressed_msg(2, b"jpeg"))
     transport._collection_qpos_deques["left_arm"].append(_stamped_msg(2, [0, 1, 2, 3, 4, 5]))
-    transport._collection_qpos_deques["right_arm"].append(
-        _stamped_msg(2, [10, 11, 12, 13, 14, 15])
-    )
+    transport._collection_qpos_deques["right_arm"].append(_stamped_msg(2, [10, 11, 12, 13, 14, 15]))
     transport._collection_action_qpos_deques["left_arm"].append(
         _stamped_msg(2, [20, 21, 22, 23, 24, 25])
     )
@@ -1206,9 +1194,7 @@ def test_ros2_collection_diagnostics_reports_missing_action_gripper(monkeypatch)
     config = load_config(_R1LITE_COLLECTION)
     robot = ROBOT_REGISTRY.build(config.robot.type)
     transport = ros2.Ros2Transport(config, robot)
-    transport._collection_action_qpos_deques["left_arm"].append(
-        _stamped_msg(1, [0, 1, 2, 3, 4, 5])
-    )
+    transport._collection_action_qpos_deques["left_arm"].append(_stamped_msg(1, [0, 1, 2, 3, 4, 5]))
     transport._collection_action_qpos_deques["right_arm"].append(
         _stamped_msg(1, [10, 11, 12, 13, 14, 15])
     )


### PR DESCRIPTION
## Overview

This PR establishes Ruff formatting as an enforced repository contract. It adds a read-only check for pull requests and `main`, a manually dispatched correction workflow for an explicit existing branch, and a one-time Ruff 0.15.9 formatting baseline so the new check starts green.

| Field | Value |
|---|---|
| Review decision | Approve the Ruff check/fix workflow boundaries and the mechanical formatting baseline |
| Base / head | `main` <- `ci/ruff-format-actions` |
| Status | Merged as `a86c8d2`; post-merge checks green |
| Reviewers | No external reviewer required by repository policy; agent review PASS |
| Validation | Both GitHub Actions jobs passed live; 93 formatted Python files are semantic AST-equivalent |
| Main risk | Large mechanical diff needed to establish a green baseline |

## Problem And Scope

The repository already pins and configures Ruff, but it has no CI formatting gate and 93 Ruff-managed Python files do not match the configured formatter. Adding only a check would make `main` fail immediately.

In scope:

- Enforce `ruff check` and `ruff format --check` on pull requests and pushes to `main`.
- Provide a manually dispatched formatter that validates an existing target branch, applies safe Ruff fixes, verifies the result, and pushes a bot-authored correction commit only when files changed.
- Format the current Ruff-managed Python baseline with the project's pinned Ruff 0.15.9.

Out of scope:

- Test, type-check, release, or dependency-update workflows.
- Branch-protection policy changes.

## What Changes

| Area | Before | After |
|---|---|---|
| Format checks | No GitHub Actions coverage | Read-only Ruff lint and format checks on PRs and `main` |
| Corrections | Manual local formatting only | Explicit `workflow_dispatch` correction for an existing branch |
| Python baseline | 93 files would be reformatted | All 204 managed files match Ruff 0.15.9 |
| Action supply chain | None | Third-party Actions pinned to full commit SHAs |

The check workflow has only `contents: read` and does not persist checkout credentials. The correction workflow is manual, limits its token to `contents: write`, validates and quotes the branch input, verifies the corrected tree before committing, and serializes runs per target branch.

## Compatibility And Migration

The Python rewrite is formatter-only. Normalized AST comparison between `main` and the formatted files found all 93 modified Python files semantically equivalent. No runtime, API, configuration-schema, or dependency contract changes are intended.

After merge, maintainers can run **Format fix** from the Actions tab and provide an existing branch name. The workflow pushes `style: apply Ruff formatting` to that branch only when Ruff produces a clean, verified diff.

## Validation

| Check | Result | Level | Verdict |
|---|---|---|---|
| `uvx --from ruff==0.15.9 ruff check .` | All checks passed | Static | PASS |
| `uvx --from ruff==0.15.9 ruff format --check .` | 204 files already formatted | Static | PASS |
| `actionlint` 1.7.12 on both workflows | No findings | Static | PASS |
| `git diff --check` | No whitespace errors | Static | PASS |
| Normalized AST comparison | 93/93 modified Python files equivalent | Static semantic comparison | PASS |
| GitHub-hosted `Format check / Ruff` | Passed in 7s | Live CI | PASS |
| [Post-merge `main` Format check](https://github.com/Noietch/EVA-CLIENT/actions/runs/32816835831) | Passed on merge commit `a86c8d2` | Live CI | PASS |
| GitHub-hosted [`Format fix` job (temporary push trigger)](https://github.com/Noietch/EVA-CLIENT/actions/runs/32816070191) | All steps passed; bot commit `f12daef` changed only the unformatted fixture | Mutating live | PASS |
| Final [`workflow_dispatch` on `main`](https://github.com/Noietch/EVA-CLIENT/actions/runs/32816943447) | All steps passed; no correction commit was needed | Mutating live | PASS |

The correction job used a temporary push trigger because GitHub only enables a new `workflow_dispatch` entry point after its workflow file reaches the default branch; the tested job steps were otherwise unchanged.

## Risk, Rollout, And Rollback

The main review cost is the 93-file mechanical formatting diff. AST equivalence and the pinned formatter constrain that risk. The correction workflow can write to a maintainer-selected branch, but it is never automatic, rejects non-branch refs, verifies Ruff after correction, and only stages tracked changes.

Merging enables the check immediately for subsequent PRs and `main` pushes. Reverting the commit removes both workflows and restores the previous formatting baseline; the correction workflow creates ordinary commits that can be reverted independently.

## Reviewer Guide

1. `.github/workflows/format-check.yml`: verify triggers, read-only permissions, pinned Actions, and exact Ruff checks.
2. `.github/workflows/format-fix.yml`: verify manual-only invocation, branch validation, write scope, clean-tree verification, and push target.
3. Remaining Python files: treat as generated mechanical output from `ruff format .`; the AST comparison is the semantic guard.

Mechanical changes were generated with `uvx --from ruff==0.15.9 ruff format .`.





